### PR TITLE
Avoid leaks of updateSize goroutines

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -222,6 +222,12 @@ func NewKV(optParam *Options) (out *KV, err error) {
 		}
 	}()
 
+	metricsTicker := time.NewTicker(5 * time.Minute)
+	defer func() {
+		if metricsTicker != nil {
+			metricsTicker.Stop()
+		}
+	}()
 	out = &KV{
 		imm:           make([]*skl.Skiplist, 0, opt.NumMemtables),
 		flushChan:     make(chan flushTask, opt.NumMemtables),
@@ -232,8 +238,9 @@ func NewKV(optParam *Options) (out *KV, err error) {
 		elog:          trace.NewEventLog("Badger", "KV"),
 		dirLockGuard:  dirLockGuard,
 		valueDirGuard: valueDirLockGuard,
-		metricsTicker: time.NewTicker(5 * time.Minute),
+		metricsTicker: metricsTicker,
 	}
+
 	go out.updateSize()
 	out.mt = skl.NewSkiplist(arenaSize(&opt))
 
@@ -331,6 +338,7 @@ func NewKV(optParam *Options) (out *KV, err error) {
 	valueDirLockGuard = nil
 	dirLockGuard = nil
 	manifestFile = nil
+	metricsTicker = nil
 	return out, nil
 }
 

--- a/kv.go
+++ b/kv.go
@@ -249,7 +249,7 @@ func NewKV(optParam *Options) (out *KV, err error) {
 	go out.flushMemtable(lc) // Need levels controller to be up.
 
 	if err = out.vlog.Open(out, &opt); err != nil {
-		return out, err
+		return nil, err
 	}
 
 	var item KVItem

--- a/kv.go
+++ b/kv.go
@@ -423,7 +423,7 @@ func (s *KV) Close() (err error) {
 		err = errors.Wrap(syncErr, "KV.Close")
 	}
 
-	return nil
+	return err
 }
 
 const (

--- a/level_handler.go
+++ b/level_handler.go
@@ -189,12 +189,13 @@ func (s *levelHandler) numTables() int {
 func (s *levelHandler) close() error {
 	s.RLock()
 	defer s.RUnlock()
+	var err error
 	for _, t := range s.tables {
-		if err := t.Close(); err != nil {
-			return errors.Wrap(err, "levelHandler.Close")
+		if closeErr := t.Close(); closeErr != nil && err == nil {
+			err = closeErr
 		}
 	}
-	return nil
+	return errors.Wrap(err, "levelHandler.close")
 }
 
 // getTableForKey acquires a read-lock to access s.tables. It returns a list of tableHandlers.

--- a/value.go
+++ b/value.go
@@ -567,12 +567,13 @@ func (vlog *valueLog) Close() error {
 	vlog.elog.Printf("Stopping garbage collection of values.")
 	defer vlog.elog.Finish()
 
+	var err error
 	for _, f := range vlog.files {
-		if err := f.fd.Close(); err != nil {
-			return err
+		if closeErr := f.fd.Close(); closeErr != nil && err == nil {
+			err = closeErr
 		}
 	}
-	return nil
+	return err
 }
 
 // Replay replays the value log. The kv provided is only valid for the lifetime of function call.


### PR DESCRIPTION
While debugging badger deadlocks I noticed a lot of extra `updateSize` goroutines floating around.

So I tightened up the cleanup code... a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/191)
<!-- Reviewable:end -->
