### PR TITLE
Add unix support for SyncWrite option

### DIFF
--- a/y/file_dragonfly.go
+++ b/y/file_dragonfly.go
@@ -1,0 +1,9 @@
+package y
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	syncFileFlag = unix.O_SYNC
+}

--- a/y/file_freebsd.go
+++ b/y/file_freebsd.go
@@ -1,0 +1,9 @@
+package y
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	syncFileFlag = unix.O_SYNC
+}

--- a/y/file_linux.go
+++ b/y/file_linux.go
@@ -1,9 +1,0 @@
-package y
-
-import (
-	"syscall"
-)
-
-func init() {
-	syncFileFlag = syscall.O_DSYNC
-}

--- a/y/file_unix.go
+++ b/y/file_unix.go
@@ -1,0 +1,11 @@
+// +build darwin linux netbsd openbsd solaris
+
+package y
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	syncFileFlag = unix.O_DSYNC
+}


### PR DESCRIPTION
Currently the flag for SyncWrites is not set for any unix system, it's just working for linux and windows. This fix enable the SyncWrites flag for the same unix systems that are specified in table/mmap_unix.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/92)
<!-- Reviewable:end -->
