### PR TITLE
Implement Transactions: Part 2

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package badger
+
+import (
+	"encoding/hex"
+
+	"github.com/pkg/errors"
+)
+
+// ErrInvalidDir is returned when Badger cannot find the directory
+// from where it is supposed to load the key-value store.
+var ErrInvalidDir = errors.New("Invalid Dir, directory does not exist")
+
+// ErrValueLogSize is returned when opt.ValueLogFileSize option is not within the valid
+// range.
+var ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 2GB")
+
+// ErrKeyNotFound is returned when key isn't found on a txn.Get.
+var ErrKeyNotFound = errors.New("Key not found")
+
+// ErrTxnTooBig is returned if too many writes are fit into a single transaction.
+var ErrTxnTooBig = errors.New("Txn is too big to fit into one request.")
+
+// ErrConflict is returned when a transaction conflicts with another transaction. This can happen if
+// the read rows had been updated concurrently by another transaction.
+var ErrConflict = errors.New("Transaction Conflict. Please retry.")
+
+// ErrReadOnlyTxn is returned if an update function is called on a read-only transaction.
+var ErrReadOnlyTxn = errors.New("No sets or deletes are allowed in a read-only transaction.")
+
+// ErrEmptyKey is returned if an empty key is passed on an update function.
+var ErrEmptyKey = errors.New("Key cannot be empty.")
+
+const maxKeySize = 1 << 20
+
+func exceedsMaxKeySizeError(key []byte) error {
+	return errors.Errorf("Key with size %d exceeded %dMB limit. Key:\n%s",
+		len(key), maxKeySize<<20, hex.Dump(key[:1<<10]))
+}
+
+func exceedsMaxValueSizeError(value []byte, maxValueSize int64) error {
+	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMB). Key:\n%s",
+		len(value), maxValueSize<<20, hex.Dump(value[:1<<10]))
+}
+
+var (
+	// ErrRetry is returned when a log file containing the value is not found.
+	// This usually indicates that it may have been garbage collected, and the
+	// operation needs to be retried.
+	ErrRetry = errors.New("Unable to find log file. Please retry")
+
+	// ErrThresholdZero is returned if threshold is set to zero, and value log GC is called.
+	// In such a case, GC can't be run.
+	ErrThresholdZero = errors.New(
+		"Value log GC can't run because threshold is set to zero")
+
+	// ErrNoRewrite is returned if a call for value log GC doesn't result in a log file rewrite.
+	ErrNoRewrite = errors.New(
+		"Value log GC attempt didn't result in any cleanup")
+
+	// ErrRejected is returned if a value log GC is called either while another GC is running, or
+	// after KV::Close has been called.
+	ErrRejected = errors.New("Value log GC request rejected")
+
+	// ErrInvalidRequest is returned if the user request is invalid.
+	ErrInvalidRequest = errors.New("Invalid request")
+)

--- a/iterator.go
+++ b/iterator.go
@@ -34,18 +34,17 @@ const (
 // KVItem is returned during iteration. Both the Key() and Value() output is only valid until
 // iterator.Next() is called.
 type KVItem struct {
-	status     prefetchStatus
-	err        error
-	wg         sync.WaitGroup
-	kv         *KV
-	key        []byte
-	vptr       []byte
-	meta       byte
-	userMeta   byte
-	val        []byte
-	casCounter uint64   // TODO: Rename to version ts.
-	slice      *y.Slice // Used only during prefetching.
-	next       *KVItem
+	status   prefetchStatus
+	err      error
+	wg       sync.WaitGroup
+	kv       *KV
+	key      []byte
+	vptr     []byte
+	meta     byte
+	userMeta byte
+	val      []byte
+	slice    *y.Slice // Used only during prefetching.
+	next     *KVItem
 }
 
 // Key returns the key. Remember to copy if you need to access it outside the iteration loop.
@@ -116,10 +115,9 @@ func (item *KVItem) EstimatedSize() int64 {
 	return int64(vp.Len) // includes key length.
 }
 
-// Counter returns the CAS counter associated with the value.
-// TODO: Make this version.
-func (item *KVItem) Counter() uint64 {
-	return item.casCounter
+// Version returns the commit timestamp of the item.
+func (item *KVItem) Version() uint64 {
+	return y.ParseTs(item.key)
 }
 
 // UserMeta returns the userMeta set by the user. Typically, this byte, optionally set by the user
@@ -322,7 +320,6 @@ func (it *Iterator) fill(item *KVItem) {
 	vs := it.iitr.Value()
 	item.meta = vs.Meta
 	item.userMeta = vs.UserMeta
-	item.casCounter = vs.CASCounter
 	item.key = y.Safecopy(item.key, it.iitr.Key())
 	item.vptr = y.Safecopy(item.vptr, vs.Value)
 	item.val = nil

--- a/kv.go
+++ b/kv.go
@@ -18,13 +18,12 @@ package badger
 
 import (
 	"container/heap"
-	"encoding/hex"
 	"expvar"
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/trace"
@@ -72,27 +71,9 @@ type KV struct {
 
 	// Incremented in the non-concurrently accessed write loop.  But also accessed outside. So
 	// we use an atomic op.
-	lastUsedCasCounter uint64
+	lastUsedCommitTs uint64
 
 	txnState *globalTxnState
-}
-
-// ErrInvalidDir is returned when Badger cannot find the directory
-// from where it is supposed to load the key-value store.
-var ErrInvalidDir = errors.New("Invalid Dir, directory does not exist")
-
-// ErrValueLogSize is returned when opt.ValueLogFileSize option is not within the valid
-// range.
-var ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 2GB")
-
-func exceedsMaxKeySizeError(key []byte) error {
-	return errors.Errorf("Key with size %d exceeded %dMB limit. Key:\n%s",
-		len(key), maxKeySize<<20, hex.Dump(key[:1<<10]))
-}
-
-func exceedsMaxValueSizeError(value []byte, maxValueSize int64) error {
-	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMB). Key:\n%s",
-		len(value), maxValueSize<<20, hex.Dump(value[:1<<10]))
 }
 
 const (
@@ -196,34 +177,41 @@ func NewKV(optParam *Options) (out *KV, err error) {
 		return nil, err
 	}
 
-	var item KVItem
-	if err := out.Get(head, &item); err != nil {
+	vs, err := out.get(head)
+	if err != nil {
 		return nil, errors.Wrap(err, "Retrieving head")
 	}
-
-	var val []byte
-	err = item.Value(func(v []byte) error {
-		val = make([]byte, len(v))
-		copy(val, v)
-		return nil
-	})
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Retrieving head value")
+	out.txnState.curRead = vs.Version
+	var vptr valuePointer
+	if len(vs.Value) > 0 {
+		vptr.Decode(vs.Value)
 	}
+
 	// lastUsedCasCounter will either be the value stored in !badger!head, or some subsequently
 	// written value log entry that we replay.  (Subsequent value log entries might be _less_
 	// than lastUsedCasCounter, if there was value log gc so we have to max() values while
 	// replaying.)
-	out.lastUsedCasCounter = item.casCounter
-
-	var vptr valuePointer
-	if len(val) > 0 {
-		vptr.Decode(val)
-	}
+	// out.lastUsedCasCounter = item.casCounter
+	// TODO: Figure this out. This would update the read timestamp, and set nextCommitTs.
 
 	replayCloser := y.NewCloser(1)
 	go out.doWrites(replayCloser)
+
+	type txnEntry struct {
+		nk []byte
+		v  y.ValueStruct
+	}
+
+	var txn []txnEntry
+	var lastCommit uint64
+
+	toLSM := func(nk []byte, vs y.ValueStruct) {
+		for err := out.ensureRoomForWrite(); err != nil; err = out.ensureRoomForWrite() {
+			out.elog.Printf("Replay: Making room for writes")
+			time.Sleep(10 * time.Millisecond)
+		}
+		out.mt.Put(nk, vs)
+	}
 
 	first := true
 	fn := func(e Entry, vp valuePointer) error { // Function for replaying.
@@ -231,19 +219,11 @@ func NewKV(optParam *Options) (out *KV, err error) {
 			out.elog.Printf("First key=%s\n", e.Key)
 		}
 		first = false
-		if out.lastUsedCasCounter < e.casCounter {
-			out.lastUsedCasCounter = e.casCounter
+
+		if out.txnState.curRead < y.ParseTs(e.Key) {
+			out.txnState.curRead = y.ParseTs(e.Key)
 		}
 
-		if e.CASCounterCheck != 0 {
-			oldValue, err := out.get(e.Key)
-			if err != nil {
-				return err
-			}
-			if oldValue.CASCounter != e.CASCounterCheck {
-				return nil
-			}
-		}
 		nk := make([]byte, len(e.Key))
 		copy(nk, e.Key)
 		var nv []byte
@@ -252,22 +232,47 @@ func NewKV(optParam *Options) (out *KV, err error) {
 			nv = make([]byte, len(e.Value))
 			copy(nv, e.Value)
 		} else {
-			nv = make([]byte, valuePointerEncodedSize)
+			nv = make([]byte, vptrSize)
 			vp.Encode(nv)
 			meta = meta | BitValuePointer
 		}
 
 		v := y.ValueStruct{
-			Value:      nv,
-			Meta:       meta,
-			UserMeta:   e.UserMeta,
-			CASCounter: e.casCounter,
+			Value:    nv,
+			Meta:     meta,
+			UserMeta: e.UserMeta,
 		}
-		for err := out.ensureRoomForWrite(); err != nil; err = out.ensureRoomForWrite() {
-			out.elog.Printf("Replay: Making room for writes")
-			time.Sleep(10 * time.Millisecond)
+
+		if e.Meta&BitFinTxn > 0 {
+			txnTs, err := strconv.ParseUint(string(e.Value), 10, 64)
+			if err != nil {
+				return errors.Wrapf(err, "Unable to parse txn fin: %q", e.Value)
+			}
+			y.AssertTrue(lastCommit == txnTs)
+			y.AssertTrue(len(txn) > 0)
+			// Got the end of txn. Now we can store them.
+			for _, t := range txn {
+				toLSM(t.nk, t.v)
+			}
+			txn = txn[:0]
+
+		} else if e.Meta&BitTxn == 0 {
+			// This entry is from a rewrite.
+			toLSM(nk, v)
+
+			// We shouldn't get this entry in the middle of a transaction.
+			y.AssertTrue(lastCommit == 0)
+			y.AssertTrue(len(txn) == 0)
+
+		} else {
+			txnTs := y.ParseTs(nk)
+			if lastCommit == 0 {
+				lastCommit = txnTs
+			}
+			y.AssertTrue(lastCommit == txnTs)
+			te := txnEntry{nk: nk, v: v}
+			txn = append(txn, te)
 		}
-		out.mt.Put(nk, v)
 		return nil
 	}
 	if err = out.vlog.Replay(vptr, fn); err != nil {
@@ -275,6 +280,8 @@ func NewKV(optParam *Options) (out *KV, err error) {
 	}
 
 	replayCloser.SignalAndWait() // Wait for replay to be applied first.
+	// Now that we have the curRead, we can update the nextCommit.
+	out.txnState.nextCommit = out.txnState.curRead + 1
 
 	// Mmap writable log
 	lf := out.vlog.filesMap[out.vlog.maxFid]
@@ -467,46 +474,6 @@ func (s *KV) get(key []byte) (y.ValueStruct, error) {
 	return s.lc.get(key)
 }
 
-// Get looks for key and returns a KVItem.
-// If key is not found, item.Value() is nil.
-// TODO: Remove.
-func (s *KV) Get(key []byte, item *KVItem) error {
-	vs, err := s.get(key)
-	if err != nil {
-		return errors.Wrapf(err, "KV::Get key: %q", key)
-	}
-
-	item.meta = vs.Meta
-	item.userMeta = vs.UserMeta
-	item.casCounter = vs.CASCounter
-	item.key = key
-	item.kv = s
-	item.vptr = vs.Value
-
-	return nil
-}
-
-// Exists looks if a key exists. Returns true if the
-// key exists otherwises return false. if err is not nil an error occurs during
-// the key lookup and the existence of the key is unknown
-func (s *KV) Exists(key []byte) (bool, error) {
-	vs, err := s.get(key)
-	if err != nil {
-		return false, err
-	}
-
-	if vs.Value == nil && vs.Meta == 0 {
-		return false, nil
-	}
-
-	if (vs.Meta & BitDelete) != 0 {
-		// Tombstone encountered.
-		return false, nil
-	}
-
-	return true, nil
-}
-
 func (s *KV) updateOffset(ptrs []valuePointer) {
 	var ptr valuePointer
 	for i := len(ptrs) - 1; i >= 0; i-- {
@@ -542,62 +509,24 @@ func (s *KV) writeToLSM(b *request) error {
 	}
 
 	for i, entry := range b.Entries {
-		entry.Error = nil
-		if entry.CASCounterCheck != 0 {
-			oldValue, err := s.get(entry.Key)
-			if err != nil {
-				return errors.Wrap(err, "writeToLSM")
-			}
-			// No need to decode existing value. Just need old CAS counter.
-			if oldValue.CASCounter != entry.CASCounterCheck {
-				entry.Error = ErrCasMismatch
-				continue
-			}
-		}
-
-		if entry.Meta == BitSetIfAbsent {
-			// Someone else might have written a value, so lets check again if key exists.
-			exists, err := s.Exists(entry.Key)
-			if err != nil {
-				return err
-			}
-			// Value already exists, don't write.
-			if exists {
-				entry.Error = ErrKeyExists
-				continue
-			}
-		}
-
 		if s.shouldWriteValueToLSM(*entry) { // Will include deletion / tombstone case.
 			s.mt.Put(entry.Key,
 				y.ValueStruct{
-					Value:      entry.Value,
-					Meta:       entry.Meta,
-					UserMeta:   entry.UserMeta,
-					CASCounter: entry.casCounter})
+					Value:    entry.Value,
+					Meta:     entry.Meta,
+					UserMeta: entry.UserMeta,
+				})
 		} else {
-			var offsetBuf [valuePointerEncodedSize]byte
+			var offsetBuf [vptrSize]byte
 			s.mt.Put(entry.Key,
 				y.ValueStruct{
-					Value:      b.Ptrs[i].Encode(offsetBuf[:]),
-					Meta:       entry.Meta | BitValuePointer,
-					UserMeta:   entry.UserMeta,
-					CASCounter: entry.casCounter})
+					Value:    b.Ptrs[i].Encode(offsetBuf[:]),
+					Meta:     entry.Meta | BitValuePointer,
+					UserMeta: entry.UserMeta,
+				})
 		}
 	}
 	return nil
-}
-
-// lastCASCounter returns the last-used cas counter.
-func (s *KV) lastCASCounter() uint64 {
-	return atomic.LoadUint64(&s.lastUsedCasCounter)
-}
-
-// newCASCounters generates a set of unique CAS counters -- the interval [x, x + howMany) where x
-// is the return value.
-func (s *KV) newCASCounters(howMany uint64) uint64 {
-	last := atomic.AddUint64(&s.lastUsedCasCounter, howMany)
-	return last - howMany + 1
 }
 
 // writeRequests is called serially by only one goroutine.
@@ -615,19 +544,6 @@ func (s *KV) writeRequests(reqs []*request) error {
 
 	s.elog.Printf("writeRequests called. Writing to value log")
 
-	// CAS counter for all operations has to go onto value log. Otherwise, if it is just in
-	// memtable for a long time, and following CAS operations use that as a check, when
-	// replaying, we will think that these CAS operations should fail, when they are actually
-	// valid.
-
-	// There is code (in flushMemtable) whose correctness depends on us generating CAS Counter
-	// values _before_ we modify s.vptr here.
-	for _, req := range reqs {
-		counterBase := s.newCASCounters(uint64(len(req.Entries)))
-		for i, e := range req.Entries {
-			e.casCounter = counterBase + uint64(i)
-		}
-	}
 	err := s.vlog.write(reqs)
 	if err != nil {
 		done(err)
@@ -723,310 +639,63 @@ func (s *KV) doWrites(lc *y.Closer) {
 	}
 }
 
-func (s *KV) sendToWriteCh(entries []*Entry) []*request {
-	var reqs []*request
+func (s *KV) sendToWriteCh(entries []*Entry) (*request, error) {
 	var count, size int64
-	var b *request
-	var bad []*Entry
-	for _, entry := range entries {
-		if len(entry.Key) > maxKeySize {
-			entry.Error = exceedsMaxKeySizeError(entry.Key)
-			bad = append(bad, entry)
-			continue
-		}
-		if len(entry.Value) > int(s.opt.ValueLogFileSize) {
-			entry.Error = exceedsMaxValueSizeError(entry.Value, s.opt.ValueLogFileSize)
-			bad = append(bad, entry)
-			continue
-		}
-		if b == nil {
-			b = requestPool.Get().(*request)
-			b.Entries = b.Entries[:0]
-			b.Wg = sync.WaitGroup{}
-			b.Wg.Add(1)
-		}
+	for _, e := range entries {
+		size += int64(s.opt.estimateSize(e))
 		count++
-		size += int64(s.opt.estimateSize(entry))
-		b.Entries = append(b.Entries, entry)
-		if count >= s.opt.maxBatchCount || size >= s.opt.maxBatchSize {
-			s.writeCh <- b
-			y.NumPuts.Add(int64(len(b.Entries)))
-			reqs = append(reqs, b)
-			count = 0
-			size = 0
-			b = nil
-		}
+	}
+	if count >= s.opt.maxBatchCount || size >= s.opt.maxBatchSize {
+		return nil, ErrTxnTooBig
 	}
 
-	if size > 0 {
-		s.writeCh <- b
-		y.NumPuts.Add(int64(len(b.Entries)))
-		reqs = append(reqs, b)
-	}
+	// We can only service one request because we need each txn to be stored in a contigous section.
+	// Txns should not interleave among other txns or rewrites.
+	req := requestPool.Get().(*request)
+	req.Entries = entries
+	req.Wg = sync.WaitGroup{}
+	req.Wg.Add(1)
+	s.writeCh <- req
+	y.NumPuts.Add(int64(len(entries)))
 
-	if len(bad) > 0 {
-		b := requestPool.Get().(*request)
-		b.Entries = bad
-		b.Wg = sync.WaitGroup{}
-		b.Err = nil
-		b.Ptrs = nil
-		reqs = append(reqs, b)
-		y.NumBlockedPuts.Add(int64(len(bad)))
-	}
-
-	return reqs
+	return req, nil
 }
 
-// BatchSet applies a list of badger.Entry. If a request level error occurs it
-// will be returned. Errors are also set on each Entry and must be checked
-// individually.
+// batchSet applies a list of badger.Entry. If a request level error occurs it
+// will be returned.
 //   Check(kv.BatchSet(entries))
-//   for _, e := range entries {
-//      Check(e.Error)
-//   }
-func (s *KV) BatchSet(entries []*Entry) error {
-	reqs := s.sendToWriteCh(entries)
-
-	var err error
-	for _, req := range reqs {
-		req.Wg.Wait()
-		if req.Err != nil {
-			err = req.Err
-		}
-		requestPool.Put(req)
+func (s *KV) batchSet(entries []*Entry) error {
+	req, err := s.sendToWriteCh(entries)
+	if err != nil {
+		return err
 	}
-	return err
+
+	req.Wg.Wait()
+	req.Entries = nil
+	requestPool.Put(req)
+	return req.Err
 }
 
-// BatchSetAsync is the asynchronous version of BatchSet. It accepts a callback
+// batchSetAsync is the asynchronous version of batchSet. It accepts a callback
 // function which is called when all the sets are complete. If a request level
-// error occurs, it will be passed back via the callback. The caller should
-// still check for errors set on each Entry individually.
-//   kv.BatchSetAsync(entries, func(err error)) {
+// error occurs, it will be passed back via the callback.
+//   err := kv.BatchSetAsync(entries, func(err error)) {
 //      Check(err)
-//      for _, e := range entries {
-//         Check(e.Error)
-//      }
 //   }
-func (s *KV) BatchSetAsync(entries []*Entry, f func(error)) {
-	reqs := s.sendToWriteCh(entries)
-
+func (s *KV) batchSetAsync(entries []*Entry, f func(error)) error {
+	req, err := s.sendToWriteCh(entries)
+	if err != nil {
+		return err
+	}
 	go func() {
-		var err error
-		for _, req := range reqs {
-			req.Wg.Wait()
-			if req.Err != nil {
-				err = req.Err
-			}
-			requestPool.Put(req)
-		}
-		// All writes complete, let's call the callback function now.
+		req.Wg.Wait()
+		err := req.Err
+		req.Entries = nil
+		requestPool.Put(req)
+		// Write is complete. Let's call the callback function now.
 		f(err)
 	}()
-}
-
-// Set sets the provided value for a given key. If key is not present, it is created.  If it is
-// present, the existing value is overwritten with the one provided.
-// Along with key and value, Set can also take an optional userMeta byte. This byte is stored
-// alongside the key, and can be used as an aid to interpret the value or store other contextual
-// bits corresponding to the key-value pair.
-func (s *KV) Set(key, val []byte, userMeta byte) error {
-	e := &Entry{
-		Key:      key,
-		Value:    val,
-		UserMeta: userMeta,
-	}
-	if err := s.BatchSet([]*Entry{e}); err != nil {
-		return err
-	}
-	return e.Error
-}
-
-// SetAsync is the asynchronous version of Set. It accepts a callback function which is called
-// when the set is complete. Any error encountered during execution is passed as an argument
-// to the callback function.
-func (s *KV) SetAsync(key, val []byte, userMeta byte, f func(error)) {
-	e := &Entry{
-		Key:      key,
-		Value:    val,
-		UserMeta: userMeta,
-	}
-	s.BatchSetAsync([]*Entry{e}, func(err error) {
-		if err != nil {
-			f(err)
-			return
-		}
-		if e.Error != nil {
-			f(e.Error)
-			return
-		}
-		f(nil)
-	})
-}
-
-func (s *KV) setIfAbsent(key, val []byte, userMeta byte) (*Entry, error) {
-	exists, err := s.Exists(key)
-	if err != nil {
-		return nil, err
-	}
-	// Found the key, return KeyExists
-	if exists {
-		return nil, ErrKeyExists
-	}
-
-	e := &Entry{
-		Key:      key,
-		Meta:     BitSetIfAbsent,
-		Value:    val,
-		UserMeta: userMeta,
-	}
-	return e, nil
-}
-
-// SetIfAbsent sets value of key if key is not present.
-// If it is present, it returns the KeyExists error.
-func (s *KV) SetIfAbsent(key, val []byte, userMeta byte) error {
-	e, err := s.setIfAbsent(key, val, userMeta)
-	if err != nil {
-		return err
-	}
-
-	if err := s.BatchSet([]*Entry{e}); err != nil {
-		return err
-	}
-	return e.Error
-}
-
-// SetIfAbsentAsync is the asynchronous version of SetIfAbsent. It accepts a callback function which
-// is called when the operation is complete. Any error encountered during execution is passed as an
-// argument to the callback function.
-func (s *KV) SetIfAbsentAsync(key, val []byte, userMeta byte, f func(error)) error {
-	e, err := s.setIfAbsent(key, val, userMeta)
-	if err != nil {
-		return err
-	}
-
-	s.BatchSetAsync([]*Entry{e}, func(err error) {
-		if err != nil {
-			f(err)
-			return
-		}
-		if e.Error != nil {
-			f(e.Error)
-			return
-		}
-		f(nil)
-	})
 	return nil
-}
-
-// EntriesSet adds a Set to the list of entries.
-// Exposing this so that user does not have to specify the Entry directly.
-func EntriesSet(s []*Entry, key, val []byte) []*Entry {
-	return append(s, &Entry{
-		Key:   key,
-		Value: val,
-	})
-}
-
-// CompareAndSet sets the given value, ensuring that the no other Set operation has happened,
-// since last read. If the key has a different casCounter, this would not update the key
-// and return an error.
-func (s *KV) CompareAndSet(key []byte, val []byte, casCounter uint64) error {
-	e := &Entry{
-		Key:             key,
-		Value:           val,
-		CASCounterCheck: casCounter,
-	}
-	if err := s.BatchSet([]*Entry{e}); err != nil {
-		return err
-	}
-	return e.Error
-}
-
-func (s *KV) compareAsync(e *Entry, f func(error)) {
-	b := requestPool.Get().(*request)
-	b.Wg = sync.WaitGroup{}
-	b.Wg.Add(1)
-	s.writeCh <- b
-
-	go func() {
-		b.Wg.Wait()
-		if b.Err != nil {
-			f(b.Err)
-			return
-		}
-		f(e.Error)
-	}()
-}
-
-// CompareAndSetAsync is the asynchronous version of CompareAndSet. It accepts a callback function
-// which is called when the CompareAndSet completes. Any error encountered during execution is
-// passed as an argument to the callback function.
-func (s *KV) CompareAndSetAsync(key []byte, val []byte, casCounter uint64, f func(error)) {
-	e := &Entry{
-		Key:             key,
-		Value:           val,
-		CASCounterCheck: casCounter,
-	}
-	s.compareAsync(e, f)
-}
-
-// Delete deletes a key.
-// Exposing this so that user does not have to specify the Entry directly.
-// For example, BitDelete seems internal to badger.
-func (s *KV) Delete(key []byte) error {
-	e := &Entry{
-		Key:  key,
-		Meta: BitDelete,
-	}
-
-	return s.BatchSet([]*Entry{e})
-}
-
-// DeleteAsync is the asynchronous version of Delete. It calls the callback function after deletion
-// is complete. Any error encountered during the execution is passed as an argument to the
-// callback function.
-func (s *KV) DeleteAsync(key []byte, f func(error)) {
-	e := &Entry{
-		Key:  key,
-		Meta: BitDelete,
-	}
-	s.BatchSetAsync([]*Entry{e}, f)
-}
-
-// EntriesDelete adds a Del to the list of entries.
-func EntriesDelete(s []*Entry, key []byte) []*Entry {
-	return append(s, &Entry{
-		Key:  key,
-		Meta: BitDelete,
-	})
-}
-
-// CompareAndDelete deletes a key ensuring that it has not been changed since last read.
-// If existing key has different casCounter, this would not delete the key and return an error.
-func (s *KV) CompareAndDelete(key []byte, casCounter uint64) error {
-	e := &Entry{
-		Key:             key,
-		Meta:            BitDelete,
-		CASCounterCheck: casCounter,
-	}
-	if err := s.BatchSet([]*Entry{e}); err != nil {
-		return err
-	}
-	return e.Error
-}
-
-// CompareAndDeleteAsync is the asynchronous version of CompareAndDelete. It accepts a callback
-// function which is called when the CompareAndDelete completes. Any error encountered during
-// execution is passed as an argument to the callback function.
-func (s *KV) CompareAndDeleteAsync(key []byte, casCounter uint64, f func(error)) {
-	e := &Entry{
-		Key:             key,
-		Meta:            BitDelete,
-		CASCounterCheck: casCounter,
-	}
-	s.compareAsync(e, f)
 }
 
 var errNoRoom = errors.New("No room for write")
@@ -1097,17 +766,13 @@ func (s *KV) flushMemtable(lc *y.Closer) error {
 
 		if !ft.vptr.IsZero() {
 			s.elog.Printf("Storing offset: %+v\n", ft.vptr)
-			offset := make([]byte, valuePointerEncodedSize)
+			offset := make([]byte, vptrSize)
 			ft.vptr.Encode(offset)
-			// CAS counter is needed and is desirable -- it's the first value log entry
-			// we replay, so to speak, perhaps the only, and we use it to re-initialize
-			// the CAS counter.
-			//
-			// The write loop generates CAS counter values _before_ it sets vptr.  It
-			// is crucial that we read the cas counter here _after_ reading vptr.  That
-			// way, our value here is guaranteed to be >= the CASCounter values written
-			// before vptr (because they don't get replayed).
-			ft.mt.Put(head, y.ValueStruct{Value: offset, CASCounter: s.lastCASCounter()})
+
+			// Pick the max commit ts, so in case of crash, our read ts would be higher than all the
+			// commits.
+			headTs := y.KeyWithTs(head, s.txnState.commitTs())
+			ft.mt.Put(headTs, y.ValueStruct{Value: offset})
 		}
 		fileID := s.lc.reserveFileID()
 		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, s.opt.Dir), true)

--- a/level_handler.go
+++ b/level_handler.go
@@ -256,8 +256,9 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 			continue
 		}
 		if y.SameKey(key, it.Key()) {
-			// TODO: Update the CASCounter timestamp entry to embed key version.
-			return it.Value(), decr()
+			vs := it.Value()
+			vs.Version = y.ParseTs(it.Key())
+			return vs, decr()
 		}
 	}
 	return y.ValueStruct{}, decr()

--- a/options.go
+++ b/options.go
@@ -18,7 +18,6 @@ package badger
 
 import (
 	"github.com/dgraph-io/badger/options"
-	"github.com/dgraph-io/badger/y"
 )
 
 // NOTE: Keep the comments in the following to 75 chars width, so they
@@ -101,8 +100,5 @@ var DefaultOptions = Options{
 }
 
 func (opt *Options) estimateSize(entry *Entry) int {
-	if len(entry.Value) < opt.ValueThreshold {
-		return len(entry.Key) + len(entry.Value) + y.MetaSize + y.UserMetaSize + y.CasSize
-	}
-	return len(entry.Key) + 16 + y.MetaSize + y.UserMetaSize + y.CasSize
+	return entry.estimateSize(opt.ValueThreshold)
 }

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -116,7 +116,7 @@ func (s *Arena) getKey(offset uint32, size uint16) []byte {
 // getVal returns byte slice at offset. The given size should be just the value
 // size and should NOT include the meta bytes.
 func (s *Arena) getVal(offset uint32, size uint16) (ret y.ValueStruct) {
-	ret.DecodeEntireSlice(s.buf[offset : offset+uint32(y.ValueStructSerializedSize(size))])
+	ret.Decode(s.buf[offset : offset+uint32(size)])
 	return
 }
 

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -109,7 +109,7 @@ func newNode(arena *Arena, key []byte, v y.ValueStruct, height int) *node {
 	node.keyOffset = arena.putKey(key)
 	node.keySize = uint16(len(key))
 	node.height = uint16(height)
-	node.value = encodeValue(arena.putVal(v), uint16(len(v.Value)))
+	node.value = encodeValue(arena.putVal(v), uint16(v.EncodedSize()))
 	return node
 }
 
@@ -379,10 +379,13 @@ func (s *Skiplist) Get(key []byte) y.ValueStruct {
 		return y.ValueStruct{}
 	}
 	valOffset, valSize := n.getValueOffset()
-	if !y.SameKey(key, s.arena.getKey(n.keyOffset, n.keySize)) {
+	nextKey := s.arena.getKey(n.keyOffset, n.keySize)
+	if !y.SameKey(key, nextKey) {
 		return y.ValueStruct{}
 	}
-	return s.arena.getVal(valOffset, valSize)
+	vs := s.arena.getVal(valOffset, valSize)
+	vs.Version = y.ParseTs(nextKey)
+	return vs
 }
 
 // NewIterator returns a skiplist iterator.  You have to Close() the iterator.

--- a/structs.go
+++ b/structs.go
@@ -1,0 +1,128 @@
+package badger
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/dgraph-io/badger/y"
+)
+
+type valuePointer struct {
+	Fid    uint32
+	Len    uint32
+	Offset uint32
+}
+
+func (p valuePointer) Less(o valuePointer) bool {
+	if p.Fid != o.Fid {
+		return p.Fid < o.Fid
+	}
+	if p.Offset != o.Offset {
+		return p.Offset < o.Offset
+	}
+	return p.Len < o.Len
+}
+
+func (p valuePointer) IsZero() bool {
+	return p.Fid == 0 && p.Offset == 0 && p.Len == 0
+}
+
+const vptrSize = 12
+
+// Encode encodes Pointer into byte buffer.
+func (p valuePointer) Encode(b []byte) []byte {
+	binary.BigEndian.PutUint32(b[:4], p.Fid)
+	binary.BigEndian.PutUint32(b[4:8], p.Len)
+	binary.BigEndian.PutUint32(b[8:12], p.Offset)
+	return b[:vptrSize]
+}
+
+func (p *valuePointer) Decode(b []byte) {
+	p.Fid = binary.BigEndian.Uint32(b[:4])
+	p.Len = binary.BigEndian.Uint32(b[4:8])
+	p.Offset = binary.BigEndian.Uint32(b[8:12])
+}
+
+// header is used in value log as a header before Entry.
+type header struct {
+	klen     uint32
+	vlen     uint32
+	meta     byte
+	userMeta byte
+}
+
+const (
+	headerBufSize = 10
+)
+
+func (h header) Encode(out []byte) {
+	y.AssertTrue(len(out) >= headerBufSize)
+	binary.BigEndian.PutUint32(out[0:4], h.klen)
+	binary.BigEndian.PutUint32(out[4:8], h.vlen)
+	out[8] = h.meta
+	out[9] = h.userMeta
+}
+
+// Decodes h from buf.
+func (h *header) Decode(buf []byte) {
+	h.klen = binary.BigEndian.Uint32(buf[0:4])
+	h.vlen = binary.BigEndian.Uint32(buf[4:8])
+	h.meta = buf[8]
+	h.userMeta = buf[9]
+}
+
+// Entry provides Key, Value and if required, CASCounterCheck to kv.BatchSet() API.
+// If CASCounterCheck is provided, it would be compared against the current casCounter
+// assigned to this key-value. Set be done on this key only if the counters match.
+type Entry struct {
+	Key      []byte
+	Value    []byte
+	Meta     byte
+	UserMeta byte
+
+	// Fields maintained internally.
+	offset uint32
+}
+
+func (e *Entry) estimateSize(threshold int) int {
+	if len(e.Value) < threshold {
+		return len(e.Key) + len(e.Value) + 2 // Meta, UserMeta
+	}
+	return len(e.Key) + 12 + 2 // 12 for ValuePointer, 2 for metas.
+}
+
+// Encodes e to buf. Returns number of bytes written.
+func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
+	var h header
+	h.klen = uint32(len(e.Key))
+	h.vlen = uint32(len(e.Value))
+	h.meta = e.Meta
+	h.userMeta = e.UserMeta
+
+	var headerEnc [headerBufSize]byte
+	h.Encode(headerEnc[:])
+
+	hash := crc32.New(y.CastagnoliCrcTable)
+
+	buf.Write(headerEnc[:])
+	hash.Write(headerEnc[:])
+
+	buf.Write(e.Key)
+	hash.Write(e.Key)
+
+	buf.Write(e.Value)
+	hash.Write(e.Value)
+
+	var crcBuf [4]byte
+	binary.BigEndian.PutUint32(crcBuf[:], hash.Sum32())
+	buf.Write(crcBuf[:])
+
+	return len(headerEnc) + len(e.Key) + len(e.Value) + len(crcBuf), nil
+}
+
+func (e Entry) print(prefix string) {
+	fmt.Printf("%s Key: %s Meta: %d UserMeta: %d Offset: %d len(val)=%d",
+		prefix, e.Key, e.Meta, e.UserMeta, e.offset, len(e.Value))
+}

--- a/table/builder.go
+++ b/table/builder.go
@@ -130,7 +130,7 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	h := header{
 		plen: uint16(len(key) - len(diffKey)),
 		klen: uint16(len(diffKey)),
-		vlen: uint16(len(v.Value) + y.MetaSize + y.UserMetaSize + y.CasSize),
+		vlen: uint16(v.EncodedSize()),
 		prev: b.prevOffset, // prevOffset is the location of the last key-value added.
 	}
 	b.prevOffset = uint32(b.buf.Len()) - b.baseOffset // Remember current offset for the next Add call.
@@ -139,13 +139,13 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	var hbuf [10]byte
 	h.Encode(hbuf[:])
 	b.buf.Write(hbuf[:])
-	b.buf.Write(diffKey)    // We only need to store the key difference.
+	b.buf.Write(diffKey) // We only need to store the key difference.
+
+	// This should be kept in sync with ValueStruct encode function.
 	b.buf.WriteByte(v.Meta) // Meta byte precedes actual value.
 	b.buf.WriteByte(v.UserMeta)
-	var casBytes [y.CasSize]byte
-	binary.BigEndian.PutUint64(casBytes[:], v.CASCounter)
-	b.buf.Write(casBytes[:])
 	b.buf.Write(v.Value)
+
 	b.counter++ // Increment number of keys added for this current block.
 }
 

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -386,7 +386,7 @@ func (itr *Iterator) Key() []byte {
 
 // Value follows the y.Iterator interface
 func (itr *Iterator) Value() (ret y.ValueStruct) {
-	ret.DecodeEntireSlice(itr.bi.Value())
+	ret.Decode(itr.bi.Value())
 	return
 }
 

--- a/value.go
+++ b/value.go
@@ -24,6 +24,7 @@ import (
 	"hash/crc32"
 	"io"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"os"
 	"sort"
@@ -41,46 +42,15 @@ import (
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.
 const (
-	BitDelete       byte  = 1 // Set if the key has been deleted.
-	BitValuePointer byte  = 2 // Set if the value is NOT stored directly next to key.
-	BitUnused       byte  = 4
-	BitSetIfAbsent  byte  = 8  // Set if the key is set using SetIfAbsent.
-	BitFinTxn       byte  = 16 // Set if the entry is to indicate end of txn in value log.
-	M               int64 = 1 << 20
+	BitDelete       byte = 1 << 0 // Set if the key has been deleted.
+	BitValuePointer byte = 1 << 1 // Set if the value is NOT stored directly next to key.
+
+	// The MSB 2 bits are for transactions.
+	BitTxn    byte = 1 << 6 // Set if the entry is part of a txn.
+	BitFinTxn byte = 1 << 7 // Set if the entry is to indicate end of txn in value log.
+
+	M int64 = 1 << 20
 )
-
-var (
-	// ErrRetry is returned when a log file containing the value is not found.
-	// This usually indicates that it may have been garbage collected, and the
-	// operation needs to be retried.
-	ErrRetry = errors.New("Unable to find log file. Please retry")
-
-	// ErrCasMismatch is returned when a CompareAndSet operation has failed due
-	// to a counter mismatch.
-	ErrCasMismatch = errors.New("CompareAndSet failed due to counter mismatch")
-
-	// ErrKeyExists is returned by SetIfAbsent metadata bit is set, but the
-	// key already exists in the store.
-	ErrKeyExists = errors.New("SetIfAbsent failed since key already exists")
-
-	// ErrThresholdZero is returned if threshold is set to zero, and value log GC is called.
-	// In such a case, GC can't be run.
-	ErrThresholdZero = errors.New(
-		"Value log GC can't run because threshold is set to zero")
-
-	// ErrNoRewrite is returned if a call for value log GC doesn't result in a log file rewrite.
-	ErrNoRewrite = errors.New(
-		"Value log GC attempt didn't result in any cleanup")
-
-	// ErrRejected is returned if a value log GC is called either while another GC is running, or
-	// after KV::Close has been called.
-	ErrRejected = errors.New("Value log GC request rejected")
-
-	// ErrInvalidRequest is returned if the user request is invalid.
-	ErrInvalidRequest = errors.New("Invalid request")
-)
-
-const maxKeySize = 1 << 20
 
 type logFile struct {
 	path string
@@ -204,6 +174,7 @@ func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) error {
 		hash := crc32.New(y.CastagnoliCrcTable)
 		tee := io.TeeReader(reader, hash)
 
+		// TODO: Move this entry decode into structs.go
 		if _, err = io.ReadFull(tee, hbuf[:]); err != nil {
 			if err == io.EOF {
 				break
@@ -242,8 +213,6 @@ func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) error {
 		}
 		e.Meta = h.meta
 		e.UserMeta = h.userMeta
-		e.casCounter = h.casCounter
-		e.CASCounterCheck = h.casCounterCheck
 		if _, err = io.ReadFull(tee, e.Value); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				truncate = true
@@ -315,11 +284,7 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 		if err != nil {
 			return err
 		}
-
-		if (vs.Meta & BitDelete) > 0 {
-			return nil
-		}
-		if (vs.Meta & BitValuePointer) == 0 {
+		if discardEntry(e, vs) {
 			return nil
 		}
 
@@ -339,34 +304,24 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 		if vp.Fid == f.fid && vp.Offset == e.offset {
 			// This new entry only contains the key, and a pointer to the value.
 			ne := new(Entry)
-			if e.Meta == BitSetIfAbsent {
-				// If we rewrite this entry without removing BitSetIfAbsent, lsm would see that
-				// the key is already present, which would be this same entry and won't update
-				// the vptr to point to the new file.
-				e.Meta = 0
-			}
-			y.AssertTruef(e.Meta == 0, "Got meta: 0")
-			ne.Meta = e.Meta
+			ne.Meta = 0 // Remove all bits.
 			ne.UserMeta = e.UserMeta
 			ne.Key = make([]byte, len(e.Key))
 			copy(ne.Key, e.Key)
 			ne.Value = make([]byte, len(e.Value))
 			copy(ne.Value, e.Value)
-			// CAS counter check. Do not rewrite if key has a newer value.
-			ne.CASCounterCheck = vs.CASCounter
 			wb = append(wb, ne)
 			size += int64(vlog.opt.estimateSize(ne))
 			if size >= 64*M {
 				elog.Printf("request has %d entries, size %d", len(wb), size)
-				if err := vlog.kv.BatchSet(wb); err != nil {
+				if err := vlog.kv.batchSet(wb); err != nil {
 					return err
 				}
 				size = 0
 				wb = wb[:0]
 			}
 		} else {
-			// This can now happen because we can move some entries forward, but then not write
-			// them to LSM tree due to CAS check failure.
+			log.Printf("WARNING: This entry should have been caught. %+v\n", e)
 		}
 		return nil
 	}
@@ -378,13 +333,30 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 		return err
 	}
 
-	if len(wb) > 0 {
-		elog.Printf("request has %d entries, size %d", len(wb), size)
-		if err := vlog.kv.BatchSet(wb); err != nil {
+	elog.Printf("request has %d entries, size %d", len(wb), size)
+	batchSize := 1024
+	var loops int
+	for i := 0; i < len(wb); i += batchSize {
+		loops++
+		if batchSize == 0 {
+			log.Printf("WARNING: We shouldn't reach batch size of zero.")
+			return ErrNoRewrite
+		}
+		end := i + batchSize
+		if end > len(wb) {
+			end = len(wb)
+		}
+		if err := vlog.kv.batchSet(wb[i:end]); err != nil {
+			if err == ErrTxnTooBig {
+				// Decrease the batch size to half.
+				batchSize = batchSize / 2
+				elog.Printf("Dropped batch size to %d", batchSize)
+				continue
+			}
 			return err
 		}
 	}
-	elog.Printf("Processed %d entries in total", count)
+	elog.Printf("Processed %d entries in %d loops", len(wb), loops)
 
 	elog.Printf("Removing fid: %d", f.fid)
 	var deleteFileNow bool
@@ -452,127 +424,6 @@ func (vlog *valueLog) deleteLogFile(lf *logFile) error {
 		return err
 	}
 	return os.Remove(path)
-}
-
-// Entry provides Key, Value and if required, CASCounterCheck to kv.BatchSet() API.
-// If CASCounterCheck is provided, it would be compared against the current casCounter
-// assigned to this key-value. Set be done on this key only if the counters match.
-type Entry struct {
-	Key             []byte
-	Meta            byte
-	UserMeta        byte
-	Value           []byte
-	CASCounterCheck uint64 // If nonzero, we will check if existing casCounter matches.
-	Error           error  // Error if any.
-
-	// Fields maintained internally.
-	offset     uint32
-	casCounter uint64
-}
-
-// Encodes e to buf. Returns number of bytes written.
-func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
-	var h header
-	h.klen = uint32(len(e.Key))
-	h.vlen = uint32(len(e.Value))
-	h.meta = e.Meta
-	h.userMeta = e.UserMeta
-	h.casCounter = e.casCounter
-	h.casCounterCheck = e.CASCounterCheck
-
-	var headerEnc [headerBufSize]byte
-	h.Encode(headerEnc[:])
-
-	hash := crc32.New(y.CastagnoliCrcTable)
-
-	buf.Write(headerEnc[:])
-	hash.Write(headerEnc[:])
-
-	buf.Write(e.Key)
-	hash.Write(e.Key)
-
-	buf.Write(e.Value)
-	hash.Write(e.Value)
-
-	var crcBuf [4]byte
-	binary.BigEndian.PutUint32(crcBuf[:], hash.Sum32())
-	buf.Write(crcBuf[:])
-
-	return len(headerEnc) + len(e.Key) + len(e.Value) + len(crcBuf), nil
-}
-
-func (e Entry) print(prefix string) {
-	fmt.Printf("%s Key: %s Meta: %d UserMeta: %d Offset: %d len(val)=%d cas=%d check=%d\n",
-		prefix, e.Key, e.Meta, e.UserMeta, e.offset, len(e.Value), e.casCounter, e.CASCounterCheck)
-}
-
-type header struct {
-	klen            uint32
-	vlen            uint32
-	meta            byte
-	userMeta        byte
-	casCounter      uint64
-	casCounterCheck uint64
-}
-
-const (
-	headerBufSize = 26
-)
-
-func (h header) Encode(out []byte) {
-	y.AssertTrue(len(out) >= headerBufSize)
-	binary.BigEndian.PutUint32(out[0:4], h.klen)
-	binary.BigEndian.PutUint32(out[4:8], h.vlen)
-	out[8] = h.meta
-	out[9] = h.userMeta
-	binary.BigEndian.PutUint64(out[10:18], h.casCounter)
-	binary.BigEndian.PutUint64(out[18:26], h.casCounterCheck)
-}
-
-// Decodes h from buf.
-func (h *header) Decode(buf []byte) {
-	h.klen = binary.BigEndian.Uint32(buf[0:4])
-	h.vlen = binary.BigEndian.Uint32(buf[4:8])
-	h.meta = buf[8]
-	h.userMeta = buf[9]
-	h.casCounter = binary.BigEndian.Uint64(buf[10:18])
-	h.casCounterCheck = binary.BigEndian.Uint64(buf[18:26])
-}
-
-type valuePointer struct {
-	Fid    uint32
-	Len    uint32
-	Offset uint32
-}
-
-func (p valuePointer) Less(o valuePointer) bool {
-	if p.Fid != o.Fid {
-		return p.Fid < o.Fid
-	}
-	if p.Offset != o.Offset {
-		return p.Offset < o.Offset
-	}
-	return p.Len < o.Len
-}
-
-func (p valuePointer) IsZero() bool {
-	return p.Fid == 0 && p.Offset == 0 && p.Len == 0
-}
-
-const valuePointerEncodedSize = 12
-
-// Encode encodes Pointer into byte buffer.
-func (p valuePointer) Encode(b []byte) []byte {
-	binary.BigEndian.PutUint32(b[:4], p.Fid)
-	binary.BigEndian.PutUint32(b[4:8], p.Len)
-	binary.BigEndian.PutUint32(b[8:valuePointerEncodedSize], p.Offset)
-	return b[:valuePointerEncodedSize]
-}
-
-func (p *valuePointer) Decode(b []byte) {
-	p.Fid = binary.BigEndian.Uint32(b[:4])
-	p.Len = binary.BigEndian.Uint32(b[4:8])
-	p.Offset = binary.BigEndian.Uint32(b[8:valuePointerEncodedSize])
 }
 
 type valueLog struct {
@@ -952,8 +803,6 @@ func valueBytesToEntry(buf []byte) (e Entry) {
 	n += h.klen
 	e.Meta = h.meta
 	e.UserMeta = h.userMeta
-	e.casCounter = h.casCounter
-	e.CASCounterCheck = h.casCounterCheck
 	e.Value = buf[n : n+h.vlen]
 	return
 }
@@ -971,6 +820,26 @@ func (vlog *valueLog) pickLog() *logFile {
 		idx = rand.Intn(idx) // Another level of rand to favor smaller fids.
 	}
 	return vlog.filesMap[fids[idx]]
+}
+
+func discardEntry(e Entry, vs y.ValueStruct) bool {
+	if vs.Version != y.ParseTs(e.Key) {
+		// Version not found. Discard.
+		return true
+	}
+	if (vs.Meta & BitDelete) > 0 {
+		// Key deleted. Discard.
+		return true
+	}
+	if (vs.Meta & BitValuePointer) == 0 {
+		// Key also stores the value in LSM. Discard.
+		return true
+	}
+	if (vs.Meta & BitFinTxn) > 0 {
+		// Just a txn finish entry. Discard.
+		return true
+	}
+	return false
 }
 
 func (vlog *valueLog) doRunGC(gcThreshold float64) error {
@@ -1018,20 +887,13 @@ func (vlog *valueLog) doRunGC(gcThreshold float64) error {
 		if err != nil {
 			return err
 		}
-		if (vs.Meta & BitDelete) > 0 {
-			// Key has been deleted. Discard.
-			r.discard += esz
-			return nil
-		}
-		if (vs.Meta & BitValuePointer) == 0 {
-			// Value is stored alongside key. Discard.
+		if discardEntry(e, vs) {
 			r.discard += esz
 			return nil
 		}
 
 		// Value is still present in value log.
 		y.AssertTrue(len(vs.Value) > 0)
-
 		vp.Decode(vs.Value)
 
 		if vp.Fid > lf.fid {
@@ -1054,13 +916,10 @@ func (vlog *valueLog) doRunGC(gcThreshold float64) error {
 			err := vlog.readValueBytes(vp, func(buf []byte) error {
 				ne := valueBytesToEntry(buf)
 				ne.offset = vp.Offset
-				if ne.casCounter == e.casCounter {
-					ne.print("Latest Entry Header in LSM")
-					e.print("Latest Entry in Log")
-					return errors.Errorf("This shouldn't happen. Latest Pointer:%+v. Meta:%v.",
-						vp, vs.Meta)
-				}
-				return nil
+				ne.print("Latest Entry Header in LSM")
+				e.print("Latest Entry in Log")
+				return errors.Errorf("This shouldn't happen. Latest Pointer:%+v. Meta:%v.",
+					vp, vs.Meta)
 			})
 			if err != nil {
 				return errStop

--- a/value_test.go
+++ b/value_test.go
@@ -117,7 +117,7 @@ func TestValueGC(t *testing.T) {
 			Value: v,
 		})
 	}
-	kv.BatchSet(entries)
+	kv.batchSet(entries)
 	for _, e := range entries {
 		require.NoError(t, e.Error, "entry with error: %+v", e)
 	}

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -19,7 +19,6 @@ package y
 import (
 	"bytes"
 	"container/heap"
-	"encoding/binary"
 
 	"github.com/pkg/errors"
 )
@@ -27,49 +26,31 @@ import (
 // ValueStruct represents the value info that can be associated with a key, but also the internal
 // Meta field.
 type ValueStruct struct {
-	Value      []byte
-	Meta       byte
-	UserMeta   byte
-	CASCounter uint64
-}
+	Meta     byte
+	UserMeta byte
+	Value    []byte
 
-// MakeValueStruct is the most convenient way for unit tests to make a ValueStruct.  (Also, the
-// code will break if we add another field.)
-func MakeValueStruct(value []byte, meta byte, userMeta byte, casCounter uint64) ValueStruct {
-	return ValueStruct{Value: value, Meta: meta, UserMeta: userMeta, CASCounter: casCounter}
+	Version uint64 // This field is not serialized. Only for internal usage.
 }
 
 // EncodedSize is the size of the ValueStruct when encoded
 func (v *ValueStruct) EncodedSize() int {
-	return len(v.Value) + valueValueOffset
+	return len(v.Value) + 2
 }
 
-// ValueStructSerializedSize converts a value size to the full serialized size of value + metadata.
-func ValueStructSerializedSize(size uint16) int {
-	return int(size) + valueValueOffset
-}
-
-const (
-	valueMetaOffset     = 0
-	valueUserMetaOffset = valueMetaOffset + MetaSize
-	valueCasOffset      = valueUserMetaOffset + UserMetaSize
-	valueValueOffset    = valueCasOffset + CasSize
-)
-
-// DecodeEntireSlice uses the length of the slice to infer the length of the Value field.
-func (v *ValueStruct) DecodeEntireSlice(b []byte) {
-	v.Value = b[valueValueOffset:]
-	v.Meta = b[valueMetaOffset]
-	v.UserMeta = b[valueUserMetaOffset]
-	v.CASCounter = binary.BigEndian.Uint64(b[valueCasOffset : valueCasOffset+CasSize])
+// Decode uses the length of the slice to infer the length of the Value field.
+func (v *ValueStruct) Decode(b []byte) {
+	v.Meta = b[0]
+	v.UserMeta = b[1]
+	v.Value = b[2:]
 }
 
 // Encode expects a slice of length at least v.EncodedSize().
+// TODO: Who calls this?
 func (v *ValueStruct) Encode(b []byte) {
-	b[valueMetaOffset] = v.Meta
-	b[valueUserMetaOffset] = v.UserMeta
-	binary.BigEndian.PutUint64(b[valueCasOffset:valueCasOffset+CasSize], v.CASCounter)
-	copy(b[valueValueOffset:valueValueOffset+len(v.Value)], v.Value)
+	b[0] = v.Meta
+	b[1] = v.UserMeta
+	copy(b[2:], v.Value)
 }
 
 // Iterator is an interface for a basic iterator.

--- a/y/y.go
+++ b/y/y.go
@@ -27,13 +27,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Constants used in serialization sizes, and in ValueStruct serialization
-const (
-	MetaSize     = 1
-	UserMetaSize = 1
-	CasSize      = 8
-)
-
 // ErrEOF indicates an end of file when trying to read from a memory mapped file
 // and encountering the end of slice.
 var ErrEOF = errors.New("End of mapped region")


### PR DESCRIPTION
- Move all errors into a new file: errors.go.
- Remove all public APIs from kv.go. All the public APIs now flow through transactions.
- Remove SetIfAbsent, CompareAndSet, etc. They should all be done via transactions now.
- Remove CAS counter from everywhere.
- Simplify serialization/deserialization of various structs.
- Move them into new structs.go file (currently only contains value.go structs).
- Logic to handle transaction boundaries when replaying value log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/249)
<!-- Reviewable:end -->
