### PR TITLE
Replace mistaken test of memtable size for last-flush completion.

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -361,7 +361,7 @@ func (s *KV) Close() (err error) {
 	// and remove them completely, while the block / memtable writer is still
 	// trying to push stuff into the memtable. This will also resolve the value
 	// offset problem: as we push into memtable, we update value offsets there.
-	if s.mt.Size() > 0 {
+	if !s.mt.Empty() {
 		s.elog.Printf("Flushing memtable")
 		for {
 			pushedFlushTask := func() bool {

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -345,6 +345,12 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 	}
 }
 
+// Empty returns if the Skiplist is empty.
+func (s *Skiplist) Empty() bool {
+	// TODO: We should make a more efficient implementation.
+	return s.findLast() == nil
+}
+
 // findLast returns the last element. If head (empty list), we return nil. All the find functions
 // will NEVER return the head nodes.
 func (s *Skiplist) findLast() *node {

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -347,7 +347,6 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 
 // Empty returns if the Skiplist is empty.
 func (s *Skiplist) Empty() bool {
-	// TODO: We should make a more efficient implementation.
 	return s.findLast() == nil
 }
 


### PR DESCRIPTION
Replaces a `.Size() > 0` test with a real test to see if the skiplist has keys.

I'm going to make a separate change that renames the `Size` method -- it's too easy for somebody else to make the same kind of mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/160)
<!-- Reviewable:end -->
