### PR TITLE
Use mmap for reading values everywhere.

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -89,13 +89,9 @@ func (item *KVItem) prefetchValue() {
 			item.status = prefetched
 			return
 		}
-		buf := item.slice.Resize(len(val))
 
-		// Check if we are using the same backing array,
-		// and avoid copying if that is the case.
-		if &buf[0] != &val[0] {
-			copy(buf, val)
-		}
+		buf := item.slice.Resize(len(val))
+		copy(buf, val)
 		item.val = buf
 		item.status = prefetched
 	})

--- a/kv.go
+++ b/kv.go
@@ -417,7 +417,7 @@ func (s *KV) yieldItemValue(item *KVItem, consumer func([]byte)) error {
 
 	var vp valuePointer
 	vp.Decode(item.vptr)
-	err := s.vlog.Read(vp, item.slice, consumer)
+	err := s.vlog.Read(vp, consumer)
 	if err != nil {
 		return err
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -58,8 +58,14 @@ func TestValueBasic(t *testing.T) {
 	require.Len(t, b.Ptrs, 2)
 	fmt.Printf("Pointer written: %+v %+v\n", b.Ptrs[0], b.Ptrs[1])
 
-	buf1, err1 := log.readValueBytes(b.Ptrs[0], new(y.Slice))
-	buf2, err2 := log.readValueBytes(b.Ptrs[1], new(y.Slice))
+	var buf1, buf2 []byte
+	var err1, err2 error
+	err1 = log.readValueBytes(b.Ptrs[0], func(val []byte) {
+		buf1 = y.Safecopy(nil, val)
+	})
+	err2 = log.readValueBytes(b.Ptrs[1], func(val []byte) {
+		buf2 = y.Safecopy(nil, val)
+	})
 
 	require.NoError(t, err1)
 	require.NoError(t, err2)
@@ -386,16 +392,17 @@ func BenchmarkReadWrite(b *testing.B) {
 							b.Fatalf("Zero length of ptrs")
 						}
 						idx := rand.Intn(ln)
-						buf, err := vl.readValueBytes(ptrs[idx], new(y.Slice))
+						err := vl.readValueBytes(ptrs[idx], func(buf []byte) {
+							e := valueBytesToEntry(buf)
+							if len(e.Key) != 16 {
+								b.Fatalf("Key is invalid")
+							}
+							if len(e.Value) != vsz {
+								b.Fatalf("Value is invalid")
+							}
+						})
 						if err != nil {
 							b.Fatalf("Benchmark Read: %v", err)
-						}
-						e := valueBytesToEntry(buf)
-						if len(e.Key) != 16 {
-							b.Fatalf("Key is invalid")
-						}
-						if len(e.Value) != vsz {
-							b.Fatalf("Value is invalid")
 						}
 					}
 				}


### PR DESCRIPTION
This change adds support for mmap-ing the writable value log file,
in addition to the read-only files. We mmap the files with the size
set to 2GB, which is the theoritical maximum size the value log file
can grow to.

It is not very clear what the implications of mmap-ing beyond the
size of the file is. The mmap manpage does not indicate anything
specific. Moreover, it also says:

> “The effect of changing the size of the underlying file of a mapping
on the pages that correspond to added or removed regions of the
file is unspecified.”

The approach used here is similar to what BoltDB is doing, so there
is some confidence that it is fine.

Other changes:

* Since we are doing mmap reads exclusively, we no longer need to
  pass around a slice to copy the buffer. So some methods signatures
  also changed as a result of that.

* Add an mmapLock field to logFile struct to prevent munmap() from
  happening before the consumer has finished reading the mmap buffer.

* Add logFile.mmap() and logFile.munmap() convenience methods.

* Replaced valueLog.getFileRLocked() with valueLog.getFileMmapRLocked()

* Make logFile.readValueBytes() method take a callback for consuming
bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/209)
<!-- Reviewable:end -->
