### PR TITLE
Allocate nodes from the arena.

### DIFF
--- a/options.go
+++ b/options.go
@@ -74,7 +74,8 @@ type Options struct {
 	// ------------------------------
 	DoNotCompact bool // Stops LSM tree from compactions.
 
-	maxBatchSize int64 // max batch size in bytes
+	maxBatchCount int64 // max entries in batch
+	maxBatchSize  int64 // max batch size in bytes
 }
 
 // DefaultOptions sets a list of recommended options for good performance.

--- a/skl/README.md
+++ b/skl/README.md
@@ -1,33 +1,33 @@
 This is much better than `skiplist` and `slist`.
 
 ```
-BenchmarkReadWrite/frac_0-8         	 2000000	      1056 ns/op
-BenchmarkReadWrite/frac_1-8         	 2000000	       945 ns/op
-BenchmarkReadWrite/frac_2-8         	 2000000	       854 ns/op
-BenchmarkReadWrite/frac_3-8         	 2000000	       777 ns/op
-BenchmarkReadWrite/frac_4-8         	 2000000	       721 ns/op
-BenchmarkReadWrite/frac_5-8         	 3000000	       660 ns/op
-BenchmarkReadWrite/frac_6-8         	 5000000	       553 ns/op
-BenchmarkReadWrite/frac_7-8         	 5000000	       518 ns/op
-BenchmarkReadWrite/frac_8-8         	 5000000	       435 ns/op
-BenchmarkReadWrite/frac_9-8         	10000000	       385 ns/op
-BenchmarkReadWrite/frac_10-8        	100000000	        21.5 ns/op
+BenchmarkReadWrite/frac_0-8         	 3000000	       537 ns/op
+BenchmarkReadWrite/frac_1-8         	 3000000	       503 ns/op
+BenchmarkReadWrite/frac_2-8         	 3000000	       492 ns/op
+BenchmarkReadWrite/frac_3-8         	 3000000	       475 ns/op
+BenchmarkReadWrite/frac_4-8         	 3000000	       440 ns/op
+BenchmarkReadWrite/frac_5-8         	 5000000	       442 ns/op
+BenchmarkReadWrite/frac_6-8         	 5000000	       380 ns/op
+BenchmarkReadWrite/frac_7-8         	 5000000	       338 ns/op
+BenchmarkReadWrite/frac_8-8         	 5000000	       294 ns/op
+BenchmarkReadWrite/frac_9-8         	10000000	       268 ns/op
+BenchmarkReadWrite/frac_10-8        	100000000	        26.3 ns/op
 ```
 
-But compared to a simple map with read-write lock, it is still slower.
+And even better than a simple map with read-write lock:
 
 ```
-BenchmarkReadWriteMap/frac_0-8      	 2000000	       780 ns/op
-BenchmarkReadWriteMap/frac_1-8      	 2000000	       669 ns/op
-BenchmarkReadWriteMap/frac_2-8      	 3000000	       625 ns/op
-BenchmarkReadWriteMap/frac_3-8      	 3000000	       611 ns/op
-BenchmarkReadWriteMap/frac_4-8      	 3000000	       483 ns/op
-BenchmarkReadWriteMap/frac_5-8      	 3000000	       478 ns/op
-BenchmarkReadWriteMap/frac_6-8      	 5000000	       558 ns/op
-BenchmarkReadWriteMap/frac_7-8      	 3000000	       469 ns/op
-BenchmarkReadWriteMap/frac_8-8      	 5000000	       452 ns/op
-BenchmarkReadWriteMap/frac_9-8      	 5000000	       370 ns/op
-BenchmarkReadWriteMap/frac_10-8     	10000000	       228 ns/op
+BenchmarkReadWriteMap/frac_0-8         	 2000000	       774 ns/op
+BenchmarkReadWriteMap/frac_1-8         	 2000000	       647 ns/op
+BenchmarkReadWriteMap/frac_2-8         	 3000000	       605 ns/op
+BenchmarkReadWriteMap/frac_3-8         	 3000000	       603 ns/op
+BenchmarkReadWriteMap/frac_4-8         	 3000000	       556 ns/op
+BenchmarkReadWriteMap/frac_5-8         	 3000000	       472 ns/op
+BenchmarkReadWriteMap/frac_6-8         	 3000000	       476 ns/op
+BenchmarkReadWriteMap/frac_7-8         	 3000000	       457 ns/op
+BenchmarkReadWriteMap/frac_8-8         	 5000000	       444 ns/op
+BenchmarkReadWriteMap/frac_9-8         	 5000000	       361 ns/op
+BenchmarkReadWriteMap/frac_10-8        	10000000	       212 ns/op
 ```
 
 # Node Pooling

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -56,10 +56,12 @@ func (s *Arena) reset() {
 // putNode allocates a node in the arena. The node is aligned on a pointer-sized
 // boundary. The arena offset of the node is returned.
 func (s *Arena) putNode(height int) uint32 {
-	towerSize := offsetSize * (height - 1)
+	// Compute the amount of the tower that will never be used, since the height
+	// is less than maxHeight.
+	unusedSize := (maxHeight - height) * offsetSize
 
 	// Pad the allocation with enough bytes to ensure pointer alignment.
-	l := uint32(nodeSize + towerSize + ptrAlign)
+	l := uint32(MaxNodeSize - unusedSize + ptrAlign)
 	n := atomic.AddUint32(&s.n, l)
 	y.AssertTruef(int(n) <= len(s.buf),
 		"Arena too small, toWrite:%d newTotal:%d limit:%d",

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -18,8 +18,14 @@ package skl
 
 import (
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/dgraph-io/badger/y"
+)
+
+const (
+	offsetSize = int(unsafe.Sizeof(uint32(0)))
+	ptrAlign   = int(unsafe.Sizeof(uintptr(0))) - 1
 )
 
 // Arena should be lock-free.
@@ -30,7 +36,10 @@ type Arena struct {
 
 // newArena returns a new arena.
 func newArena(n int64) *Arena {
+	// Don't store data at position 0 in order to reserve offset=0 as a kind
+	// of nil pointer.
 	out := &Arena{
+		n:   1,
 		buf: make([]byte, n),
 	}
 	return out
@@ -42,6 +51,23 @@ func (s *Arena) size() int64 {
 
 func (s *Arena) reset() {
 	atomic.StoreUint32(&s.n, 0)
+}
+
+// putNode allocates a node in the arena. The node is aligned on a pointer-sized
+// boundary. The arena offset of the node is returned.
+func (s *Arena) putNode(height int) uint32 {
+	towerSize := offsetSize * (height - 1)
+
+	// Pad the allocation with enough bytes to ensure pointer alignment.
+	l := uint32(nodeSize + towerSize + ptrAlign)
+	n := atomic.AddUint32(&s.n, l)
+	y.AssertTruef(int(n) <= len(s.buf),
+		"Arena too small, toWrite:%d newTotal:%d limit:%d",
+		l, n, len(s.buf))
+
+	// Return the aligned offset.
+	m := (n - l + uint32(ptrAlign)) & ^uint32(ptrAlign)
+	return m
 }
 
 // Put will *copy* val into arena. To make better use of this, reuse your input
@@ -70,6 +96,16 @@ func (s *Arena) putKey(key []byte) uint32 {
 	return m
 }
 
+// getNode returns a pointer to the node located at offset. If the offset is
+// zero, then the nil node pointer is returned.
+func (s *Arena) getNode(offset uint32) *node {
+	if offset == 0 {
+		return nil
+	}
+
+	return (*node)(unsafe.Pointer(&s.buf[offset]))
+}
+
 // getKey returns byte slice at offset.
 func (s *Arena) getKey(offset uint32, size uint16) []byte {
 	return s.buf[offset : offset+uint32(size)]
@@ -80,4 +116,14 @@ func (s *Arena) getKey(offset uint32, size uint16) []byte {
 func (s *Arena) getVal(offset uint32, size uint16) (ret y.ValueStruct) {
 	ret.DecodeEntireSlice(s.buf[offset : offset+uint32(y.ValueStructSerializedSize(size))])
 	return
+}
+
+// getNodeOffset returns the offset of node in the arena. If the node pointer is
+// nil, then the zero offset is returned.
+func (s *Arena) getNodeOffset(nd *node) uint32 {
+	if nd == nil {
+		return 0
+	}
+
+	return uint32(uintptr(unsafe.Pointer(nd)) - uintptr(unsafe.Pointer(&s.buf[0])))
 }

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -46,12 +46,19 @@ import (
 const (
 	maxHeight      = 20
 	heightIncrease = math.MaxUint32 / 3
+	nodeSize       = int(unsafe.Sizeof(node{}))
 )
+
+// MaxNodeSize is the memory footprint of a node of maximum height.
+const MaxNodeSize = nodeSize + (maxHeight-1)*offsetSize
 
 type node struct {
 	// A byte slice is 24 bytes. We are trying to save space here.
 	keyOffset uint32 // Immutable. No need to lock to access key.
 	keySize   uint16 // Immutable. No need to lock to access key.
+
+	// Height of the tower.
+	height uint16
 
 	// Multiple parts of the value are encoded as a single uint64 so that it
 	// can be atomically loaded and stored:
@@ -59,9 +66,13 @@ type node struct {
 	//   value size  : uint16 (bits 32-47)
 	value uint64
 
-	// []*node. Size is <=kMaxNumLevels. Usually a very small array. CAS.
-	// No need to lock.
-	next []unsafe.Pointer
+	// When node is allocated, extra space is allocated after it in memory,
+	// and unsafe operations are used to access array elements, which are
+	// offsets to the previous and next nodes. This is usually a very small
+	// array, since the probability of each successive level decreases
+	// exponentially. The size is always <= maxHeight. All accesses to elements
+	// should use CAS operations, with no need to lock.
+	tower [1]uint32
 }
 
 // Skiplist maps keys to values (in memory)
@@ -70,23 +81,6 @@ type Skiplist struct {
 	head   *node
 	ref    int32
 	arena  *Arena
-}
-
-var (
-	nodePools []sync.Pool
-)
-
-func init() {
-	nodePools = make([]sync.Pool, maxHeight+1)
-	for i := 1; i <= maxHeight; i++ {
-		func(i int) { // Need a function here in order to capture variable i.
-			nodePools[i].New = func() interface{} {
-				return &node{
-					next: make([]unsafe.Pointer, i),
-				}
-			}
-		}(i)
-	}
 }
 
 // IncrRef increases the refcount
@@ -100,13 +94,7 @@ func (s *Skiplist) DecrRef() {
 	if newRef > 0 {
 		return
 	}
-	// Deallocate all nodes.
-	x := s.head
-	for x != nil {
-		next := x.getNext(0)
-		nodePools[len(x.next)].Put(x)
-		x = next
-	}
+
 	s.arena.reset()
 	// Indicate we are closed. Good for testing.  Also, lets GC reclaim memory. Race condition
 	// here would suggest we are accessing skiplist when we are supposed to have no reference!
@@ -116,15 +104,14 @@ func (s *Skiplist) DecrRef() {
 func (s *Skiplist) valid() bool { return s.arena != nil }
 
 func newNode(arena *Arena, key []byte, v y.ValueStruct, height int) *node {
-	keyOffset := arena.putKey(key)
-	valOffset := arena.putVal(v)
-	value := encodeValue(valOffset, uint16(len(v.Value)))
-	return &node{
-		keyOffset: keyOffset,
-		keySize:   uint16(len(key)),
-		value:     value,
-		next:      make([]unsafe.Pointer, height),
-	}
+	// The base level is already allocated in the node struct.
+	offset := arena.putNode(height)
+	node := arena.getNode(offset)
+	node.keyOffset = arena.putKey(key)
+	node.keySize = uint16(len(key))
+	node.height = uint16(height)
+	node.value = encodeValue(arena.putVal(v), uint16(len(v.Value)))
+	return node
 }
 
 func encodeValue(valOffset uint32, valSize uint16) uint64 {
@@ -164,12 +151,16 @@ func (s *node) setValue(arena *Arena, v y.ValueStruct) {
 	atomic.StoreUint64(&s.value, value)
 }
 
-func (s *node) getNext(h int) *node {
-	return (*node)(atomic.LoadPointer(&s.next[h]))
+func (s *node) getNextOffset(h int) uint32 {
+	return atomic.LoadUint32(&s.unsafeTower()[h])
 }
 
-func (s *node) casNext(h int, old, val *node) bool {
-	return atomic.CompareAndSwapPointer(&s.next[h], unsafe.Pointer(old), unsafe.Pointer(val))
+func (s *node) casNextOffset(h int, old, val uint32) bool {
+	return atomic.CompareAndSwapUint32(&s.unsafeTower()[h], old, val)
+}
+
+func (s *node) unsafeTower() *[maxHeight]uint32 {
+	return (*[maxHeight]uint32)(unsafe.Pointer(&s.tower))
 }
 
 // Returns true if key is strictly > n.key.
@@ -187,6 +178,10 @@ func randomHeight() int {
 	return h
 }
 
+func (s *Skiplist) getNext(nd *node, height int) *node {
+	return s.arena.getNode(nd.getNextOffset(height))
+}
+
 // findNear finds the node near to key.
 // If less=true, it finds rightmost node such that node.key < key (if allowEqual=false) or
 // node.key <= key (if allowEqual=true).
@@ -198,7 +193,7 @@ func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool
 	level := int(s.getHeight() - 1)
 	for {
 		// Assume x.key < key.
-		next := x.getNext(level)
+		next := s.getNext(x, level)
 		if next == nil {
 			// x.key < key < END OF LIST
 			if level > 0 {
@@ -231,7 +226,7 @@ func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool
 			}
 			if !less {
 				// We want >, so go to base level to grab the next bigger note.
-				return next.getNext(0), false
+				return s.getNext(next, 0), false
 			}
 			// We want <. If not base level, we should go closer in the next level.
 			if level > 0 {
@@ -268,7 +263,7 @@ func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool
 func (s *Skiplist) findSpliceForLevel(key []byte, before *node, level int) (*node, *node) {
 	for {
 		// Assume before.key < key.
-		next := before.getNext(level)
+		next := s.getNext(before, level)
 		if next == nil {
 			return before, next
 		}
@@ -336,8 +331,9 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 				// the base level. But we know we are not on the base level.
 				y.AssertTrue(prev[i] != next[i])
 			}
-			x.next[i] = unsafe.Pointer(next[i])
-			if prev[i].casNext(i, next[i], x) {
+			nextOffset := s.arena.getNodeOffset(next[i])
+			x.unsafeTower()[i] = nextOffset
+			if prev[i].casNextOffset(i, nextOffset, s.arena.getNodeOffset(x)) {
 				// Managed to insert x between prev[i] and next[i]. Go to the next level.
 				break
 			}
@@ -365,7 +361,7 @@ func (s *Skiplist) findLast() *node {
 	n := s.head
 	level := int(s.getHeight()) - 1
 	for {
-		next := n.getNext(level)
+		next := s.getNext(n, level)
 		if next != nil {
 			n = next
 			continue
@@ -430,7 +426,7 @@ func (s *Iterator) Value() y.ValueStruct {
 // Next advances to the next position.
 func (s *Iterator) Next() {
 	y.AssertTrue(s.Valid())
-	s.n = s.n.getNext(0)
+	s.n = s.list.getNext(s.n, 0)
 }
 
 // Prev advances to the previous position.
@@ -452,7 +448,7 @@ func (s *Iterator) SeekForPrev(target []byte) {
 // SeekToFirst seeks position at the first entry in list.
 // Final state of iterator is Valid() iff list is not empty.
 func (s *Iterator) SeekToFirst() {
-	s.n = s.list.head.getNext(0)
+	s.n = s.list.getNext(s.list.head, 0)
 }
 
 // SeekToLast seeks position at the last entry in list.

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -39,11 +39,11 @@ func newValue(v int) []byte {
 
 // length iterates over skiplist to give exact size.
 func length(s *Skiplist) int {
-	x := s.head.getNext(0)
+	x := s.getNext(s.head, 0)
 	count := 0
 	for x != nil {
 		count++
-		x = x.getNext(0)
+		x = s.getNext(x, 0)
 	}
 	return count
 }
@@ -426,7 +426,7 @@ func BenchmarkReadWrite(b *testing.B) {
 	for i := 0; i <= 10; i++ {
 		readFrac := float32(i) / 10.0
 		b.Run(fmt.Sprintf("frac_%d", i), func(b *testing.B) {
-			l := NewSkiplist(arenaSize * 64) // TODO: Fix this. Allow arena size to vary with b.N.
+			l := NewSkiplist(int64((b.N + 1) * MaxNodeSize))
 			defer l.DecrRef()
 			b.ResetTimer()
 			var count int


### PR DESCRIPTION
The skiplist allocates keys and values from the arena, but not nodes.
This change begins allocating nodes from the arena. Links between
nodes at the same level are now offsets into the arena rather than
pointers. The "tower" of links is allocated as extra bytes appended
to the end of the node rather than a separate array.

Together, these changes significantly speed up skiplist writes and
reads. It also reduces overall memory usage (by using next offsets
rather than next pointers), as well as GC pressure (nodes do not
use pointers to reference one another).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/231)
<!-- Reviewable:end -->
