### PR TITLE
badger: fix error return

### DIFF
--- a/badger/value.go
+++ b/badger/value.go
@@ -138,6 +138,9 @@ func (f *logFile) iterate(offset int64, fn logEntry) error {
 				return err
 			}
 			decompressed, err = lz4.Decode(decompressed, v[:vl])
+			if err != nil {
+				return err
+			}
 
 			e.Meta = h.meta
 			e.casCounter = h.casCounter


### PR DESCRIPTION
Propagate any errors from lz4.Decode. Looks like the existing code 
would panic with a slice indexing error when extracting the key and
value from the decompressed data if Decode failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/17)
<!-- Reviewable:end -->
