### PR TITLE
Allow user to call Value Log GC.

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -1190,15 +1190,15 @@ func (s *KV) updateSize(lc *y.Closer) {
 // space can be discarded.  This results in a lifetime value log write amplification of 2 (1 from
 // original write + 0.5 rewrite + 0.25 + 0.125 + ... = 2). Setting it to higher value would result
 // in fewer space reclaims, while setting it to a lower value would result in more space reclaims at
-// the cost of increased activity on the LSM tree. discardRatio must be lower than 1.0, otherwise an
-// ErrInvalidRequest is returned.
+// the cost of increased activity on the LSM tree. discardRatio must be in the range (0.0, 1.0),
+// both endpoints excluded, otherwise an ErrInvalidRequest is returned.
 //
 // Only one GC is allowed at a time. If another value log GC is running, or KV has been closed, this
 // would return an ErrRejected.
 //
 // Note: Every time GC is run, it would produce a spike of activity on the LSM tree.
 func (s *KV) RunValueLogGC(discardRatio float64) error {
-	if discardRatio > 0.99 || discardRatio < 0.0 {
+	if discardRatio >= 1.0 || discardRatio <= 0.0 {
 		return ErrInvalidRequest
 	}
 	return s.vlog.runGC(discardRatio)

--- a/kv_test.go
+++ b/kv_test.go
@@ -38,7 +38,6 @@ func getTestOptions(dir string) *Options {
 	opt.Dir = dir
 	opt.ValueDir = dir
 	opt.SyncWrites = true // Some tests seem to need this to pass.
-	opt.ValueGCThreshold = 0.8
 	return opt
 }
 

--- a/options.go
+++ b/options.go
@@ -17,8 +17,6 @@
 package badger
 
 import (
-	"time"
-
 	"github.com/dgraph-io/badger/options"
 	"github.com/dgraph-io/badger/y"
 )
@@ -45,11 +43,6 @@ type Options struct {
 	// How should LSM tree be accessed.
 	TableLoadingMode options.FileLoadingMode
 
-	// How often to run value log garbage collector. Every time it runs,
-	// there'd be a spike in LSM tree activity. But, running it frequently
-	// allows reclaiming disk space from an ever-growing value log.
-	ValueGCRunInterval time.Duration
-
 	// 3. Flags that user might want to review
 	// ----------------------------------------
 	// The following affect all levels of LSM tree.
@@ -70,10 +63,6 @@ type Options struct {
 
 	// Maximum total size for L1.
 	LevelOneSize int64
-
-	// Run value log garbage collection if we can reclaim at least this
-	// much space. This is a ratio.
-	ValueGCThreshold float64
 
 	// Size of single value log file.
 	ValueLogFileSize int64
@@ -106,10 +95,8 @@ var DefaultOptions = Options{
 	SyncWrites:              false,
 	// Nothing to read/write value log using standard File I/O
 	// MemoryMap to mmap() the value log files
-	ValueGCRunInterval: 10 * time.Minute,
-	ValueGCThreshold:   0.5, // Set to zero to not run GC.
-	ValueLogFileSize:   1 << 30,
-	ValueThreshold:     20,
+	ValueLogFileSize: 1 << 30,
+	ValueThreshold:   20,
 }
 
 func (opt *Options) estimateSize(entry *Entry) int {


### PR DESCRIPTION
- Remove the automatic time based run of value log GC.
- Remove both the value log GC options, i.e. ValueLogThreshold and ValueLogDuration.
- Add a long comment for godoc to explain to the user how to call and what to expect from value log GC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/225)
<!-- Reviewable:end -->
