### PR TITLE
Improve error for key value size limits

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -87,8 +87,8 @@ func exceedsMaxKeySizeError(key []byte) error {
 }
 
 func exceedsMaxValueSizeError(value []byte, maxValueSize int64) error {
-	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%d). Key:\n%s",
-		len(value), maxValueSize, hex.Dump(value[:1<<10]))
+	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMB). Key:\n%s",
+		len(value), maxValueSize<<20, hex.Dump(value[:1<<10]))
 }
 
 const (

--- a/kv.go
+++ b/kv.go
@@ -80,9 +80,13 @@ var ErrInvalidDir = errors.New("Invalid Dir, directory does not exist")
 // range.
 var ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 1GB")
 
-// ErrExceedsMaxKeyValueSize is returned as part of Entry when the size of the key or value
-// exceeds the specified limits.
-var ErrExceedsMaxKeyValueSize = errors.New("Key (value) size exceeded 1MB (1GB) limit")
+// ErrExceedsMaxKeySize is returned as part of an entry when the size of the
+// key exceeds the size limit.
+var ErrExceedsMaxKeySize = errors.New("Key size exceeded 1MB limit")
+
+// ErrExceedsMaxValueSize is returned as part of an entry when the size of the
+// value exceeds the size limit.
+var ErrExceedsMaxValueSize = errors.New("Value size exceeded 1GB limit")
 
 const (
 	kvWriteChCapacity = 1000
@@ -701,8 +705,13 @@ func (s *KV) sendToWriteCh(entries []*Entry) []*request {
 	var b *request
 	var bad []*Entry
 	for _, entry := range entries {
-		if len(entry.Key) > maxKeySize || len(entry.Value) > maxValueSize {
-			entry.Error = ErrExceedsMaxKeyValueSize
+		if len(entry.Key) > maxKeySize {
+			entry.Error = ErrExceedsMaxKeySize
+			bad = append(bad, entry)
+			continue
+		}
+		if len(entry.Value) > maxValueSize {
+			entry.Error = ErrExceedsMaxValueSize
 			bad = append(bad, entry)
 			continue
 		}

--- a/kv.go
+++ b/kv.go
@@ -89,9 +89,18 @@ type ExceedsMaxKeySizeError struct {
 	KeySize   int
 }
 
-func (e ExceedsMaxKeySizeError) Error() string {
+func (e *ExceedsMaxKeySizeError) Error() string {
 	return fmt.Sprintf("Key with size %d exceeded %dMB limit. Key:\n%s",
 		e.KeySize, maxKeySize<<20, hex.Dump(e.KeyPrefix))
+}
+
+func newExceedsMaxKeySizeError(key []byte) *ExceedsMaxKeySizeError {
+	err := &ExceedsMaxKeySizeError{
+		KeyPrefix: make([]byte, 1<<10),
+		KeySize:   len(key),
+	}
+	copy(err.KeyPrefix, key)
+	return err
 }
 
 type ExceedsMaxValueSizeError struct {
@@ -102,9 +111,19 @@ type ExceedsMaxValueSizeError struct {
 
 // ExceedsMaxValueSizeError is returned as part of an entry when the size of
 // the value exceeds the size limit.
-func (e ExceedsMaxValueSizeError) Error() string {
+func (e *ExceedsMaxValueSizeError) Error() string {
 	return fmt.Sprintf("Value with size %d exceeded ValueLogFileSize (%d). Key:\n%s",
 		e.ValueSize, e.MaxValueSize, hex.Dump(e.ValuePrefix))
+}
+
+func newExceedsMaxValueSizeError(value []byte, maxValueSize int) *ExceedsMaxValueSizeError {
+	err := &ExceedsMaxValueSizeError{
+		ValuePrefix:  make([]byte, 1<<10),
+		ValueSize:    len(value),
+		MaxValueSize: maxValueSize,
+	}
+	copy(err.ValuePrefix, value)
+	return err
 }
 
 const (
@@ -725,19 +744,12 @@ func (s *KV) sendToWriteCh(entries []*Entry) []*request {
 	var bad []*Entry
 	for _, entry := range entries {
 		if len(entry.Key) > maxKeySize {
-			entry.Error = ExceedsMaxKeySizeError{
-				KeyPrefix: entry.Key[:1<<10],
-				KeySize:   len(entry.Key),
-			}
+			entry.Error = newExceedsMaxKeySizeError(entry.Key)
 			bad = append(bad, entry)
 			continue
 		}
 		if len(entry.Value) > int(s.opt.ValueLogFileSize) {
-			entry.Error = ExceedsMaxValueSizeError{
-				ValuePrefix:  entry.Value[:1<<10],
-				ValueSize:    len(entry.Value),
-				MaxValueSize: int(s.opt.ValueLogFileSize),
-			}
+			entry.Error = newExceedsMaxValueSizeError(entry.Value, int(s.opt.ValueLogFileSize))
 			bad = append(bad, entry)
 			continue
 		}

--- a/kv.go
+++ b/kv.go
@@ -90,8 +90,8 @@ type ExceedsMaxKeySizeError struct {
 }
 
 func (e ExceedsMaxKeySizeError) Error() string {
-	return fmt.Sprintf("Key with size %d exceeded 1MB limit. Key:\n%s",
-		e.KeySize, hex.Dump(e.KeyPrefix))
+	return fmt.Sprintf("Key with size %d exceeded %dMB limit. Key:\n%s",
+		e.KeySize, maxKeySize<<20, hex.Dump(e.KeyPrefix))
 }
 
 type ExceedsMaxValueSizeError struct {

--- a/kv_test.go
+++ b/kv_test.go
@@ -838,15 +838,15 @@ func TestBigKeyValuePairs(t *testing.T) {
 	bigV := make([]byte, opt.ValueLogFileSize+1)
 	small := make([]byte, 10)
 
-	require.IsType(t, ExceedsMaxKeySizeError{}, kv.Set(bigK, small, 0))
-	require.IsType(t, ExceedsMaxValueSizeError{}, kv.Set(small, bigV, 0))
+	require.IsType(t, &ExceedsMaxKeySizeError{}, kv.Set(bigK, small, 0))
+	require.IsType(t, &ExceedsMaxValueSizeError{}, kv.Set(small, bigV, 0))
 
 	e1 := Entry{Key: small, Value: small}
 	e2 := Entry{Key: bigK, Value: bigV}
 	err = kv.BatchSet([]*Entry{&e1, &e2})
 	require.Nil(t, err)
 	require.Nil(t, e1.Error)
-	require.IsType(t, ExceedsMaxKeySizeError{}, e2.Error)
+	require.IsType(t, &ExceedsMaxKeySizeError{}, e2.Error)
 
 	// make sure e1 was actually set:
 	var item KVItem

--- a/kv_test.go
+++ b/kv_test.go
@@ -837,15 +837,15 @@ func TestBigKeyValuePairs(t *testing.T) {
 	bigV := make([]byte, maxValueSize+1)
 	small := make([]byte, 10)
 
-	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(bigK, small, 0))
-	require.Equal(t, ErrExceedsMaxKeyValueSize, kv.Set(small, bigV, 0))
+	require.Equal(t, ErrExceedsMaxKeySize, kv.Set(bigK, small, 0))
+	require.Equal(t, ErrExceedsMaxValueSize, kv.Set(small, bigV, 0))
 
 	e1 := Entry{Key: small, Value: small}
 	e2 := Entry{Key: bigK, Value: bigV}
 	err = kv.BatchSet([]*Entry{&e1, &e2})
 	require.Nil(t, err)
 	require.Nil(t, e1.Error)
-	require.Equal(t, ErrExceedsMaxKeyValueSize, e2.Error)
+	require.Equal(t, ErrExceedsMaxKeySize, e2.Error)
 
 	// make sure e1 was actually set:
 	var item KVItem

--- a/kv_test.go
+++ b/kv_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"sort"
 	"sync"
 	"testing"
@@ -838,15 +839,15 @@ func TestBigKeyValuePairs(t *testing.T) {
 	bigV := make([]byte, opt.ValueLogFileSize+1)
 	small := make([]byte, 10)
 
-	require.IsType(t, &ExceedsMaxKeySizeError{}, kv.Set(bigK, small, 0))
-	require.IsType(t, &ExceedsMaxValueSizeError{}, kv.Set(small, bigV, 0))
+	require.Regexp(t, regexp.MustCompile("Key.*exceeded"), kv.Set(bigK, small, 0).Error())
+	require.Regexp(t, regexp.MustCompile("Value.*exceeded"), kv.Set(small, bigV, 0).Error())
 
 	e1 := Entry{Key: small, Value: small}
 	e2 := Entry{Key: bigK, Value: bigV}
 	err = kv.BatchSet([]*Entry{&e1, &e2})
 	require.Nil(t, err)
 	require.Nil(t, e1.Error)
-	require.IsType(t, &ExceedsMaxKeySizeError{}, e2.Error)
+	require.Regexp(t, regexp.MustCompile("Key.*exceeded"), e2.Error.Error())
 
 	// make sure e1 was actually set:
 	var item KVItem

--- a/kv_test.go
+++ b/kv_test.go
@@ -830,22 +830,23 @@ func TestBigKeyValuePairs(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	kv, err := NewKV(getTestOptions(dir))
+	opt := getTestOptions(dir)
+	kv, err := NewKV(opt)
 	require.NoError(t, err)
 
 	bigK := make([]byte, maxKeySize+1)
-	bigV := make([]byte, maxValueSize+1)
+	bigV := make([]byte, opt.ValueLogFileSize+1)
 	small := make([]byte, 10)
 
-	require.Equal(t, ErrExceedsMaxKeySize, kv.Set(bigK, small, 0))
-	require.Equal(t, ErrExceedsMaxValueSize, kv.Set(small, bigV, 0))
+	require.IsType(t, ExceedsMaxKeySizeError{}, kv.Set(bigK, small, 0))
+	require.IsType(t, ExceedsMaxValueSizeError{}, kv.Set(small, bigV, 0))
 
 	e1 := Entry{Key: small, Value: small}
 	e2 := Entry{Key: bigK, Value: bigV}
 	err = kv.BatchSet([]*Entry{&e1, &e2})
 	require.Nil(t, err)
 	require.Nil(t, e1.Error)
-	require.Equal(t, ErrExceedsMaxKeySize, e2.Error)
+	require.IsType(t, ExceedsMaxKeySizeError{}, e2.Error)
 
 	// make sure e1 was actually set:
 	var item KVItem

--- a/value.go
+++ b/value.go
@@ -80,10 +80,7 @@ var (
 	ErrInvalidRequest = errors.New("Invalid request")
 )
 
-const (
-	maxKeySize   = 1 << 20
-	maxValueSize = 1 << 30
-)
+const maxKeySize = 1 << 20
 
 type logFile struct {
 	path string
@@ -215,7 +212,7 @@ func (lf *logFile) iterate(offset uint32, fn logEntry) error {
 		var e Entry
 		e.offset = recordOffset
 		h.Decode(hbuf[:])
-		if h.klen > maxKeySize || h.vlen > maxValueSize {
+		if h.klen > maxKeySize {
 			truncate = true
 			break
 		}

--- a/value.go
+++ b/value.go
@@ -80,7 +80,7 @@ var (
 	ErrInvalidRequest = errors.New("Invalid request")
 )
 
-const maxKeySize = 16 << 20
+const maxKeySize = 1 << 20
 
 type logFile struct {
 	path string

--- a/value.go
+++ b/value.go
@@ -80,7 +80,7 @@ var (
 	ErrInvalidRequest = errors.New("Invalid request")
 )
 
-const maxKeySize = 1 << 20
+const maxKeySize = 16 << 20
 
 type logFile struct {
 	path string


### PR DESCRIPTION
We now have two separate errors, one for keys and one for values. The error will contain the first 1KB of the offending key/value, and show what the limit was.

Also, the max value size is now the same as the value log size. It's not checked when replaying the value log, since the setting could have been different for a previous run of badger.

I increased the limit for the key size from 1MB to 16MB (found some data in the graph overflow dataset that possibly violates the 1MB limit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/237)
<!-- Reviewable:end -->
