### PR TITLE
Use unsynchronized random number generator.

### DIFF
--- a/skl/README.md
+++ b/skl/README.md
@@ -1,33 +1,33 @@
 This is much better than `skiplist` and `slist`.
 
 ```
-BenchmarkReadWrite/frac_0-4         	 1000000	      1516 ns/op
-BenchmarkReadWrite/frac_1-4         	 1000000	      1456 ns/op
-BenchmarkReadWrite/frac_2-4         	 1000000	      1354 ns/op
-BenchmarkReadWrite/frac_3-4         	 1000000	      1295 ns/op
-BenchmarkReadWrite/frac_4-4         	 1000000	      1142 ns/op
-BenchmarkReadWrite/frac_5-4         	 1000000	      1077 ns/op
-BenchmarkReadWrite/frac_6-4         	 1000000	      1003 ns/op
-BenchmarkReadWrite/frac_7-4         	 2000000	      1054 ns/op
-BenchmarkReadWrite/frac_8-4         	 2000000	       929 ns/op
-BenchmarkReadWrite/frac_9-4         	 3000000	       815 ns/op
-BenchmarkReadWrite/frac_10-4        	 5000000	       472 ns/op
+BenchmarkReadWrite/frac_0-8         	 2000000	      1056 ns/op
+BenchmarkReadWrite/frac_1-8         	 2000000	       945 ns/op
+BenchmarkReadWrite/frac_2-8         	 2000000	       854 ns/op
+BenchmarkReadWrite/frac_3-8         	 2000000	       777 ns/op
+BenchmarkReadWrite/frac_4-8         	 2000000	       721 ns/op
+BenchmarkReadWrite/frac_5-8         	 3000000	       660 ns/op
+BenchmarkReadWrite/frac_6-8         	 5000000	       553 ns/op
+BenchmarkReadWrite/frac_7-8         	 5000000	       518 ns/op
+BenchmarkReadWrite/frac_8-8         	 5000000	       435 ns/op
+BenchmarkReadWrite/frac_9-8         	10000000	       385 ns/op
+BenchmarkReadWrite/frac_10-8        	100000000	        21.5 ns/op
 ```
 
 But compared to a simple map with read-write lock, it is still slower.
 
 ```
-BenchmarkReadWriteMap/frac_0-4         	 2000000	       883 ns/op
-BenchmarkReadWriteMap/frac_1-4         	 2000000	       830 ns/op
-BenchmarkReadWriteMap/frac_2-4         	 2000000	       658 ns/op
-BenchmarkReadWriteMap/frac_3-4         	 2000000	       662 ns/op
-BenchmarkReadWriteMap/frac_4-4         	 2000000	       657 ns/op
-BenchmarkReadWriteMap/frac_5-4         	 2000000	       650 ns/op
-BenchmarkReadWriteMap/frac_6-4         	 3000000	       592 ns/op
-BenchmarkReadWriteMap/frac_7-4         	 3000000	       573 ns/op
-BenchmarkReadWriteMap/frac_8-4         	 3000000	       539 ns/op
-BenchmarkReadWriteMap/frac_9-4         	 3000000	       521 ns/op
-BenchmarkReadWriteMap/frac_10-4        	 3000000	       479 ns/op
+BenchmarkReadWriteMap/frac_0-8      	 2000000	       780 ns/op
+BenchmarkReadWriteMap/frac_1-8      	 2000000	       669 ns/op
+BenchmarkReadWriteMap/frac_2-8      	 3000000	       625 ns/op
+BenchmarkReadWriteMap/frac_3-8      	 3000000	       611 ns/op
+BenchmarkReadWriteMap/frac_4-8      	 3000000	       483 ns/op
+BenchmarkReadWriteMap/frac_5-8      	 3000000	       478 ns/op
+BenchmarkReadWriteMap/frac_6-8      	 5000000	       558 ns/op
+BenchmarkReadWriteMap/frac_7-8      	 3000000	       469 ns/op
+BenchmarkReadWriteMap/frac_8-8      	 5000000	       452 ns/op
+BenchmarkReadWriteMap/frac_9-8      	 5000000	       370 ns/op
+BenchmarkReadWriteMap/frac_10-8     	10000000	       228 ns/op
 ```
 
 # Node Pooling


### PR DESCRIPTION
The skiplist benchmark was using the global random number generator,
which is guarded by a mutex. This causes contention on multi-core
machines and skews the benchmark results in a material way. Instead,
use a separate random number generator per benchmark goroutine.
Update the README results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/229)
<!-- Reviewable:end -->
