### PR TITLE
Add FillItem method.

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -175,6 +175,7 @@ func (it *Iterator) fill(item *KVItem) {
 	item.casCounter = vs.CASCounter
 	item.key = y.Safecopy(item.key, it.iitr.Key())
 	item.vptr = y.Safecopy(item.vptr, vs.Value)
+	item.val = nil
 	if it.opt.FetchValues {
 		item.wg.Add(1)
 		go func() {


### PR DESCRIPTION
Fixes #166.

We now expose a public FillItem method of KVItem struct which allows for filling values selectively during key-only iteration.

A few caveats here:

1. This requires a valid item returned during a Badger iteration. If the item is not valid, the behavior is undefined.

2. I chose acquire a lock before calling the private `fillitem` method. This may not be strictly necessary. But I wanted to avoid a misbehaving caller which may call this method even from a key-value iteration. Calling this method from an ongoing key-value iteration can interact with the prefetching.

Please let me know your thoughts, @manishrjain @srh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/175)
<!-- Reviewable:end -->
