### PR TITLE
Fix error cleanup in and after OpenTable calls

### DIFF
--- a/compact_log_test.go
+++ b/compact_log_test.go
@@ -183,6 +183,7 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 
 	f = buildTestTable(t, "l", 2)
 	t2, err := table.OpenTable(f, table.MemoryMap)
+	require.NoError(t, err)
 	defer t2.DecrRef()
 	done = lh0.tryAddLevel0Table(t2)
 	require.Equal(t, true, done)

--- a/kv.go
+++ b/kv.go
@@ -953,12 +953,11 @@ func (s *KV) flushMemtable(lc *y.LevelCloser) error {
 		}
 
 		tbl, err := table.OpenTable(fd, s.opt.MapTablesTo)
-		defer tbl.DecrRef()
-
 		if err != nil {
 			s.elog.Printf("ERROR while opening table: %v", err)
 			return err
 		}
+		defer tbl.DecrRef()
 		s.lc.addLevel0Table(tbl) // This will incrRef again.
 
 		// Update s.imm. Need a lock.

--- a/table/table.go
+++ b/table/table.go
@@ -114,16 +114,23 @@ func (b byKey) Len() int               { return len(b) }
 func (b byKey) Swap(i int, j int)      { b[i], b[j] = b[j], b[i] }
 func (b byKey) Less(i int, j int) bool { return bytes.Compare(b[i].key, b[j].key) < 0 }
 
-// OpenTable assumes file has only one table and opens it.
+// OpenTable assumes file has only one table and opens it.  Takes ownership of fd upon function
+// entry.  Returns a table with one reference count on it (decrementing which may delete the file!
+// -- consider t.Close() instead).
 func OpenTable(fd *os.File, mapTableTo int) (*Table, error) {
 	fileInfo, err := fd.Stat()
 	if err != nil {
+		// It's OK to ignore fd.Close() errs in this function because we have only read
+		// from the file.
+		_ = fd.Close()
 		return nil, y.Wrap(err)
 	}
 
-	id, ok := ParseFileID(fileInfo.Name())
+	filename := fileInfo.Name()
+	id, ok := ParseFileID(filename)
 	if !ok {
-		return nil, errors.Errorf("Invalid filename: %s", fd.Name())
+		_ = fd.Close()
+		return nil, errors.Errorf("Invalid filename: %s", filename)
 	}
 	t := &Table{
 		fd:         fd,
@@ -137,12 +144,14 @@ func OpenTable(fd *os.File, mapTableTo int) (*Table, error) {
 	if mapTableTo == MemoryMap {
 		t.mmap, err = mmap(fd, fileInfo.Size())
 		if err != nil {
-			return t, y.Wrapf(err, "Unable to map file")
+			_ = fd.Close()
+			return nil, y.Wrapf(err, "Unable to map file")
 		}
 	} else if mapTableTo == LoadToRAM {
 		err = t.LoadToRAM()
 		if err != nil {
-			return t, y.Wrap(err)
+			_ = fd.Close()
+			return nil, y.Wrap(err)
 		}
 	}
 


### PR DESCRIPTION
- We now close fd inside of OpenTable upon error.

- At many callsites (where we call OpenTable many times in a loop) we
now cleanup resources properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/102)
<!-- Reviewable:end -->
