### PR TITLE
Fix condition for value log GC threshold

### DIFF
--- a/value.go
+++ b/value.go
@@ -864,7 +864,7 @@ func (vlog *valueLog) doRunGC() error {
 	}
 	vlog.elog.Printf("Fid: %d Data status=%+v\n", lf.fid, r)
 
-	if r.total < 10.0 || r.keep >= vlog.opt.ValueGCThreshold*r.total {
+	if r.total < 10.0 || r.discard < vlog.opt.ValueGCThreshold*r.total {
 		vlog.elog.Printf("Skipping GC on fid: %d\n\n", lf.fid)
 		return nil
 	}


### PR DESCRIPTION
Documentation on the config option:

```
// Run value log garbage collection if we can reclaim at least this much space. This is a ratio.
```

Since the behaviour is difficult for the end user to see, I think it makes more sense to change the behaviour rather than the documentation (user probably didn't notice there was a problem).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/152)
<!-- Reviewable:end -->
