### PR TITLE
Update format string for file path to use 6 chars

### DIFF
--- a/value.go
+++ b/value.go
@@ -490,7 +490,7 @@ type valueLog struct {
 }
 
 func vlogFilePath(dirPath string, fid uint32) string {
-	return fmt.Sprintf("%s%s%09d.vlog", dirPath, string(os.PathSeparator), fid)
+	return fmt.Sprintf("%s%s%06d.vlog", dirPath, string(os.PathSeparator), fid)
 }
 
 func (vlog *valueLog) fpath(fid uint32) string {


### PR DESCRIPTION
I ran into an issue with this change when I tried to run benchmarks against an older dataset. The filenames did not correspond, and Badger crashed with an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/196)
<!-- Reviewable:end -->
