### PR TITLE
Make cas counter a 64-bit incrementing counter

### DIFF
--- a/compact_log_test.go
+++ b/compact_log_test.go
@@ -138,7 +138,7 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 	})
 	for i, kv := range keyValues {
 		y.AssertTrue(len(kv) == 2)
-		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', uint16(i), 0})
+		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', 0, uint16(i)})
 		if t != nil {
 			require.NoError(t, err)
 		} else {

--- a/compact_log_test.go
+++ b/compact_log_test.go
@@ -138,7 +138,7 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 	})
 	for i, kv := range keyValues {
 		y.AssertTrue(len(kv) == 2)
-		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', 0, uint16(i)})
+		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', 0, uint64(i)})
 		if t != nil {
 			require.NoError(t, err)
 		} else {

--- a/iterator.go
+++ b/iterator.go
@@ -32,7 +32,7 @@ type KVItem struct {
 	meta       byte
 	userMeta   byte
 	val        []byte
-	casCounter uint16
+	casCounter uint64
 	slice      *y.Slice
 	next       *KVItem
 }
@@ -51,7 +51,7 @@ func (item *KVItem) Value() []byte {
 }
 
 // Counter returns the CAS counter associated with the value.
-func (item *KVItem) Counter() uint16 {
+func (item *KVItem) Counter() uint64 {
 	return item.casCounter
 }
 

--- a/kv.go
+++ b/kv.go
@@ -982,7 +982,10 @@ func (s *KV) flushMemtable(lc *y.LevelCloser) error {
 			s.Lock() // For vptr.
 			s.vptr.Encode(offset)
 			s.Unlock()
-			ft.mt.Put(head, y.ValueStruct{Value: offset}) // casCounter not needed.
+			// CAS counter is needed and is desirable -- it's the first value log entry
+			// we reply, perhaps the only, and we use it to re-initialize the CAS
+			// counter.
+			ft.mt.Put(head, y.ValueStruct{Value: offset, CASCounter: newCASCounter()})
 		}
 		fileID, _ := s.lc.reserveFileIDs(1)
 		fd, err := y.OpenSyncedFile(table.NewFilename(fileID, s.opt.Dir), true)

--- a/kv.go
+++ b/kv.go
@@ -1007,6 +1007,12 @@ func (s *KV) flushMemtable(lc *y.LevelCloser) error {
 			// CAS counter is needed and is desirable -- it's the first value log entry
 			// we replay, so to speak, perhaps the only, and we use it to re-initialize
 			// the CAS counter.
+			//
+			// In the write loop, the s.vptr value gets updated _after_ the values are
+			// written to the value log.  This means we might store a !badger!head with
+			// a later CAS counter (because it's accessed atomically and not tied to
+			// the vptr value by any mechanism, and then replay value log entries with
+			// a smaller CAS counter.
 			ft.mt.Put(head, y.ValueStruct{Value: offset, CASCounter: s.newCASCounter()})
 		}
 		fileID, _ := s.lc.reserveFileIDs(1)

--- a/kv.go
+++ b/kv.go
@@ -812,7 +812,7 @@ func EntriesSet(s []*Entry, key, val []byte) []*Entry {
 // CompareAndSet sets the given value, ensuring that the no other Set operation has happened,
 // since last read. If the key has a different casCounter, this would not update the key
 // and return an error.
-func (s *KV) CompareAndSet(key []byte, val []byte, casCounter uint16) error {
+func (s *KV) CompareAndSet(key []byte, val []byte, casCounter uint64) error {
 	e := &Entry{
 		Key:             key,
 		Value:           val,
@@ -843,7 +843,7 @@ func (s *KV) compareAsync(e *Entry, f func(error)) {
 // CompareAndSetAsync is the asynchronous version of CompareAndSet. It accepts a callback function
 // which is called when the CompareAndSet completes. Any error encountered during execution is
 // passed as an argument to the callback function.
-func (s *KV) CompareAndSetAsync(key []byte, val []byte, casCounter uint16, f func(error)) {
+func (s *KV) CompareAndSetAsync(key []byte, val []byte, casCounter uint64, f func(error)) {
 	e := &Entry{
 		Key:             key,
 		Value:           val,
@@ -885,7 +885,7 @@ func EntriesDelete(s []*Entry, key []byte) []*Entry {
 
 // CompareAndDelete deletes a key ensuring that it has not been changed since last read.
 // If existing key has different casCounter, this would not delete the key and return an error.
-func (s *KV) CompareAndDelete(key []byte, casCounter uint16) error {
+func (s *KV) CompareAndDelete(key []byte, casCounter uint64) error {
 	e := &Entry{
 		Key:             key,
 		Meta:            BitDelete,
@@ -900,7 +900,7 @@ func (s *KV) CompareAndDelete(key []byte, casCounter uint16) error {
 // CompareAndDeleteAsync is the asynchronous version of CompareAndDelete. It accepts a callback
 // function which is called when the CompareAndDelete completes. Any error encountered during
 // execution is passed as an argument to the callback function.
-func (s *KV) CompareAndDeleteAsync(key []byte, casCounter uint16, f func(error)) {
+func (s *KV) CompareAndDeleteAsync(key []byte, casCounter uint64, f func(error)) {
 	e := &Entry{
 		Key:             key,
 		Meta:            BitDelete,

--- a/kv.go
+++ b/kv.go
@@ -113,9 +113,9 @@ var DefaultOptions = Options{
 func (opt *Options) estimateSize(entry *Entry) int {
 	if len(entry.Value) < opt.ValueThreshold {
 		// 4 is for cas + meta
-		return len(entry.Key) + len(entry.Value) + 4
+		return len(entry.Key) + len(entry.Value) + y.MetaSize + y.UserMetaSize + y.CasSize
 	}
-	return len(entry.Key) + 16 + 4
+	return len(entry.Key) + 16 + y.MetaSize + y.UserMetaSize + y.CasSize
 }
 
 // KV provides the various functions required to interact with Badger.

--- a/kv.go
+++ b/kv.go
@@ -140,7 +140,6 @@ type KV struct {
 
 	// Incremented in the non-concurrently accessed write loop.  But also incremented outside.
 	// So we use an atomic op.
-	// TODO: Don't use an atomic op.
 	lastUsedCasCounter uint64
 }
 

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -82,11 +82,5 @@ func (s *Arena) GetKey(offset uint32, size uint16) []byte {
 // GetVal returns byte slice at offset. The given size should be just the value
 // size and should NOT include the meta bytes.
 func (s *Arena) GetVal(offset uint32, size uint16) y.ValueStruct {
-	out := y.ValueStruct{
-		Value:      s.buf[offset+y.ValueValueOffset : offset+y.ValueValueOffset+uint32(size)],
-		Meta:       s.buf[offset+y.ValueMetaOffset],
-		UserMeta:   s.buf[offset+y.ValueUserMetaOffset],
-		CASCounter: binary.BigEndian.Uint16(s.buf[offset+y.ValueCasOffset : offset+y.ValueCasOffset+y.CasSize]),
-	}
-	return out
+	return y.DecodeValueStruct(s.buf[offset : offset+uint32(y.ValueStructSerializedSize(size))])
 }

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -50,7 +50,7 @@ func (s *Arena) Reset() {
 // size of val. We could also store this size inside arena but the encoding and
 // decoding will incur some overhead.
 func (s *Arena) PutVal(v y.ValueStruct) uint32 {
-	l := uint32(len(v.Value)) + 4
+	l := uint32(len(v.Value)) + y.MetaSize + y.UserMetaSize + y.CasSize
 	n := atomic.AddUint32(&s.n, l)
 	y.AssertTruef(int(n) <= len(s.buf),
 		"Arena too small, toWrite:%d newTotal:%d limit:%d",
@@ -58,8 +58,8 @@ func (s *Arena) PutVal(v y.ValueStruct) uint32 {
 	m := n - l
 	s.buf[m] = v.Meta
 	s.buf[m+1] = v.UserMeta
-	binary.BigEndian.PutUint16(s.buf[m+2:m+4], v.CASCounter)
-	copy(s.buf[m+4:n], v.Value)
+	binary.BigEndian.PutUint16(s.buf[m+2:m+2+y.CasSize], v.CASCounter)
+	copy(s.buf[m+2+y.CasSize:n], v.Value)
 	return m
 }
 
@@ -80,13 +80,13 @@ func (s *Arena) GetKey(offset uint32, size uint16) []byte {
 }
 
 // GetVal returns byte slice at offset. The given size should be just the value
-// size and should NOT include the meta byte.
+// size and should NOT include the meta bytes.
 func (s *Arena) GetVal(offset uint32, size uint16) y.ValueStruct {
 	out := y.ValueStruct{
-		Value:      s.buf[offset+4 : offset+4+uint32(size)],
-		Meta:       s.buf[offset],
-		UserMeta:   s.buf[offset+1],
-		CASCounter: binary.BigEndian.Uint16(s.buf[offset+2 : offset+4]),
+		Value:      s.buf[offset+y.ValueValueOffset : offset+y.ValueValueOffset+uint32(size)],
+		Meta:       s.buf[offset+y.ValueMetaOffset],
+		UserMeta:   s.buf[offset+y.ValueUserMetaOffset],
+		CASCounter: binary.BigEndian.Uint16(s.buf[offset+y.ValueCasOffset : offset+y.ValueCasOffset+y.CasSize]),
 	}
 	return out
 }

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -55,7 +55,7 @@ func (s *Arena) PutVal(v y.ValueStruct) uint32 {
 		"Arena too small, toWrite:%d newTotal:%d limit:%d",
 		l, n, len(s.buf))
 	m := n - l
-	y.EncodeValueStruct(s.buf[m:], &v)
+	v.Encode(s.buf[m:])
 	return m
 }
 
@@ -77,6 +77,7 @@ func (s *Arena) GetKey(offset uint32, size uint16) []byte {
 
 // GetVal returns byte slice at offset. The given size should be just the value
 // size and should NOT include the meta bytes.
-func (s *Arena) GetVal(offset uint32, size uint16) y.ValueStruct {
-	return y.DecodeValueStruct(s.buf[offset : offset+uint32(y.ValueStructSerializedSize(size))])
+func (s *Arena) GetVal(offset uint32, size uint16) (ret y.ValueStruct) {
+	ret.DecodeEntireSlice(s.buf[offset : offset+uint32(y.ValueStructSerializedSize(size))])
+	return
 }

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -91,9 +91,9 @@ func TestBasic(t *testing.T) {
 
 	// Try inserting values.
 	// Somehow require.Nil doesn't work when checking for unsafe.Pointer(nil).
-	l.Put([]byte("key1"), y.ValueStruct{val1, 55, 60000, 0})
-	l.Put([]byte("key3"), y.ValueStruct{val3, 56, 60001, 0})
-	l.Put([]byte("key2"), y.ValueStruct{val2, 57, 60002, 0})
+	l.Put([]byte("key1"), y.ValueStruct{val1, 55, 0, 60000})
+	l.Put([]byte("key3"), y.ValueStruct{val3, 56, 0, 60001})
+	l.Put([]byte("key2"), y.ValueStruct{val2, 57, 0, 60002})
 
 	v := l.Get([]byte("key"))
 	require.True(t, v.Value == nil)
@@ -116,7 +116,7 @@ func TestBasic(t *testing.T) {
 	require.EqualValues(t, 56, v.Meta)
 	require.EqualValues(t, 60001, v.CASCounter)
 
-	l.Put([]byte("key2"), y.ValueStruct{val4, 12, 50000, 0})
+	l.Put([]byte("key2"), y.ValueStruct{val4, 12, 0, 50000})
 	v = l.Get([]byte("key2"))
 	require.True(t, v.Value != nil)
 	require.EqualValues(t, "00072", string(v.Value))
@@ -134,7 +134,7 @@ func TestConcurrentBasic(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			l.Put([]byte(fmt.Sprintf("%05d", i)),
-				y.ValueStruct{newValue(i), 0, uint16(i), 0})
+				y.ValueStruct{newValue(i), 0, 0, uint16(i)})
 		}(i)
 	}
 	wg.Wait()
@@ -165,7 +165,7 @@ func TestOneKey(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			l.Put(key, y.ValueStruct{newValue(i), 0, uint16(i), 0})
+			l.Put(key, y.ValueStruct{newValue(i), 0, 0, uint16(i)})
 		}(i)
 	}
 	// We expect that at least some write made it such that some read returns a value.
@@ -195,7 +195,7 @@ func TestFindNear(t *testing.T) {
 	defer l.DecrRef()
 	for i := 0; i < 1000; i++ {
 		key := fmt.Sprintf("%05d", i*10+5)
-		l.Put([]byte(key), y.ValueStruct{newValue(i), 0, uint16(i), 0})
+		l.Put([]byte(key), y.ValueStruct{newValue(i), 0, 0, uint16(i)})
 	}
 
 	n, eq := l.findNear([]byte("00001"), false, false)
@@ -307,7 +307,7 @@ func TestIteratorNext(t *testing.T) {
 	require.False(t, it.Valid())
 	for i := n - 1; i >= 0; i-- {
 		l.Put([]byte(fmt.Sprintf("%05d", i)),
-			y.ValueStruct{newValue(i), 0, uint16(i), 0})
+			y.ValueStruct{newValue(i), 0, 0, uint16(i)})
 	}
 	it.SeekToFirst()
 	for i := 0; i < n; i++ {
@@ -331,7 +331,7 @@ func TestIteratorPrev(t *testing.T) {
 	require.False(t, it.Valid())
 	for i := 0; i < n; i++ {
 		l.Put([]byte(fmt.Sprintf("%05d", i)),
-			y.ValueStruct{newValue(i), 0, uint16(i), 0})
+			y.ValueStruct{newValue(i), 0, 0, uint16(i)})
 	}
 	it.SeekToLast()
 	for i := n - 1; i >= 0; i-- {
@@ -359,7 +359,7 @@ func TestIteratorSeek(t *testing.T) {
 	// 1000, 1010, 1020, ..., 1990.
 	for i := n - 1; i >= 0; i-- {
 		v := i*10 + 1000
-		l.Put([]byte(fmt.Sprintf("%05d", i*10+1000)), y.ValueStruct{newValue(v), 0, 555, 0})
+		l.Put([]byte(fmt.Sprintf("%05d", i*10+1000)), y.ValueStruct{newValue(v), 0, 0, 555})
 	}
 	it.Seek([]byte(""))
 	require.True(t, it.Valid())

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -134,7 +134,7 @@ func TestConcurrentBasic(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			l.Put([]byte(fmt.Sprintf("%05d", i)),
-				y.ValueStruct{newValue(i), 0, 0, uint16(i)})
+				y.ValueStruct{newValue(i), 0, 0, uint64(i)})
 		}(i)
 	}
 	wg.Wait()
@@ -165,7 +165,7 @@ func TestOneKey(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			l.Put(key, y.ValueStruct{newValue(i), 0, 0, uint16(i)})
+			l.Put(key, y.ValueStruct{newValue(i), 0, 0, uint64(i)})
 		}(i)
 	}
 	// We expect that at least some write made it such that some read returns a value.
@@ -195,7 +195,7 @@ func TestFindNear(t *testing.T) {
 	defer l.DecrRef()
 	for i := 0; i < 1000; i++ {
 		key := fmt.Sprintf("%05d", i*10+5)
-		l.Put([]byte(key), y.ValueStruct{newValue(i), 0, 0, uint16(i)})
+		l.Put([]byte(key), y.ValueStruct{newValue(i), 0, 0, uint64(i)})
 	}
 
 	n, eq := l.findNear([]byte("00001"), false, false)
@@ -307,7 +307,7 @@ func TestIteratorNext(t *testing.T) {
 	require.False(t, it.Valid())
 	for i := n - 1; i >= 0; i-- {
 		l.Put([]byte(fmt.Sprintf("%05d", i)),
-			y.ValueStruct{newValue(i), 0, 0, uint16(i)})
+			y.ValueStruct{newValue(i), 0, 0, uint64(i)})
 	}
 	it.SeekToFirst()
 	for i := 0; i < n; i++ {
@@ -331,7 +331,7 @@ func TestIteratorPrev(t *testing.T) {
 	require.False(t, it.Valid())
 	for i := 0; i < n; i++ {
 		l.Put([]byte(fmt.Sprintf("%05d", i)),
-			y.ValueStruct{newValue(i), 0, 0, uint16(i)})
+			y.ValueStruct{newValue(i), 0, 0, uint64(i)})
 	}
 	it.SeekToLast()
 	for i := n - 1; i >= 0; i-- {

--- a/table/builder.go
+++ b/table/builder.go
@@ -149,7 +149,7 @@ func (b *TableBuilder) addHelper(key []byte, v y.ValueStruct) {
 	b.buf.WriteByte(v.Meta) // Meta byte precedes actual value.
 	b.buf.WriteByte(v.UserMeta)
 	var casBytes [y.CasSize]byte
-	binary.BigEndian.PutUint16(casBytes[:], v.CASCounter)
+	binary.BigEndian.PutUint64(casBytes[:], v.CASCounter)
 	b.buf.Write(casBytes[:])
 	b.buf.Write(v.Value)
 	b.counter++ // Increment number of keys added for this current block.

--- a/table/builder.go
+++ b/table/builder.go
@@ -136,8 +136,8 @@ func (b *TableBuilder) addHelper(key []byte, v y.ValueStruct) {
 	h := header{
 		plen: uint16(len(key) - len(diffKey)),
 		klen: uint16(len(diffKey)),
-		vlen: uint16(len(v.Value) + 1 + 2 + 1), // Include meta byte and casCounter.
-		prev: b.prevOffset,                     // prevOffset is the location of the last key-value added.
+		vlen: uint16(len(v.Value) + y.MetaSize + y.UserMetaSize + y.CasSize),
+		prev: b.prevOffset, // prevOffset is the location of the last key-value added.
 	}
 	b.prevOffset = uint32(b.buf.Len()) - b.baseOffset // Remember current offset for the next Add call.
 
@@ -148,7 +148,7 @@ func (b *TableBuilder) addHelper(key []byte, v y.ValueStruct) {
 	b.buf.Write(diffKey)    // We only need to store the key difference.
 	b.buf.WriteByte(v.Meta) // Meta byte precedes actual value.
 	b.buf.WriteByte(v.UserMeta)
-	var casBytes [2]byte
+	var casBytes [y.CasSize]byte
 	binary.BigEndian.PutUint16(casBytes[:], v.CASCounter)
 	b.buf.Write(casBytes[:])
 	b.buf.Write(v.Value)

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -18,7 +18,6 @@ package table
 
 import (
 	"bytes"
-	"encoding/binary"
 	"io"
 	"math"
 	"sort"
@@ -392,13 +391,7 @@ func (itr *TableIterator) Key() []byte {
 }
 
 func (itr *TableIterator) Value() y.ValueStruct {
-	v := itr.bi.Value()
-	return y.ValueStruct{
-		Value:      v[y.ValueValueOffset:],
-		Meta:       v[y.ValueMetaOffset],
-		UserMeta:   v[y.ValueUserMetaOffset],
-		CASCounter: binary.BigEndian.Uint16(v[y.ValueCasOffset : y.ValueCasOffset+y.CasSize]),
-	}
+	return y.DecodeValueStruct(itr.bi.Value())
 }
 
 func (s *TableIterator) Next() {

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -394,10 +394,10 @@ func (itr *TableIterator) Key() []byte {
 func (itr *TableIterator) Value() y.ValueStruct {
 	v := itr.bi.Value()
 	return y.ValueStruct{
-		Value:      v[4:],
-		Meta:       v[0],
-		UserMeta:   v[1],
-		CASCounter: binary.BigEndian.Uint16(v[2:4]),
+		Value:      v[y.ValueValueOffset:],
+		Meta:       v[y.ValueMetaOffset],
+		UserMeta:   v[y.ValueUserMetaOffset],
+		CASCounter: binary.BigEndian.Uint16(v[y.ValueCasOffset : y.ValueCasOffset+y.CasSize]),
 	}
 }
 

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -390,8 +390,9 @@ func (itr *TableIterator) Key() []byte {
 	return itr.bi.Key()
 }
 
-func (itr *TableIterator) Value() y.ValueStruct {
-	return y.DecodeValueStruct(itr.bi.Value())
+func (itr *TableIterator) Value() (ret y.ValueStruct) {
+	ret.DecodeEntireSlice(itr.bi.Value())
+	return
 }
 
 func (s *TableIterator) Next() {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -61,7 +61,7 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 	})
 	for i, kv := range keyValues {
 		y.AssertTrue(len(kv) == 2)
-		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', 0, uint16(i)})
+		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', 0, uint64(i)})
 		if t != nil {
 			require.NoError(t, err)
 		} else {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -61,7 +61,7 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 	})
 	for i, kv := range keyValues {
 		y.AssertTrue(len(kv) == 2)
-		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', uint16(i), 0})
+		err := b.Add([]byte(kv[0]), y.ValueStruct{[]byte(kv[1]), 'A', 0, uint16(i)})
 		if t != nil {
 			require.NoError(t, err)
 		} else {
@@ -617,7 +617,7 @@ func BenchmarkRead(b *testing.B) {
 	for i := 0; i < n; i++ {
 		k := fmt.Sprintf("%016x", i)
 		v := fmt.Sprintf("%d", i)
-		y.Check(builder.Add([]byte(k), y.ValueStruct{[]byte(v), 123, 5555, 0}))
+		y.Check(builder.Add([]byte(k), y.ValueStruct{[]byte(v), 123, 0, 5555}))
 	}
 
 	f.Write(builder.Finish([]byte("somemetadata")))
@@ -647,7 +647,7 @@ func BenchmarkReadAndBuild(b *testing.B) {
 	for i := 0; i < n; i++ {
 		k := fmt.Sprintf("%016x", i)
 		v := fmt.Sprintf("%d", i)
-		y.Check(builder.Add([]byte(k), y.ValueStruct{[]byte(v), 123, 5555, 0}))
+		y.Check(builder.Add([]byte(k), y.ValueStruct{[]byte(v), 123, 0, 5555}))
 	}
 
 	f.Write(builder.Finish([]byte("somemetadata")))
@@ -687,7 +687,7 @@ func BenchmarkReadMerged(b *testing.B) {
 			// id := i*tableSize+j (not interleaved)
 			k := fmt.Sprintf("%016x", id)
 			v := fmt.Sprintf("%d", id)
-			y.Check(builder.Add([]byte(k), y.ValueStruct{[]byte(v), 123, 5555, 0}))
+			y.Check(builder.Add([]byte(k), y.ValueStruct{[]byte(v), 123, 0, 5555}))
 		}
 		f.Write(builder.Finish([]byte("somemetadata")))
 		tbl, err := OpenTable(f, MemoryMap)

--- a/util.go
+++ b/util.go
@@ -136,12 +136,6 @@ func getIDMap(dir string) map[uint64]struct{} {
 	return idMap
 }
 
-func newCASCounter() uint64 {
-	// Oh well, only 63 bits of randomness.  Doing this gross thing because we expect to switch to
-	// an actual incrementing counter anyway.  (We can't return zero.)
-	return rand.Uint64() | 1
-}
-
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }

--- a/util.go
+++ b/util.go
@@ -136,20 +136,10 @@ func getIDMap(dir string) map[uint64]struct{} {
 	return idMap
 }
 
-// mod65535 mods by 65535 fast.
-func mod65535(a uint32) uint32 {
-	a = (a >> 16) + (a & 0xFFFF) /* sum base 2**16 digits */
-	if a < 65535 {
-		return a
-	}
-	if a < (2 * 65535) {
-		return a - 65535
-	}
-	return a - (2 * 65535)
-}
-
-func newCASCounter() uint16 {
-	return uint16(1 + mod65535(rand.Uint32()))
+func newCASCounter() uint64 {
+	// Oh well, only 63 bits of randomness.  Doing this gross thing because we expect to switch to
+	// an actual incrementing counter anyway.  (We can't return zero.)
+	return rand.Uint64() | 1
 }
 
 func init() {

--- a/value.go
+++ b/value.go
@@ -580,7 +580,6 @@ func (l *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 
 	// Seek to the end to start writing.
 	var err error
-	// TODO: Why is there no l.RLock() here?
 	last := l.files[len(l.files)-1]
 	lastOffset, err := last.fd.Seek(0, io.SeekEnd)
 	last.offset = uint32(lastOffset)

--- a/value.go
+++ b/value.go
@@ -587,10 +587,12 @@ func (l *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 }
 
 type request struct {
+	// Input values
 	Entries []*Entry
-	Ptrs    []valuePointer
-	Wg      sync.WaitGroup
-	Err     error
+	// Output values
+	Ptrs []valuePointer
+	Wg   sync.WaitGroup
+	Err  error
 }
 
 // sync is thread-unsafe and should not be called concurrently with write.

--- a/value.go
+++ b/value.go
@@ -108,7 +108,7 @@ type logEntry func(e Entry, vp valuePointer) error
 // iterate iterates over log file. It doesn't not allocate new memory for every kv pair.
 // Therefore, the kv pair is only valid for the duration of fn call.
 func (f *logFile) iterate(offset uint32, fn logEntry) error {
-	_, err := f.fd.Seek(int64(offset), 0)
+	_, err := f.fd.Seek(int64(offset), io.SeekStart)
 	if err != nil {
 		return y.Wrap(err)
 	}

--- a/value.go
+++ b/value.go
@@ -127,7 +127,7 @@ func (f *logFile) iterate(offset uint32, fn logEntry) error {
 	}
 
 	reader := bufio.NewReader(f.fd)
-	var hbuf [14]byte
+	var hbuf [headerBufSize]byte
 	var h header
 	var count int
 	k := make([]byte, 1<<10)
@@ -339,7 +339,7 @@ type entryEncoder struct {
 // Encodes e to buf either plain or compressed.
 // Returns number of bytes written.
 func (enc *entryEncoder) Encode(e *Entry, buf *bytes.Buffer) (int, error) {
-	var headerEnc [14]byte
+	var headerEnc [headerBufSize]byte
 	var h header
 
 	if int32(len(e.Key)+len(e.Value)) > enc.opt.ValueCompressionMinSize {
@@ -398,8 +398,12 @@ type header struct {
 	casCounterCheck uint16
 }
 
+const (
+	headerBufSize = 14
+)
+
 func (h header) Encode(out []byte) {
-	y.AssertTrue(len(out) >= 14)
+	y.AssertTrue(len(out) >= headerBufSize)
 	binary.BigEndian.PutUint32(out[0:4], h.klen)
 	binary.BigEndian.PutUint32(out[4:8], h.vlen)
 	out[8] = h.meta

--- a/value.go
+++ b/value.go
@@ -580,6 +580,7 @@ func (l *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 
 	// Seek to the end to start writing.
 	var err error
+	// TODO: Why is there no l.RLock() here?
 	last := l.files[len(l.files)-1]
 	lastOffset, err := last.fd.Seek(0, io.SeekEnd)
 	last.offset = uint32(lastOffset)

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -47,18 +47,16 @@ func ValueStructSerializedSize(size uint16) int {
 	return int(size) + ValueValueOffset
 }
 
-// DecodeValueStruct uses the length of the slice to infer the length of the Value field.
-func DecodeValueStruct(b []byte) ValueStruct {
-	return ValueStruct{
-		Value:      b[ValueValueOffset:],
-		Meta:       b[ValueMetaOffset],
-		UserMeta:   b[ValueUserMetaOffset],
-		CASCounter: binary.BigEndian.Uint64(b[ValueCasOffset : ValueCasOffset+CasSize]),
-	}
+// DecodeEntireSlice uses the length of the slice to infer the length of the Value field.
+func (v *ValueStruct) DecodeEntireSlice(b []byte) {
+	v.Value = b[ValueValueOffset:]
+	v.Meta = b[ValueMetaOffset]
+	v.UserMeta = b[ValueUserMetaOffset]
+	v.CASCounter = binary.BigEndian.Uint64(b[ValueCasOffset : ValueCasOffset+CasSize])
 }
 
-// EncodeValueStruct expects a slice of length v.EncodedSize().
-func EncodeValueStruct(b []byte, v *ValueStruct) {
+// Encode expects a slice of length at least v.EncodedSize().
+func (v *ValueStruct) Encode(b []byte) {
 	b[ValueMetaOffset] = v.Meta
 	b[ValueUserMetaOffset] = v.UserMeta
 	binary.BigEndian.PutUint64(b[ValueCasOffset:ValueCasOffset+CasSize], v.CASCounter)

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -38,6 +38,10 @@ type ValueStruct struct {
 	CASCounter uint16
 }
 
+func (v *ValueStruct) EncodedSize() int {
+	return len(v.Value) + ValueValueOffset
+}
+
 // Converts a value size to the full serialized size of value + metadata.
 func ValueStructSerializedSize(size uint16) int {
 	return int(size) + ValueValueOffset
@@ -51,6 +55,14 @@ func DecodeValueStruct(b []byte) ValueStruct {
 		UserMeta:   b[ValueUserMetaOffset],
 		CASCounter: binary.BigEndian.Uint16(b[ValueCasOffset : ValueCasOffset+CasSize]),
 	}
+}
+
+// EncodeValueStruct expects a slice of length v.EncodedSize().
+func EncodeValueStruct(b []byte, v *ValueStruct) {
+	b[ValueMetaOffset] = v.Meta
+	b[ValueUserMetaOffset] = v.UserMeta
+	binary.BigEndian.PutUint16(b[ValueCasOffset:ValueCasOffset+CasSize], v.CASCounter)
+	copy(b[ValueValueOffset:ValueValueOffset+len(v.Value)], v.Value)
 }
 
 // Iterator is an interface for a basic iterator.

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -34,8 +34,8 @@ const (
 type ValueStruct struct {
 	Value      []byte
 	Meta       byte
-	CASCounter uint16
 	UserMeta   byte
+	CASCounter uint16
 }
 
 // Converts a value size to the full serialized size of value + metadata.

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	ValueMetaOffset     = 0
-	ValueUserMetaOffset = ValueMetaOffset + MetaSize
-	ValueCasOffset      = ValueUserMetaOffset + UserMetaSize
-	ValueValueOffset    = ValueCasOffset + CasSize
+	valueMetaOffset     = 0
+	valueUserMetaOffset = valueMetaOffset + MetaSize
+	valueCasOffset      = valueUserMetaOffset + UserMetaSize
+	valueValueOffset    = valueCasOffset + CasSize
 )
 
 type ValueStruct struct {
@@ -39,28 +39,28 @@ type ValueStruct struct {
 }
 
 func (v *ValueStruct) EncodedSize() int {
-	return len(v.Value) + ValueValueOffset
+	return len(v.Value) + valueValueOffset
 }
 
 // Converts a value size to the full serialized size of value + metadata.
 func ValueStructSerializedSize(size uint16) int {
-	return int(size) + ValueValueOffset
+	return int(size) + valueValueOffset
 }
 
 // DecodeEntireSlice uses the length of the slice to infer the length of the Value field.
 func (v *ValueStruct) DecodeEntireSlice(b []byte) {
-	v.Value = b[ValueValueOffset:]
-	v.Meta = b[ValueMetaOffset]
-	v.UserMeta = b[ValueUserMetaOffset]
-	v.CASCounter = binary.BigEndian.Uint64(b[ValueCasOffset : ValueCasOffset+CasSize])
+	v.Value = b[valueValueOffset:]
+	v.Meta = b[valueMetaOffset]
+	v.UserMeta = b[valueUserMetaOffset]
+	v.CASCounter = binary.BigEndian.Uint64(b[valueCasOffset : valueCasOffset+CasSize])
 }
 
 // Encode expects a slice of length at least v.EncodedSize().
 func (v *ValueStruct) Encode(b []byte) {
-	b[ValueMetaOffset] = v.Meta
-	b[ValueUserMetaOffset] = v.UserMeta
-	binary.BigEndian.PutUint64(b[ValueCasOffset:ValueCasOffset+CasSize], v.CASCounter)
-	copy(b[ValueValueOffset:ValueValueOffset+len(v.Value)], v.Value)
+	b[valueMetaOffset] = v.Meta
+	b[valueUserMetaOffset] = v.UserMeta
+	binary.BigEndian.PutUint64(b[valueCasOffset:valueCasOffset+CasSize], v.CASCounter)
+	copy(b[valueValueOffset:valueValueOffset+len(v.Value)], v.Value)
 }
 
 // Iterator is an interface for a basic iterator.

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -24,13 +24,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	valueMetaOffset     = 0
-	valueUserMetaOffset = valueMetaOffset + MetaSize
-	valueCasOffset      = valueUserMetaOffset + UserMetaSize
-	valueValueOffset    = valueCasOffset + CasSize
-)
-
 type ValueStruct struct {
 	Value      []byte
 	Meta       byte
@@ -46,6 +39,13 @@ func (v *ValueStruct) EncodedSize() int {
 func ValueStructSerializedSize(size uint16) int {
 	return int(size) + valueValueOffset
 }
+
+const (
+	valueMetaOffset     = 0
+	valueUserMetaOffset = valueMetaOffset + MetaSize
+	valueCasOffset      = valueUserMetaOffset + UserMetaSize
+	valueValueOffset    = valueCasOffset + CasSize
+)
 
 // DecodeEntireSlice uses the length of the slice to infer the length of the Value field.
 func (v *ValueStruct) DecodeEntireSlice(b []byte) {

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -35,7 +35,7 @@ type ValueStruct struct {
 	Value      []byte
 	Meta       byte
 	UserMeta   byte
-	CASCounter uint16
+	CASCounter uint64
 }
 
 func (v *ValueStruct) EncodedSize() int {
@@ -53,7 +53,7 @@ func DecodeValueStruct(b []byte) ValueStruct {
 		Value:      b[ValueValueOffset:],
 		Meta:       b[ValueMetaOffset],
 		UserMeta:   b[ValueUserMetaOffset],
-		CASCounter: binary.BigEndian.Uint16(b[ValueCasOffset : ValueCasOffset+CasSize]),
+		CASCounter: binary.BigEndian.Uint64(b[ValueCasOffset : ValueCasOffset+CasSize]),
 	}
 }
 
@@ -61,7 +61,7 @@ func DecodeValueStruct(b []byte) ValueStruct {
 func EncodeValueStruct(b []byte, v *ValueStruct) {
 	b[ValueMetaOffset] = v.Meta
 	b[ValueUserMetaOffset] = v.UserMeta
-	binary.BigEndian.PutUint16(b[ValueCasOffset:ValueCasOffset+CasSize], v.CASCounter)
+	binary.BigEndian.PutUint64(b[ValueCasOffset:ValueCasOffset+CasSize], v.CASCounter)
 	copy(b[ValueValueOffset:ValueValueOffset+len(v.Value)], v.Value)
 }
 

--- a/y/iterator_test.go
+++ b/y/iterator_test.go
@@ -70,7 +70,7 @@ func (s *SimpleIterator) Seek(key []byte) {
 
 func (s *SimpleIterator) Key() []byte { return s.keys[s.idx] }
 func (s *SimpleIterator) Value() ValueStruct {
-	return ValueStruct{s.vals[s.idx], 55, 12345, 0}
+	return ValueStruct{s.vals[s.idx], 55, 0, 12345}
 }
 func (s *SimpleIterator) Valid() bool {
 	return s.idx >= 0 && s.idx < len(s.keys)

--- a/y/y.go
+++ b/y/y.go
@@ -28,11 +28,6 @@ const (
 	MetaSize     = 1
 	UserMetaSize = 1
 	CasSize      = 2
-
-	ValueMetaOffset     = 0
-	ValueUserMetaOffset = ValueMetaOffset + MetaSize
-	ValueCasOffset      = ValueUserMetaOffset + UserMetaSize
-	ValueValueOffset    = ValueCasOffset + CasSize
 )
 
 var (

--- a/y/y.go
+++ b/y/y.go
@@ -27,7 +27,7 @@ import (
 const (
 	MetaSize     = 1
 	UserMetaSize = 1
-	CasSize      = 2
+	CasSize      = 8
 )
 
 var (

--- a/y/y.go
+++ b/y/y.go
@@ -23,6 +23,18 @@ import (
 	"sync/atomic"
 )
 
+// Constants used in serialization sizes, and in ValueStruct serialization
+const (
+	MetaSize     = 1
+	UserMetaSize = 1
+	CasSize      = 2
+
+	ValueMetaOffset     = 0
+	ValueUserMetaOffset = ValueMetaOffset + MetaSize
+	ValueCasOffset      = ValueUserMetaOffset + UserMetaSize
+	ValueValueOffset    = ValueCasOffset + CasSize
+)
+
 var (
 	// This is O_DSYNC (datasync) on platforms that support it -- see file_unix.go
 	datasyncFileFlag = 0x0


### PR DESCRIPTION
Makes the cas counter a 64-bit incrementing counter.  It's actually an accurate and precise count of how many values we put into the value log.

If I didn't have @janardhan1993's recent userMeta change to look at it'd be a lot more difficult and error-prone, so I added some constants, deduped and moved ValueStruct encoding/decoding logic to one place to make similar modifications easier in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/130)
<!-- Reviewable:end -->
