### PR TITLE
Use atomic operations to access value.

### DIFF
--- a/skl/skl.go
+++ b/skl/skl.go
@@ -55,8 +55,8 @@ type node struct {
 
 	// Multiple parts of the value are encoded as a single uint64 so that it
 	// can be atomically loaded and stored:
-	//   uint32: offset
-	//   uint16: size
+	//   value offset: uint32 (bits 0-31)
+	//   value size  : uint16 (bits 32-47)
 	value uint64
 
 	// []*node. Size is <=kMaxNumLevels. Usually a very small array. CAS.


### PR DESCRIPTION
Using atomic operations saves 8 bytes per node (size of mutex).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/232)
<!-- Reviewable:end -->
