### PR TITLE
Limit key/value sizes to 1G

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -788,7 +788,7 @@ func (s *KV) sendToWriteCh(entries []*Entry) []*request {
 		b.Err = nil
 		b.Ptrs = nil
 		reqs = append(reqs, b)
-		y.NumBlockedLargePuts.Add(int64(len(bad)))
+		y.NumBlockedPuts.Add(int64(len(bad)))
 	}
 
 	return reqs

--- a/kv.go
+++ b/kv.go
@@ -140,7 +140,7 @@ type KV struct {
 
 var ErrInvalidDir error = errors.New("Invalid Dir, directory does not exist")
 var ErrValueLogSize error = errors.New("Invalid ValueLogFileSize, must be between 1MB and 1GB")
-var ErrExceedsMaxKeyValueSize error = errors.New("Key/value size exceeded 1GB limit")
+var ErrExceedsMaxKeyValueSize error = errors.New("Key (value) size exceeded 1MB (1GB) limit")
 
 const (
 	kvWriteChCapacity = 1000
@@ -753,7 +753,7 @@ func (s *KV) sendToWriteCh(entries []*Entry) []*request {
 	var b *request
 	var bad []*Entry
 	for _, entry := range entries {
-		if len(entry.Key) > maxKeyValueSize || len(entry.Value) > maxKeyValueSize {
+		if len(entry.Key) > maxKeySize || len(entry.Value) > maxValueSize {
 			entry.Error = ErrExceedsMaxKeyValueSize
 			bad = append(bad, entry)
 			continue

--- a/kv.go
+++ b/kv.go
@@ -788,6 +788,7 @@ func (s *KV) sendToWriteCh(entries []*Entry) []*request {
 		b.Err = nil
 		b.Ptrs = nil
 		reqs = append(reqs, b)
+		y.NumBlockedLargePuts.Add(int64(len(bad)))
 	}
 
 	return reqs

--- a/kv_test.go
+++ b/kv_test.go
@@ -805,14 +805,15 @@ func TestBigKeyValuePairs(t *testing.T) {
 	kv, err := NewKV(getTestOptions(dir))
 	require.NoError(t, err)
 
-	big := make([]byte, maxKeyValueSize+1)
+	bigK := make([]byte, maxKeySize+1)
+	bigV := make([]byte, maxValueSize+1)
 	small := make([]byte, 10)
 
-	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(big, small, 0))
-	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(small, big, 0))
+	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(bigK, small, 0))
+	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(small, bigV, 0))
 
 	e1 := Entry{Key: small, Value: small}
-	e2 := Entry{Key: big, Value: big}
+	e2 := Entry{Key: bigK, Value: bigV}
 	err = kv.BatchSet([]*Entry{&e1, &e2})
 	require.Equal(t, ErrExceedsMaxKeyValueSize, err)
 	require.Nil(t, e1.Error)

--- a/kv_test.go
+++ b/kv_test.go
@@ -815,7 +815,7 @@ func TestBigKeyValuePairs(t *testing.T) {
 	e1 := Entry{Key: small, Value: small}
 	e2 := Entry{Key: bigK, Value: bigV}
 	err = kv.BatchSet([]*Entry{&e1, &e2})
-	require.Equal(t, ErrExceedsMaxKeyValueSize, err)
+	require.Nil(t, err)
 	require.Nil(t, e1.Error)
 	require.Equal(t, ErrExceedsMaxKeyValueSize, e2.Error)
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -805,7 +805,7 @@ func TestBigKeyValuePairs(t *testing.T) {
 	kv, err := NewKV(getTestOptions(dir))
 	require.NoError(t, err)
 
-	big := make([]byte, (1<<30)+1)
+	big := make([]byte, maxKeyValueSize+1)
 	small := make([]byte, 10)
 
 	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(big, small, 0))

--- a/kv_test.go
+++ b/kv_test.go
@@ -796,3 +796,33 @@ func TestPidFile(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Another process is using this Badger database")
 }
+
+func TestBigKeyValuePairs(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	kv, err := NewKV(getTestOptions(dir))
+	require.NoError(t, err)
+
+	big := make([]byte, (1<<30)+1)
+	small := make([]byte, 10)
+
+	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(big, small, 0))
+	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(small, big, 0))
+
+	e1 := Entry{Key: small, Value: small}
+	e2 := Entry{Key: big, Value: big}
+	err = kv.BatchSet([]*Entry{&e1, &e2})
+	require.Equal(t, ErrExceedsMaxKeyValueSize, err)
+	require.Nil(t, e1.Error)
+	require.Equal(t, ErrExceedsMaxKeyValueSize, e2.Error)
+
+	// make sure e1 was actually set:
+	var item KVItem
+	require.NoError(t, kv.Get(small, &item))
+	require.Equal(t, item.Key(), small)
+	require.Equal(t, item.Value(), small)
+
+	require.NoError(t, kv.Close())
+}

--- a/value.go
+++ b/value.go
@@ -52,7 +52,10 @@ var Corrupt error = errors.New("Unable to find log. Potential data corruption.")
 var CasMismatch error = errors.New("CompareAndSet failed due to counter mismatch.")
 var KeyExists error = errors.New("SetIfAbsent failed since key already exists.")
 
-const maxKeyValueSize = 1 << 30
+const (
+	maxKeySize   = 1 << 20
+	maxValueSize = 1 << 30
+)
 
 type logFile struct {
 	sync.RWMutex
@@ -145,7 +148,7 @@ func (f *logFile) iterate(offset uint32, fn logEntry) error {
 		var e Entry
 		e.offset = recordOffset
 		h.Decode(hbuf[:])
-		if h.klen > maxKeyValueSize || h.vlen > maxKeyValueSize {
+		if h.klen > maxKeySize || h.vlen > maxValueSize {
 			truncate = true
 			break
 		}

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -23,16 +23,16 @@ var (
 	VlogSize *expvar.Map
 
 	// These are cumulative
-	NumReads            *expvar.Int
-	NumWrites           *expvar.Int
-	NumBytesRead        *expvar.Int
-	NumBytesWritten     *expvar.Int
-	NumLSMGets          *expvar.Map
-	NumLSMBloomHits     *expvar.Map
-	NumGets             *expvar.Int
-	NumPuts             *expvar.Int
-	NumBlockedLargePuts *expvar.Int
-	NumMemtableGets     *expvar.Int
+	NumReads        *expvar.Int
+	NumWrites       *expvar.Int
+	NumBytesRead    *expvar.Int
+	NumBytesWritten *expvar.Int
+	NumLSMGets      *expvar.Map
+	NumLSMBloomHits *expvar.Map
+	NumGets         *expvar.Int
+	NumPuts         *expvar.Int
+	NumBlockedPuts  *expvar.Int
+	NumMemtableGets *expvar.Int
 )
 
 // these variables are global and would have cummulative values for all kv stores.
@@ -45,7 +45,7 @@ func init() {
 	NumLSMBloomHits = expvar.NewMap("badger_lsm_bloom_hits_total")
 	NumGets = expvar.NewInt("badger_gets_total")
 	NumPuts = expvar.NewInt("badger_puts_total")
-	NumBlockedLargePuts = expvar.NewInt("badger_blocked_large_puts")
+	NumBlockedPuts = expvar.NewInt("badger_blocked_puts_total")
 	NumMemtableGets = expvar.NewInt("badger_memtable_gets_total")
 	LSMSize = expvar.NewMap("badger_lsm_size")
 	VlogSize = expvar.NewMap("badger_vlog_size")

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -23,15 +23,16 @@ var (
 	VlogSize *expvar.Map
 
 	// These are cumulative
-	NumReads        *expvar.Int
-	NumWrites       *expvar.Int
-	NumBytesRead    *expvar.Int
-	NumBytesWritten *expvar.Int
-	NumLSMGets      *expvar.Map
-	NumLSMBloomHits *expvar.Map
-	NumGets         *expvar.Int
-	NumPuts         *expvar.Int
-	NumMemtableGets *expvar.Int
+	NumReads            *expvar.Int
+	NumWrites           *expvar.Int
+	NumBytesRead        *expvar.Int
+	NumBytesWritten     *expvar.Int
+	NumLSMGets          *expvar.Map
+	NumLSMBloomHits     *expvar.Map
+	NumGets             *expvar.Int
+	NumPuts             *expvar.Int
+	NumBlockedLargePuts *expvar.Int
+	NumMemtableGets     *expvar.Int
 )
 
 // these variables are global and would have cummulative values for all kv stores.
@@ -44,6 +45,7 @@ func init() {
 	NumLSMBloomHits = expvar.NewMap("badger_lsm_bloom_hits_total")
 	NumGets = expvar.NewInt("badger_gets_total")
 	NumPuts = expvar.NewInt("badger_puts_total")
+	NumBlockedLargePuts = expvar.NewInt("badger_blocked_large_puts")
 	NumMemtableGets = expvar.NewInt("badger_memtable_gets_total")
 	LSMSize = expvar.NewMap("badger_lsm_size")
 	VlogSize = expvar.NewMap("badger_vlog_size")


### PR DESCRIPTION
* Key/values can now only be 1G.
* Checked when the user sets kv pairs.
* Checked during value log replay, truncating if the keys are too big (since it must be from a garbage file append crash scenario).

Wasn't too sure the best way to integrate checking into the BatchSet operation. I also considered looping over the `entries` at the start of `BatchSet`, but then you have to either make multiple calls to `sendToWriteCh` (for each contiguous chunk of good entries), or rebuild a slice of validated entries and pass to `sendToWriteCh`. Neither of those options seem too nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/158)
<!-- Reviewable:end -->
