### PR TITLE
Fix some golint warnings.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,10 +1,10 @@
 /*
- Package badger implements an embeddable, simple and fast key-value store, written in pure Go.
- It is designed to be highly performant for both reads and writes simultaneously.
- Badger uses LSM tree, along with a value log, to separate keys from values, hence reducing
- both write amplification and the size of the LSM tree.
- This allows LSM tree to be served entirely from RAM, while the values are served from SSD.
- As values get larger, this results in increasingly faster Set() and Get() performance than top
- of the line KV stores in market today.
+Package badger implements an embeddable, simple and fast key-value store, written in pure Go.
+It is designed to be highly performant for both reads and writes simultaneously.
+Badger uses LSM tree, along with a value log, to separate keys from values, hence reducing
+both write amplification and the size of the LSM tree.
+This allows LSM tree to be served entirely from RAM, while the values are served from SSD.
+As values get larger, this results in increasingly faster Set() and Get() performance than top
+of the line KV stores in market today.
 */
 package badger

--- a/kv.go
+++ b/kv.go
@@ -138,9 +138,9 @@ type KV struct {
 	metricsTicker      *time.Ticker
 }
 
-var ErrInvalidDir error = errors.New("Invalid Dir, directory does not exist")
-var ErrValueLogSize error = errors.New("Invalid ValueLogFileSize, must be between 1MB and 1GB")
-var ErrExceedsMaxKeyValueSize error = errors.New("Key (value) size exceeded 1MB (1GB) limit")
+var ErrInvalidDir = errors.New("Invalid Dir, directory does not exist")
+var ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 1GB")
+var ErrExceedsMaxKeyValueSize = errors.New("Key (value) size exceeded 1MB (1GB) limit")
 
 const (
 	kvWriteChCapacity = 1000

--- a/value.go
+++ b/value.go
@@ -48,9 +48,9 @@ const (
 	M               int64 = 1 << 20
 )
 
-var Corrupt error = errors.New("Unable to find log. Potential data corruption.")
-var CasMismatch error = errors.New("CompareAndSet failed due to counter mismatch.")
-var KeyExists error = errors.New("SetIfAbsent failed since key already exists.")
+var Corrupt = errors.New("Unable to find log. Potential data corruption")
+var CasMismatch = errors.New("CompareAndSet failed due to counter mismatch")
+var KeyExists = errors.New("SetIfAbsent failed since key already exists")
 
 const (
 	maxKeySize   = 1 << 20
@@ -117,13 +117,13 @@ type logEntry func(e Entry, vp valuePointer) error
 
 // iterate iterates over log file. It doesn't not allocate new memory for every kv pair.
 // Therefore, the kv pair is only valid for the duration of fn call.
-func (f *logFile) iterate(offset uint32, fn logEntry) error {
-	_, err := f.fd.Seek(int64(offset), io.SeekStart)
+func (lf *logFile) iterate(offset uint32, fn logEntry) error {
+	_, err := lf.fd.Seek(int64(offset), io.SeekStart)
 	if err != nil {
 		return y.Wrap(err)
 	}
 
-	reader := bufio.NewReader(f.fd)
+	reader := bufio.NewReader(lf.fd)
 	var hbuf [headerBufSize]byte
 	var h header
 	k := make([]byte, 1<<10)
@@ -203,7 +203,7 @@ func (f *logFile) iterate(offset uint32, fn logEntry) error {
 		recordOffset += vp.Len
 
 		vp.Offset = e.offset
-		vp.Fid = f.fid
+		vp.Fid = lf.fid
 
 		if err := fn(e, vp); err != nil {
 			if err == errStop {
@@ -214,7 +214,7 @@ func (f *logFile) iterate(offset uint32, fn logEntry) error {
 	}
 
 	if truncate {
-		if err := f.fd.Truncate(int64(recordOffset)); err != nil {
+		if err := lf.fd.Truncate(int64(recordOffset)); err != nil {
 			return err
 		}
 	}
@@ -463,12 +463,12 @@ type valueLog struct {
 	opt     Options
 }
 
-func (l *valueLog) fpath(fid uint16) string {
-	return fmt.Sprintf("%s%s%06d.vlog", l.dirPath, string(os.PathSeparator), fid)
+func (vlog *valueLog) fpath(fid uint16) string {
+	return fmt.Sprintf("%s%s%06d.vlog", vlog.dirPath, string(os.PathSeparator), fid)
 }
 
-func (l *valueLog) openOrCreateFiles() error {
-	files, err := ioutil.ReadDir(l.dirPath)
+func (vlog *valueLog) openOrCreateFiles() error {
+	files, err := ioutil.ReadDir(vlog.dirPath)
 	if err != nil {
 		return errors.Wrapf(err, "Error while opening value log")
 	}
@@ -488,25 +488,25 @@ func (l *valueLog) openOrCreateFiles() error {
 		}
 		found[fid] = struct{}{}
 
-		lf := &logFile{fid: uint16(fid), path: l.fpath(uint16(fid))}
-		l.files = append(l.files, lf)
+		lf := &logFile{fid: uint16(fid), path: vlog.fpath(uint16(fid))}
+		vlog.files = append(vlog.files, lf)
 
 	}
 
-	sort.Slice(l.files, func(i, j int) bool {
-		return l.files[i].fid < l.files[j].fid
+	sort.Slice(vlog.files, func(i, j int) bool {
+		return vlog.files[i].fid < vlog.files[j].fid
 	})
 
 	// Open all previous log files as read only. Open the last log file
 	// as read write.
-	for i := range l.files {
-		lf := l.files[i]
-		if i == len(l.files)-1 {
-			lf.fd, err = y.OpenExistingSyncedFile(l.fpath(lf.fid), l.opt.SyncWrites)
+	for i := range vlog.files {
+		lf := vlog.files[i]
+		if i == len(vlog.files)-1 {
+			lf.fd, err = y.OpenExistingSyncedFile(vlog.fpath(lf.fid), vlog.opt.SyncWrites)
 			if err != nil {
 				return errors.Wrapf(err, "Unable to open value log file as RDWR")
 			}
-			l.maxFid = uint32(lf.fid)
+			vlog.maxFid = uint32(lf.fid)
 
 		} else {
 			if err := lf.openReadOnly(); err != nil {
@@ -516,8 +516,8 @@ func (l *valueLog) openOrCreateFiles() error {
 	}
 
 	// If no files are found, then create a new file.
-	if len(l.files) == 0 {
-		_, err := l.createVlogFile(0)
+	if len(vlog.files) == 0 {
+		_, err := vlog.createVlogFile(0)
 		if err != nil {
 			return err
 		}
@@ -525,42 +525,42 @@ func (l *valueLog) openOrCreateFiles() error {
 	return nil
 }
 
-func (l *valueLog) createVlogFile(fid uint16) (*logFile, error) {
-	path := l.fpath(fid)
+func (vlog *valueLog) createVlogFile(fid uint16) (*logFile, error) {
+	path := vlog.fpath(fid)
 	lf := &logFile{fid: fid, offset: 0, path: path}
 	var err error
-	lf.fd, err = y.CreateSyncedFile(path, l.opt.SyncWrites)
+	lf.fd, err = y.CreateSyncedFile(path, vlog.opt.SyncWrites)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to create value log file")
 	}
-	err = syncDir(l.dirPath)
+	err = syncDir(vlog.dirPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to sync value log file dir")
 	}
-	l.Lock()
-	l.files = append(l.files, lf)
-	l.Unlock()
+	vlog.Lock()
+	vlog.files = append(vlog.files, lf)
+	vlog.Unlock()
 	return lf, nil
 }
 
-func (l *valueLog) Open(kv *KV, opt *Options) error {
-	l.dirPath = opt.ValueDir
-	l.opt = *opt
-	l.kv = kv
-	if err := l.openOrCreateFiles(); err != nil {
+func (vlog *valueLog) Open(kv *KV, opt *Options) error {
+	vlog.dirPath = opt.ValueDir
+	vlog.opt = *opt
+	vlog.kv = kv
+	if err := vlog.openOrCreateFiles(); err != nil {
 		return errors.Wrapf(err, "Unable to open value log")
 	}
 
-	l.elog = trace.NewEventLog("Badger", "Valuelog")
+	vlog.elog = trace.NewEventLog("Badger", "Valuelog")
 
 	return nil
 }
 
-func (l *valueLog) Close() error {
-	l.elog.Printf("Stopping garbage collection of values.")
-	defer l.elog.Finish()
+func (vlog *valueLog) Close() error {
+	vlog.elog.Printf("Stopping garbage collection of values.")
+	defer vlog.elog.Finish()
 
-	for _, f := range l.files {
+	for _, f := range vlog.files {
 		if err := f.fd.Close(); err != nil {
 			return err
 		}
@@ -569,12 +569,12 @@ func (l *valueLog) Close() error {
 }
 
 // Replay replays the value log. The kv provided is only valid for the lifetime of function call.
-func (l *valueLog) Replay(ptr valuePointer, fn logEntry) error {
+func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 	fid := ptr.Fid
 	offset := ptr.Offset + ptr.Len
-	l.elog.Printf("Seeking at value pointer: %+v\n", ptr)
+	vlog.elog.Printf("Seeking at value pointer: %+v\n", ptr)
 
-	for _, f := range l.files {
+	for _, f := range vlog.files {
 		if f.fid < fid {
 			continue
 		}
@@ -590,7 +590,7 @@ func (l *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 
 	// Seek to the end to start writing.
 	var err error
-	last := l.files[len(l.files)-1]
+	last := vlog.files[len(vlog.files)-1]
 	lastOffset, err := last.fd.Seek(0, io.SeekEnd)
 	last.offset = uint32(lastOffset)
 	return errors.Wrapf(err, "Unable to seek to end of value log: %q", last.path)
@@ -606,21 +606,21 @@ type request struct {
 }
 
 // sync is thread-unsafe and should not be called concurrently with write.
-func (l *valueLog) sync() error {
-	if l.opt.SyncWrites {
+func (vlog *valueLog) sync() error {
+	if vlog.opt.SyncWrites {
 		return nil
 	}
 
-	l.RLock()
-	if len(l.files) == 0 {
-		l.RUnlock()
+	vlog.RLock()
+	if len(vlog.files) == 0 {
+		vlog.RUnlock()
 		return nil
 	}
-	curlf := l.files[len(l.files)-1]
-	l.RUnlock()
+	curlf := vlog.files[len(vlog.files)-1]
+	vlog.RUnlock()
 
 	dirSyncCh := make(chan error)
-	go func() { dirSyncCh <- syncDir(l.opt.ValueDir) }()
+	go func() { dirSyncCh <- syncDir(vlog.opt.ValueDir) }()
 	err := curlf.sync()
 	dirSyncErr := <-dirSyncCh
 	if err != nil {
@@ -630,35 +630,35 @@ func (l *valueLog) sync() error {
 }
 
 // write is thread-unsafe by design and should not be called concurrently.
-func (l *valueLog) write(reqs []*request) error {
-	l.RLock()
-	curlf := l.files[len(l.files)-1]
-	l.RUnlock()
+func (vlog *valueLog) write(reqs []*request) error {
+	vlog.RLock()
+	curlf := vlog.files[len(vlog.files)-1]
+	vlog.RUnlock()
 
 	toDisk := func() error {
-		if l.buf.Len() == 0 {
+		if vlog.buf.Len() == 0 {
 			return nil
 		}
-		l.elog.Printf("Flushing %d blocks of total size: %d", len(reqs), l.buf.Len())
-		n, err := curlf.fd.Write(l.buf.Bytes())
+		vlog.elog.Printf("Flushing %d blocks of total size: %d", len(reqs), vlog.buf.Len())
+		n, err := curlf.fd.Write(vlog.buf.Bytes())
 		if err != nil {
 			return errors.Wrapf(err, "Unable to write to value log file: %q", curlf.path)
 		}
 		y.NumWrites.Add(1)
 		y.NumBytesWritten.Add(int64(n))
-		l.elog.Printf("Done")
+		vlog.elog.Printf("Done")
 		curlf.offset += uint32(n)
-		l.buf.Reset()
+		vlog.buf.Reset()
 
-		if curlf.offset > uint32(l.opt.ValueLogFileSize) {
+		if curlf.offset > uint32(vlog.opt.ValueLogFileSize) {
 			var err error
 			if err = curlf.doneWriting(); err != nil {
 				return err
 			}
 
-			newid := atomic.AddUint32(&l.maxFid, 1)
+			newid := atomic.AddUint32(&vlog.maxFid, 1)
 			y.AssertTruef(newid < 1<<16, "newid will overflow uint16: %v", newid)
-			newlf, err := l.createVlogFile(uint16(newid))
+			newlf, err := vlog.createVlogFile(uint16(newid))
 			if err != nil {
 				return err
 			}
@@ -675,22 +675,22 @@ func (l *valueLog) write(reqs []*request) error {
 			e := b.Entries[j]
 			var p valuePointer
 
-			if !l.opt.SyncWrites && len(e.Value) < l.opt.ValueThreshold {
+			if !vlog.opt.SyncWrites && len(e.Value) < vlog.opt.ValueThreshold {
 				// No need to write to value log.
 				b.Ptrs = append(b.Ptrs, p)
 				continue
 			}
 
 			p.Fid = curlf.fid
-			p.Offset = curlf.offset + uint32(l.buf.Len()) // Use the offset including buffer length so far.
-			plen, err := encodeEntry(e, &l.buf)           // Now encode the entry into buffer.
+			p.Offset = curlf.offset + uint32(vlog.buf.Len()) // Use the offset including buffer length so far.
+			plen, err := encodeEntry(e, &vlog.buf)           // Now encode the entry into buffer.
 			if err != nil {
 				return err
 			}
 			p.Len = uint32(plen)
 			b.Ptrs = append(b.Ptrs, p)
 
-			if p.Offset > uint32(l.opt.ValueLogFileSize) {
+			if p.Offset > uint32(vlog.opt.ValueLogFileSize) {
 				if err := toDisk(); err != nil {
 					return err
 				}
@@ -703,22 +703,22 @@ func (l *valueLog) write(reqs []*request) error {
 	// an invalid file descriptor.
 }
 
-func (l *valueLog) getFile(fid uint16) (*logFile, error) {
-	l.RLock()
-	defer l.RUnlock()
+func (vlog *valueLog) getFile(fid uint16) (*logFile, error) {
+	vlog.RLock()
+	defer vlog.RUnlock()
 
-	idx := sort.Search(len(l.files), func(idx int) bool {
-		return l.files[idx].fid >= fid
+	idx := sort.Search(len(vlog.files), func(idx int) bool {
+		return vlog.files[idx].fid >= fid
 	})
-	if idx == len(l.files) || l.files[idx].fid != fid {
+	if idx == len(vlog.files) || vlog.files[idx].fid != fid {
 		return nil, Corrupt
 	}
-	return l.files[idx], nil
+	return vlog.files[idx], nil
 }
 
 // Read reads the value log at a given location.
-func (l *valueLog) Read(p valuePointer, s *y.Slice) (e Entry, err error) {
-	lf, err := l.getFile(p.Fid)
+func (vlog *valueLog) Read(p valuePointer, s *y.Slice) (e Entry, err error) {
+	lf, err := vlog.getFile(p.Fid)
 	if err != nil {
 		return e, err
 	}
@@ -752,35 +752,35 @@ func (l *valueLog) Read(p valuePointer, s *y.Slice) (e Entry, err error) {
 	return e, nil
 }
 
-func (l *valueLog) runGCInLoop(lc *y.LevelCloser) {
+func (vlog *valueLog) runGCInLoop(lc *y.LevelCloser) {
 	defer lc.Done()
-	if l.opt.ValueGCThreshold == 0.0 {
+	if vlog.opt.ValueGCThreshold == 0.0 {
 		return
 	}
 
-	tick := time.NewTicker(l.opt.ValueGCRunInterval)
+	tick := time.NewTicker(vlog.opt.ValueGCRunInterval)
 	for {
 		select {
 		case <-lc.HasBeenClosed():
 			return
 		case <-tick.C:
-			l.doRunGC()
+			vlog.doRunGC()
 		}
 	}
 }
 
-func (l *valueLog) pickLog() *logFile {
-	l.RLock()
-	defer l.RUnlock()
-	if len(l.files) <= 1 {
+func (vlog *valueLog) pickLog() *logFile {
+	vlog.RLock()
+	defer vlog.RUnlock()
+	if len(vlog.files) <= 1 {
 		return nil
 	}
 	// This file shouldn't be being written to.
-	lfi := rand.Intn(len(l.files))
+	lfi := rand.Intn(len(vlog.files))
 	if lfi > 0 {
 		lfi = rand.Intn(lfi) // Another level of rand to favor smaller fids.
 	}
-	return l.files[lfi]
+	return vlog.files[lfi]
 }
 
 func (vlog *valueLog) doRunGC() error {
@@ -796,7 +796,7 @@ func (vlog *valueLog) doRunGC() error {
 	}
 
 	var r reason
-	var window float64 = 100.0
+	var window = 100.0
 	count := 0
 
 	// Pick a random start point for the log.


### PR DESCRIPTION
* Removed unneeded whitespace in doc.go.

* Removed type declarations in places where it was being inferred.

* Cleaned up naming of `valueLog` and `logFile` types to be consistent.
(`vlog` for `valueLog` types, `lf` for `logFile` types)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/180)
<!-- Reviewable:end -->
