### PR TITLE
Change consumer func signature to return error.

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -44,9 +44,10 @@ func Example() {
 		return
 	}
 	var val []byte
-	err := item.Value(func(v []byte) {
+	err := item.Value(func(v []byte) error {
 		val = make([]byte, len(v))
 		copy(val, v)
+		return nil
 	})
 	if err != nil {
 		fmt.Printf("Error while getting value for key: %q", key)
@@ -62,9 +63,10 @@ func Example() {
 			fmt.Printf("Error while getting key: %q", key)
 		}
 
-		err := item.Value(func(v []byte) {
+		err := item.Value(func(v []byte) error {
 			val = make([]byte, len(v))
 			copy(val, v)
+			return nil
 		})
 
 		if err != nil {

--- a/kv.go
+++ b/kv.go
@@ -182,9 +182,10 @@ func NewKV(optParam *Options) (out *KV, err error) {
 	}
 
 	var val []byte
-	err = item.Value(func(v []byte) {
+	err = item.Value(func(v []byte) error {
 		val = make([]byte, len(v))
 		copy(val, v)
+		return nil
 	})
 
 	if err != nil {
@@ -398,10 +399,9 @@ func (s *KV) getMemTables() ([]*skl.Skiplist, func()) {
 	}
 }
 
-func (s *KV) yieldItemValue(item *KVItem, consumer func([]byte)) error {
+func (s *KV) yieldItemValue(item *KVItem, consumer func([]byte) error) error {
 	if !item.hasValue() {
-		consumer(nil)
-		return nil
+		return consumer(nil)
 	}
 
 	if item.slice == nil {
@@ -411,8 +411,7 @@ func (s *KV) yieldItemValue(item *KVItem, consumer func([]byte)) error {
 	if (item.meta & BitValuePointer) == 0 {
 		val := item.slice.Resize(len(item.vptr))
 		copy(val, item.vptr)
-		consumer(val)
-		return nil
+		return consumer(val)
 	}
 
 	var vp valuePointer

--- a/kv_test.go
+++ b/kv_test.go
@@ -43,12 +43,13 @@ func getTestOptions(dir string) *Options {
 }
 
 func getItemValue(t *testing.T, item *KVItem) (val []byte) {
-	err := item.Value(func(v []byte) {
+	err := item.Value(func(v []byte) error {
 		if v == nil {
-			return
+			return nil
 		}
 		val = make([]byte, len(v))
 		copy(val, v)
+		return nil
 	})
 
 	if err != nil {
@@ -782,9 +783,10 @@ func BenchmarkExists(b *testing.B) {
 				b.Error(err)
 			}
 			var val []byte
-			err = item.Value(func(v []byte) {
+			err = item.Value(func(v []byte) error {
 				val = make([]byte, len(v))
 				copy(val, v)
+				return nil
 			})
 			if err != nil {
 				b.Error(err)

--- a/value_test.go
+++ b/value_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/y"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,11 +61,13 @@ func TestValueBasic(t *testing.T) {
 
 	var buf1, buf2 []byte
 	var err1, err2 error
-	err1 = log.readValueBytes(b.Ptrs[0], func(val []byte) {
+	err1 = log.readValueBytes(b.Ptrs[0], func(val []byte) error {
 		buf1 = y.Safecopy(nil, val)
+		return nil
 	})
-	err2 = log.readValueBytes(b.Ptrs[1], func(val []byte) {
+	err2 = log.readValueBytes(b.Ptrs[1], func(val []byte) error {
 		buf2 = y.Safecopy(nil, val)
+		return nil
 	})
 
 	require.NoError(t, err1)
@@ -392,14 +395,15 @@ func BenchmarkReadWrite(b *testing.B) {
 							b.Fatalf("Zero length of ptrs")
 						}
 						idx := rand.Intn(ln)
-						err := vl.readValueBytes(ptrs[idx], func(buf []byte) {
+						err := vl.readValueBytes(ptrs[idx], func(buf []byte) error {
 							e := valueBytesToEntry(buf)
 							if len(e.Key) != 16 {
-								b.Fatalf("Key is invalid")
+								return errors.New("Key is invalid")
 							}
 							if len(e.Value) != vsz {
-								b.Fatalf("Value is invalid")
+								return errors.New("Value is invalid")
 							}
+							return nil
 						})
 						if err != nil {
 							b.Fatalf("Benchmark Read: %v", err)


### PR DESCRIPTION
Change the signature of the consumer func passed into the KVItem.Value()
method to return an error. This makes error handling a bit more
smoother.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/217)
<!-- Reviewable:end -->
