### PR TITLE
Document the error returned by BatchSet

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -733,6 +733,7 @@ func (s *KV) sendToWriteCh(entries []*Entry) []*request {
 //   for _, e := range entries {
 //      Check(e.Error)
 //   }
+// It returns the last error set on entries, or nil if no error is set on entries.
 func (s *KV) BatchSet(entries []*Entry) error {
 	reqs := s.sendToWriteCh(entries)
 


### PR DESCRIPTION
I looked at the BatchSet implementation and understand the return value of BatchSet is the first error set on entries.
https://github.com/dgraph-io/badger/blob/2fb2716592e107675fd8dbf6814f46d105017920/kv.go#L739-L747

I think this should be documented, so this is a pull request for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/117)
<!-- Reviewable:end -->
