### PR TITLE
Avoid starting value log replay from too far ahead

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -1018,7 +1018,6 @@ func (s *KV) flushMemtable(lc *y.LevelCloser) error {
 			return nil
 		}
 
-		// TODO: Can this ever be zero?  That'd just be nuts.
 		if !ft.vptr.IsZero() {
 			s.elog.Printf("Storing offset: %+v\n", ft.vptr)
 			offset := make([]byte, 10)

--- a/kv.go
+++ b/kv.go
@@ -533,12 +533,14 @@ func (s *KV) updateOffset(ptrs []valuePointer) {
 			break
 		}
 	}
+	if ptr.IsZero() {
+		return
+	}
 
 	s.Lock()
 	defer s.Unlock()
-	if s.vptr.Less(ptr) {
-		s.vptr = ptr
-	}
+	y.AssertTrue(!ptr.Less(s.vptr))
+	s.vptr = ptr
 }
 
 var requestPool = sync.Pool{

--- a/kv.go
+++ b/kv.go
@@ -129,12 +129,12 @@ type KV struct {
 
 	closer    *y.Closer
 	elog      trace.EventLog
-	mt        *skl.Skiplist
+	mt        *skl.Skiplist   // Our latest (actively written) in-memory table
 	imm       []*skl.Skiplist // Add here only AFTER pushing to flushChan.
 	opt       Options
 	lc        *levelsController
 	vlog      valueLog
-	vptr      valuePointer
+	vptr      valuePointer // less than or equal to a pointer to the last vlog value put into mt
 	writeCh   chan *request
 	flushChan chan flushTask // For flushing memtables.
 

--- a/kv.go
+++ b/kv.go
@@ -1016,12 +1016,11 @@ func (s *KV) flushMemtable(lc *y.LevelCloser) error {
 			return nil
 		}
 
-		if ft.vptr.Fid > 0 || ft.vptr.Offset > 0 || ft.vptr.Len > 0 {
+		// TODO: Can this ever be zero?  That'd just be nuts.
+		if !ft.vptr.IsZero() {
 			s.elog.Printf("Storing offset: %+v\n", ft.vptr)
 			offset := make([]byte, 10)
-			s.Lock() // For vptr and casAsOfVptr.
-			s.vptr.Encode(offset)
-			s.Unlock()
+			ft.vptr.Encode(offset)
 			// CAS counter is needed and is desirable -- it's the first value log entry
 			// we replay, so to speak, perhaps the only, and we use it to re-initialize
 			// the CAS counter.


### PR DESCRIPTION
This change fixes a dataloss bug should the process running Badger crash or be killed.

The bug is that we write s.vptr to !badger!head when we should actually write ft.vptr.

We want to write a vptr value that is less than or equal to the last value log offset for the particular memtable we're writing.  That's ft.vptr.  The value `s.vptr` could be overwritten as we're writing to later memtables.

For example, suppose that when `writeRequests` calls `ensureRoomForWrite`, we send a flush task to `flushChan`.  That flushes the preceding (full) s.mt (call it M), along with its corresponding s.vptr (call it X) value.  Then `writeRequests` writes to the new `s.mt` skiplist and *after that* calls `updateOffset` which updates `s.vptr` to the new value Y.  (Thus `s.vptr` is always less than or equal to the last vlog pointer written to `s.mt`.  And Y >= X.)  Suppose Y > X.

The function `flushMemtable` might not read from `flushChan` until after we've written the value Y to `s.vptr`.  Then !badger!head points to Y, and the LSM is written for all vlog entries up to and including X.

That means the writes in the interval (X, Y] would be missed if we replay the value log.

So writes we've acknowledged might be lost, and we might wake up in an inconsistent state by replaying entries after Y.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/134)
<!-- Reviewable:end -->
