### PR TITLE
badger_info output improvement

### DIFF
--- a/cmd/badger_info/main.go
+++ b/cmd/badger_info/main.go
@@ -31,6 +31,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -107,7 +108,15 @@ func printInfo(dir, valueDir string) error {
 
 	for level, lm := range manifest.Levels {
 		fmt.Printf("[Level %d]\n", level)
-		for tableID := range lm.Tables {
+		// We create a sorted list of table ID's so that output is in consistent order.
+		tableIDs := make([]uint64, 0, len(lm.Tables))
+		for id := range lm.Tables {
+			tableIDs = append(tableIDs, id)
+		}
+		sort.Slice(tableIDs, func(i, j int) bool {
+			return tableIDs[i] < tableIDs[j]
+		})
+		for _, tableID := range tableIDs {
 			tableFile := table.TableFilename(tableID)
 			file, ok := fileinfoByName[tableFile]
 			if ok {


### PR DESCRIPTION
Improves badger_info output by sorting groups and outputting totals as described in #172.

I didn't sort by file range because that info is not in the manifest, and it would require looking inside every single file.  Then we'd have to handle errors.  Maybe we can do that in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/185)
<!-- Reviewable:end -->
