### PR TITLE
Explicit check and/or handle errors whereever possible.

### DIFF
--- a/dir_unix.go
+++ b/dir_unix.go
@@ -52,7 +52,7 @@ func AcquireDirectoryLock(dirPath string, pidFileName string) (*DirectoryLockGua
 	}
 	err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		return nil, errors.Wrapf(err,
 			"Cannot acquire directory lock on %q.  Another process is using this Badger database.",
 			dirPath)
@@ -62,7 +62,7 @@ func AcquireDirectoryLock(dirPath string, pidFileName string) (*DirectoryLockGua
 	// directory.
 	err = ioutil.WriteFile(absPidFilePath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0666)
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		return nil, errors.Wrapf(err,
 			"Cannot write pid file %q", absPidFilePath)
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -207,7 +207,7 @@ func (it *Iterator) ValidForPrefix(prefix []byte) bool {
 
 // Close would close the iterator. It is important to call this when you're done with iteration.
 func (it *Iterator) Close() {
-	it.iitr.Close()
+	_ = it.iitr.Close()
 }
 
 // Next would advance the iterator by one. Always check it.Valid() after a Next()

--- a/levels.go
+++ b/levels.go
@@ -347,7 +347,7 @@ func (s *levelsController) compactBuildTables(
 		// -- we're the only holders of a ref).
 		for j := 0; j < i; j++ {
 			if newTables[j] != nil {
-				newTables[j].DecrRef()
+				_ = newTables[j].DecrRef()
 			}
 		}
 		errorReturn := errors.Wrapf(firstErr, "While running compaction for: %+v", cd)

--- a/manifest.go
+++ b/manifest.go
@@ -231,7 +231,7 @@ func helpRewrite(dir string, m *Manifest) (*os.File, int, error) {
 
 	changeBuf, err := set.Marshal()
 	if err != nil {
-		fp.Close()
+		_ = fp.Close()
 		return nil, 0, err
 	}
 	var lenCrcBuf [8]byte
@@ -240,11 +240,11 @@ func helpRewrite(dir string, m *Manifest) (*os.File, int, error) {
 	buf = append(buf, lenCrcBuf[:]...)
 	buf = append(buf, changeBuf...)
 	if _, err := fp.Write(buf); err != nil {
-		fp.Close()
+		_ = fp.Close()
 		return nil, 0, err
 	}
 	if err := fp.Sync(); err != nil {
-		fp.Close()
+		_ = fp.Close()
 		return nil, 0, err
 	}
 
@@ -261,11 +261,11 @@ func helpRewrite(dir string, m *Manifest) (*os.File, int, error) {
 		return nil, 0, err
 	}
 	if _, err := fp.Seek(0, os.SEEK_END); err != nil {
-		fp.Close()
+		_ = fp.Close()
 		return nil, 0, err
 	}
 	if err := syncDir(dir); err != nil {
-		fp.Close()
+		_ = fp.Close()
 		return nil, 0, err
 	}
 

--- a/util.go
+++ b/util.go
@@ -51,7 +51,10 @@ func (s *levelHandler) getSummary(sum *summary) {
 	}
 }
 
-func (s *KV) validate() { s.lc.validate() }
+func (s *KV) validate() {
+	// FIXME we do not check for error here.
+	s.lc.validate()
+}
 
 func (s *levelsController) validate() error {
 	for _, l := range s.levels {

--- a/value.go
+++ b/value.go
@@ -381,8 +381,8 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 	// Exclusively lock the file so that there are no readers before closing/destroying it
 	f.lock.Lock()
 	rem := vlog.fpath(f.fid)
-	y.Munmap(f.fmap)
-	f.fd.Close() // close file previous to remove it
+	_ = y.Munmap(f.fmap)
+	_ = f.fd.Close() // close file previous to remove it
 	f.lock.Unlock()
 
 	elog.Printf("Removing %s", rem)
@@ -421,13 +421,13 @@ func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 	hash := crc32.New(y.CastagnoliCrcTable)
 
 	buf.Write(headerEnc[:])
-	hash.Write(headerEnc[:])
+	_, _ = hash.Write(headerEnc[:])
 
 	buf.Write(e.Key)
-	hash.Write(e.Key)
+	_, _ = hash.Write(e.Key)
 
 	buf.Write(e.Value)
-	hash.Write(e.Value)
+	_, _ = hash.Write(e.Value)
 
 	var crcBuf [4]byte
 	binary.BigEndian.PutUint32(crcBuf[:], hash.Sum32())
@@ -884,6 +884,7 @@ func (vlog *valueLog) runGCInLoop(lc *y.Closer) {
 		case <-lc.HasBeenClosed():
 			return
 		case <-tick.C:
+			// FIXME we do not check for here.
 			vlog.doRunGC()
 		}
 	}


### PR DESCRIPTION
As a convention, we should try and explicitly check for errors. If we
don’t wish to handle an error, we can just ignore it using the ‘_’
character (we should be prudent with ignoring the error, and only do it
where it is safe).

This change fixes a bunch of code flagged by the errcheck utility. We
ignore some cases, for e.g. when a function is called using the defer
keyword.

Fixes #218.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/220)
<!-- Reviewable:end -->
