### PR TITLE
Check Pid of process written to LOCK file

### DIFF
--- a/kv_test.go
+++ b/kv_test.go
@@ -805,5 +805,18 @@ func TestPidFile(t *testing.T) {
 	defer kv1.Close()
 	_, err = NewKV(options)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot create pid lock file")
+	require.Contains(t, err.Error(), "Some other process is using the store. Cannot acquire LOCK")
+}
+
+func TestPidFile2(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	options := getTestOptions(dir)
+	kv1, err := NewKV(options)
+	require.NoError(t, err)
+	kv1.Close()
+
+	_, err = NewKV(options)
+	require.NoError(t, err)
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -816,7 +816,6 @@ func TestPidFile2(t *testing.T) {
 	kv1, err := NewKV(options)
 	require.NoError(t, err)
 	kv1.Close()
-
 	_, err = NewKV(options)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This would ensure that if `dgraph` crashes or if we interrupt the `dgraphloader` then we can restart without having to delete the LOCK file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/110)
<!-- Reviewable:end -->
