### PR TITLE
DirectoryLockGuard held for both Dir and ValueDir

### DIFF
--- a/kv_test.go
+++ b/kv_test.go
@@ -805,5 +805,5 @@ func TestPidFile(t *testing.T) {
 	defer kv1.Close()
 	_, err = NewKV(options)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot create pid lock file")
+	require.Contains(t, err.Error(), "Another process is using this Badger database")
 }

--- a/y/directorylock_unix.go
+++ b/y/directorylock_unix.go
@@ -1,0 +1,68 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package y
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// DirectoryLockGuard holds a lock on a directory and a pid file inside.  The pid file isn't part
+// of the locking mechanism, it's just advisory.
+type DirectoryLockGuard struct {
+	// File handle on the directory, which we've flocked.
+	f *os.File
+	// The absolute path to our pid file.
+	path string
+}
+
+// AcquireDirectoryLock gets an exclusive lock on the directory (using flock).  It writes our pid
+// to dirPath/pidFileName for convenience.
+func AcquireDirectoryLock(dirPath string, pidFileName string) (*DirectoryLockGuard, error) {
+	// Convert to absolute path so that Release still works even if we do an unbalanced
+	// chdir in the meantime.
+	absPidFilePath, err := filepath.Abs(filepath.Join(dirPath, pidFileName))
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get absolute path for pid lock file")
+	}
+	f, err := os.Open(dirPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot open directory %q", dirPath)
+	}
+	err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err != nil {
+		f.Close()
+		return nil, errors.Wrapf(err,
+			"Cannot acquire directory lock on %q.  Another process is using this Badger database.",
+			dirPath)
+	}
+
+	// Yes, we happily overwrite a pre-existing pid file.  We're the only badger process using this
+	// directory.
+	err = ioutil.WriteFile(absPidFilePath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0666)
+	if err != nil {
+		f.Close()
+		return nil, errors.Wrapf(err,
+			"Cannot write pid file %q", absPidFilePath)
+	}
+
+	return &DirectoryLockGuard{f, absPidFilePath}, nil
+}
+
+// Release deletes the pid file and releases our lock on the directory.
+func (guard *DirectoryLockGuard) Release() error {
+	// It's important that we remove the pid file first.
+	err := os.Remove(guard.path)
+	if closeErr := guard.f.Close(); err == nil {
+		err = closeErr
+	}
+	guard.path = ""
+	guard.f = nil
+
+	return err
+}

--- a/y/directorylock_windows.go
+++ b/y/directorylock_windows.go
@@ -1,0 +1,47 @@
+package y
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// DirectoryLockGuard holds a lock on the directory.
+type DirectoryLockGuard struct {
+	path string
+}
+
+// AcquireDirectoryLock acquires exclusive access to a directory.
+func AcquireDirectoryLock(dirPath string, pidFileName string) (*DirectoryLockGuard, error) {
+	// Convert to absolute path so that Release still works even if we do an unbalanced
+	// chdir in the meantime.
+	absLockFilePath, err := filepath.Abs(filepath.Join(dirPath, pidFileName))
+	if err != nil {
+		return nil, errors.Wrap(err, "Cannot get absolute path for pid lock file")
+	}
+
+	f, err := os.OpenFile(absLockFilePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"Cannot create pid lock file %q.  Another process is using this Badger database",
+			absLockFilePath)
+	}
+	_, err = fmt.Fprintf(f, "%d\n", os.Getpid())
+	closeErr := f.Close()
+	if err != nil {
+		return nil, errors.Wrap(err, "Cannot write to pid lock file")
+	}
+	if closeErr != nil {
+		return nil, errors.Wrap(closeErr, "Cannot close pid lock file")
+	}
+	return &DirectoryLockGuard{path: absLockFilePath}, nil
+}
+
+// Release removes the directory lock.
+func (g *DirectoryLockGuard) Release() error {
+	path := g.path
+	g.path = ""
+	return os.Remove(path)
+}


### PR DESCRIPTION
This acquires a lock by flocking the directory.  Just for advisory purposes, it writes the process id to the 'LOCK' file.

I've split the implementatino between Windows and Unix -- the Windows implementation is still just doing what was there before, O_EXCL when opening the file.  I'll need to make the better Windows implementation on a Windows machine.  (It will use CreateFile with FILE_FLAG_DELETE_ON_CLOSE so that it doesn't persist after a process crash.)

If/when this PR is accepted I can make an issue for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/111)
<!-- Reviewable:end -->
