### PR TITLE
Prefetch atleast two items.

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -185,6 +185,12 @@ func (it *Iterator) fill(item *KVItem) {
 }
 
 func (it *Iterator) prefetch() {
+	prefetchSize := it.opt.PrefetchSize
+	if it.opt.PrefetchSize <= 1 {
+		// Try prefetching atleast the first two items to put into it.item and it.data.
+		prefetchSize = 2
+	}
+
 	i := it.iitr
 	var count int
 	it.item = nil
@@ -204,7 +210,7 @@ func (it *Iterator) prefetch() {
 		} else {
 			it.data.push(item)
 		}
-		if count == it.opt.PrefetchSize {
+		if count == prefetchSize {
 			break
 		}
 	}

--- a/kv.go
+++ b/kv.go
@@ -420,14 +420,14 @@ const (
 func syncDir(dir string) error {
 	f, err := OpenDir(dir)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "While opening directory: %s.", dir)
 	}
 	err = f.Sync()
 	closeErr := f.Close()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "While syncing directory: %s.", dir)
 	}
-	return closeErr
+	return errors.Wrapf(closeErr, "While closing directory: %s.", dir)
 }
 
 // getMemtables returns the current memtables and get references.

--- a/levels.go
+++ b/levels.go
@@ -144,7 +144,7 @@ func newLevelsController(kv *KV, mf *Manifest) (*levelsController, error) {
 	// manifest file).
 	if err := syncDir(kv.opt.Dir); err != nil {
 		_ = s.close()
-		return nil, errors.Wrap(err, "Directory entry for compaction log")
+		return nil, err
 	}
 
 	return s, nil


### PR DESCRIPTION
This fixes #168.

While doing a `Next` we assume that the item has already been prepared for us in `it.data` and we just need to pop and put it in `it.item`. This becomes a problem when PrefetchSize is 1.

Also, we were prefetching all matching keys when PrefetchSize <= 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/169)
<!-- Reviewable:end -->
