### PR TITLE
Avoid copying values during pre-fetching.

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -404,23 +404,13 @@ func (s *KV) yieldItemValue(item *KVItem, consumer func([]byte) error) error {
 		return consumer(nil)
 	}
 
-	if item.slice == nil {
-		item.slice = new(y.Slice)
-	}
-
 	if (item.meta & BitValuePointer) == 0 {
-		val := item.slice.Resize(len(item.vptr))
-		copy(val, item.vptr)
-		return consumer(val)
+		return consumer(item.vptr)
 	}
 
 	var vp valuePointer
 	vp.Decode(item.vptr)
-	err := s.vlog.Read(vp, consumer)
-	if err != nil {
-		return err
-	}
-	return nil
+	return s.vlog.Read(vp, consumer)
 }
 
 // get returns the value in memtable or disk for given key.


### PR DESCRIPTION
Instead of copying the values, we just discard the mmap-ed slice
returned. This should make sure the data has been loaded from disk to
RAM, and is ready when we actually need the value later in the
iteration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/219)
<!-- Reviewable:end -->
