### PR TITLE
Obey SyncWrites option for first-opened value log file

### DIFF
--- a/value.go
+++ b/value.go
@@ -545,10 +545,10 @@ func (l *valueLog) openOrCreateFiles() error {
 
 func (l *valueLog) Open(kv *KV, opt *Options) error {
 	l.dirPath = opt.ValueDir
+	l.opt = *opt
 	if err := l.openOrCreateFiles(); err != nil {
 		return errors.Wrapf(err, "Unable to open value log")
 	}
-	l.opt = *opt
 	l.kv = kv
 
 	l.elog = trace.NewEventLog("Badger", "Valuelog")


### PR DESCRIPTION
`valueLog.Open` calls `openOrCreateFiles`, which opens the first value log file that we write to, which uses `l.opt.SyncWrites` when opening the active value log file.  But `l.opt` was not initialized in `Open` until after.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/139)
<!-- Reviewable:end -->
