### PR TITLE
Fix: use write lock in valueLog.rewrite()

### DIFF
--- a/value.go
+++ b/value.go
@@ -312,7 +312,7 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 	elog.Printf("Removing fid: %d", f.fid)
 	// Entries written to LSM. Remove the older file now.
 	{
-		vlog.RLock()
+		vlog.Lock()
 		idx := sort.Search(len(vlog.files), func(idx int) bool {
 			return vlog.files[idx].fid >= f.fid
 		})
@@ -320,7 +320,7 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 			return errors.Errorf("Unable to find fid: %d", f.fid)
 		}
 		vlog.files = append(vlog.files[:idx], vlog.files[idx+1:]...)
-		vlog.RUnlock()
+		vlog.Unlock()
 	}
 
 	rem := vlog.fpath(f.fid)


### PR DESCRIPTION
Hi guys! I think it is a bug, valueLog.rewrite() modifies files array so it must use write lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/177)
<!-- Reviewable:end -->
