### PR TITLE
Remove value log compression

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -18,7 +18,6 @@ package badger
 
 import (
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -70,11 +69,6 @@ type Options struct {
 	// Size of single value log file.
 	ValueLogFileSize int64
 
-	// The following affect value compression in value log. Note that compression
-	// can significantly slow down the loading and lookup time.
-	ValueCompressionMinSize  int32   // Minimal size in bytes of KV pair to be compressed.
-	ValueCompressionMinRatio float64 // Minimal compression ratio of KV pair to be compressed.
-
 	// Sync all writes to disk. Setting this to true would slow down data loading significantly.
 	SyncWrites bool
 
@@ -96,19 +90,17 @@ var DefaultOptions = Options{
 	MapTablesTo:         table.LoadToRAM,
 	// table.MemoryMap to mmap() the tables.
 	// table.Nothing to not preload the tables.
-	MaxLevels:                7,
-	MaxTableSize:             64 << 20,
-	NumCompactors:            3,
-	NumLevelZeroTables:       5,
-	NumLevelZeroTablesStall:  10,
-	NumMemtables:             5,
-	SyncWrites:               false,
-	ValueCompressionMinRatio: 2.0,
-	ValueCompressionMinSize:  math.MaxInt32, // Turn off by default.
-	ValueGCRunInterval:       10 * time.Minute,
-	ValueGCThreshold:         0.5, // Set to zero to not run GC.
-	ValueLogFileSize:         1 << 30,
-	ValueThreshold:           20,
+	MaxLevels:               7,
+	MaxTableSize:            64 << 20,
+	NumCompactors:           3,
+	NumLevelZeroTables:      5,
+	NumLevelZeroTablesStall: 10,
+	NumMemtables:            5,
+	SyncWrites:              false,
+	ValueGCRunInterval:      10 * time.Minute,
+	ValueGCThreshold:        0.5, // Set to zero to not run GC.
+	ValueLogFileSize:        1 << 30,
+	ValueThreshold:          20,
 }
 
 func (opt *Options) estimateSize(entry *Entry) int {


### PR DESCRIPTION
Removes lz4 compression from the value log.

I made this change before doing #143 since it should make that change simpler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/145)
<!-- Reviewable:end -->
