### PR TITLE
Add Checksum to value log entries

### DIFF
--- a/value.go
+++ b/value.go
@@ -180,10 +180,13 @@ func (f *logFile) iterate(offset uint32, fn logEntry) error {
 		}
 		crc := binary.BigEndian.Uint32(crcBuf[:])
 		if crc != hash.Sum32() {
-			// TODO(peter): What to do when CRC doesn't match?
-			// 1. Return error.
-			// 2. Break out of loop (returning nil).
-			// Do we need to erase the remainder of the log file? Otherwise it would be broken 'forever'.
+			f.Lock()
+			if err := f.fd.Truncate(int64(recordOffset)); err != nil {
+				f.Unlock()
+				return err
+			}
+			f.Unlock()
+			break
 		}
 
 		var vp valuePointer

--- a/value.go
+++ b/value.go
@@ -105,7 +105,7 @@ func (lf *logFile) sync() error {
 
 var errStop = errors.New("Stop iteration")
 
-var entryHashTable = crc32.MakeTable(crc32.Koopman)
+var entryHashTable = crc32.MakeTable(crc32.Castagnoli)
 
 const entryHashSize = 4
 

--- a/value.go
+++ b/value.go
@@ -176,7 +176,10 @@ func (f *logFile) iterate(offset uint32, fn logEntry) error {
 		}
 		crc := binary.BigEndian.Uint32(crcBuf[:])
 		if crc != hash.Sum32() {
-			// TODO(peter): Check the read CRC against the calculated CRC.
+			// TODO(peter): What to do when CRC doesn't match?
+			// 1. Return error.
+			// 2. Break out of loop (returning nil).
+			// Do we need to erase the remainder of the log file? Otherwise it would be broken 'forever'.
 		}
 
 		var vp valuePointer

--- a/value.go
+++ b/value.go
@@ -205,12 +205,9 @@ func (f *logFile) iterate(offset uint32, fn logEntry) error {
 	}
 
 	if truncate {
-		f.Lock()
 		if err := f.fd.Truncate(int64(recordOffset)); err != nil {
-			f.Unlock()
 			return err
 		}
-		f.Unlock()
 	}
 
 	return nil

--- a/value_test.go
+++ b/value_test.go
@@ -274,7 +274,7 @@ func TestChecksums(t *testing.T) {
 	require.NoError(t, kv.Close())
 }
 
-func TestPatialAppendToValueLog(t *testing.T) {
+func TestPartialAppendToValueLog(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)

--- a/value_test.go
+++ b/value_test.go
@@ -269,8 +269,8 @@ func TestChecksums(t *testing.T) {
 	require.NoError(t, kv.Set(k3, v3, 0))
 	require.NoError(t, kv.Close())
 
-	// Make sure that the vlog was truncated when corrupted K2 was found. The
-	// vlog should contain K1 and K3.
+	// The vlog should contain K1 and K3 (K2 was lost when Badger started up
+	// last due to checksum failure).
 	kv, err = NewKV(getTestOptions(b1))
 	require.NoError(t, err)
 	iter := kv.NewIterator(IteratorOptions{FetchValues: true})

--- a/value_test.go
+++ b/value_test.go
@@ -56,7 +56,7 @@ func TestValueBasic(t *testing.T) {
 
 	log.write([]*request{b})
 	require.Len(t, b.Ptrs, 2)
-	fmt.Printf("Pointer written: %+v %+v", b.Ptrs[0], b.Ptrs[1])
+	fmt.Printf("Pointer written: %+v %+v\n", b.Ptrs[0], b.Ptrs[1])
 
 	e, err := log.Read(b.Ptrs[0], nil)
 	e2, err := log.Read(b.Ptrs[1], nil)


### PR DESCRIPTION
Changes:

* There is now a 32 bit CRC checksum at the end of each value log entry. So the format is now `[header][key][value][crc32]`.
* It's checked during value log replay. If an mismatch is found, the value log is truncated at the end of the last good entry.
* It's also checked during a normal value log read.
* When doing the value log replay, we also truncate the log if a partial entry is found (i.e. we reach EOF while in the middle of an entry).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/148)
<!-- Reviewable:end -->
