### PR TITLE
Managed Transactions

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -22,43 +22,31 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrInvalidDir is returned when Badger cannot find the directory
-// from where it is supposed to load the key-value store.
-var ErrInvalidDir = errors.New("Invalid Dir, directory does not exist")
-
-// ErrValueLogSize is returned when opt.ValueLogFileSize option is not within the valid
-// range.
-var ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 2GB")
-
-// ErrKeyNotFound is returned when key isn't found on a txn.Get.
-var ErrKeyNotFound = errors.New("Key not found")
-
-// ErrTxnTooBig is returned if too many writes are fit into a single transaction.
-var ErrTxnTooBig = errors.New("Txn is too big to fit into one request.")
-
-// ErrConflict is returned when a transaction conflicts with another transaction. This can happen if
-// the read rows had been updated concurrently by another transaction.
-var ErrConflict = errors.New("Transaction Conflict. Please retry.")
-
-// ErrReadOnlyTxn is returned if an update function is called on a read-only transaction.
-var ErrReadOnlyTxn = errors.New("No sets or deletes are allowed in a read-only transaction.")
-
-// ErrEmptyKey is returned if an empty key is passed on an update function.
-var ErrEmptyKey = errors.New("Key cannot be empty.")
-
-const maxKeySize = 1 << 20
-
-func exceedsMaxKeySizeError(key []byte) error {
-	return errors.Errorf("Key with size %d exceeded %dMB limit. Key:\n%s",
-		len(key), maxKeySize<<20, hex.Dump(key[:1<<10]))
-}
-
-func exceedsMaxValueSizeError(value []byte, maxValueSize int64) error {
-	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMB). Key:\n%s",
-		len(value), maxValueSize<<20, hex.Dump(value[:1<<10]))
-}
-
 var (
+	// ErrInvalidDir is returned when Badger cannot find the directory
+	// from where it is supposed to load the key-value store.
+	ErrInvalidDir = errors.New("Invalid Dir, directory does not exist")
+
+	// ErrValueLogSize is returned when opt.ValueLogFileSize option is not within the valid
+	// range.
+	ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 2GB")
+
+	// ErrKeyNotFound is returned when key isn't found on a txn.Get.
+	ErrKeyNotFound = errors.New("Key not found")
+
+	// ErrTxnTooBig is returned if too many writes are fit into a single transaction.
+	ErrTxnTooBig = errors.New("Txn is too big to fit into one request.")
+
+	// ErrConflict is returned when a transaction conflicts with another transaction. This can happen if
+	// the read rows had been updated concurrently by another transaction.
+	ErrConflict = errors.New("Transaction Conflict. Please retry.")
+
+	// ErrReadOnlyTxn is returned if an update function is called on a read-only transaction.
+	ErrReadOnlyTxn = errors.New("No sets or deletes are allowed in a read-only transaction.")
+
+	// ErrEmptyKey is returned if an empty key is passed on an update function.
+	ErrEmptyKey = errors.New("Key cannot be empty.")
+
 	// ErrRetry is returned when a log file containing the value is not found.
 	// This usually indicates that it may have been garbage collected, and the
 	// operation needs to be retried.
@@ -80,3 +68,15 @@ var (
 	// ErrInvalidRequest is returned if the user request is invalid.
 	ErrInvalidRequest = errors.New("Invalid request")
 )
+
+const maxKeySize = 1 << 20
+
+func exceedsMaxKeySizeError(key []byte) error {
+	return errors.Errorf("Key with size %d exceeded %dMB limit. Key:\n%s",
+		len(key), maxKeySize<<20, hex.Dump(key[:1<<10]))
+}
+
+func exceedsMaxValueSizeError(value []byte, maxValueSize int64) error {
+	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMB). Key:\n%s",
+		len(value), maxValueSize<<20, hex.Dump(value[:1<<10]))
+}

--- a/kv.go
+++ b/kv.go
@@ -217,7 +217,7 @@ func NewKV(optParam *Options) (out *KV, err error) {
 	}
 
 	first := true
-	fn := func(e Entry, vp valuePointer) error { // Function for replaying.
+	fn := func(e entry, vp valuePointer) error { // Function for replaying.
 		if first {
 			out.elog.Printf("First key=%s\n", e.Key)
 		}
@@ -503,7 +503,7 @@ var requestPool = sync.Pool{
 	},
 }
 
-func (s *KV) shouldWriteValueToLSM(e Entry) bool {
+func (s *KV) shouldWriteValueToLSM(e entry) bool {
 	return len(e.Value) < s.opt.ValueThreshold
 }
 
@@ -646,7 +646,7 @@ func (s *KV) doWrites(lc *y.Closer) {
 	}
 }
 
-func (s *KV) sendToWriteCh(entries []*Entry) (*request, error) {
+func (s *KV) sendToWriteCh(entries []*entry) (*request, error) {
 	var count, size int64
 	for _, e := range entries {
 		size += int64(s.opt.estimateSize(e))
@@ -671,7 +671,7 @@ func (s *KV) sendToWriteCh(entries []*Entry) (*request, error) {
 // batchSet applies a list of badger.Entry. If a request level error occurs it
 // will be returned.
 //   Check(kv.BatchSet(entries))
-func (s *KV) batchSet(entries []*Entry) error {
+func (s *KV) batchSet(entries []*entry) error {
 	req, err := s.sendToWriteCh(entries)
 	if err != nil {
 		return err
@@ -690,7 +690,7 @@ func (s *KV) batchSet(entries []*Entry) error {
 //   err := kv.BatchSetAsync(entries, func(err error)) {
 //      Check(err)
 //   }
-func (s *KV) batchSetAsync(entries []*Entry, f func(error)) error {
+func (s *KV) batchSetAsync(entries []*entry, f func(error)) error {
 	req, err := s.sendToWriteCh(entries)
 	if err != nil {
 		return err

--- a/options.go
+++ b/options.go
@@ -99,6 +99,6 @@ var DefaultOptions = Options{
 	ValueThreshold:   20,
 }
 
-func (opt *Options) estimateSize(entry *Entry) int {
-	return entry.estimateSize(opt.ValueThreshold)
+func (opt *Options) estimateSize(e *entry) int {
+	return e.estimateSize(opt.ValueThreshold)
 }

--- a/structs.go
+++ b/structs.go
@@ -73,10 +73,10 @@ func (h *header) Decode(buf []byte) {
 	h.userMeta = buf[9]
 }
 
-// Entry provides Key, Value and if required, CASCounterCheck to kv.BatchSet() API.
+// entry provides Key, Value and if required, CASCounterCheck to kv.BatchSet() API.
 // If CASCounterCheck is provided, it would be compared against the current casCounter
 // assigned to this key-value. Set be done on this key only if the counters match.
-type Entry struct {
+type entry struct {
 	Key      []byte
 	Value    []byte
 	Meta     byte
@@ -86,7 +86,7 @@ type Entry struct {
 	offset uint32
 }
 
-func (e *Entry) estimateSize(threshold int) int {
+func (e *entry) estimateSize(threshold int) int {
 	if len(e.Value) < threshold {
 		return len(e.Key) + len(e.Value) + 2 // Meta, UserMeta
 	}
@@ -94,7 +94,7 @@ func (e *Entry) estimateSize(threshold int) int {
 }
 
 // Encodes e to buf. Returns number of bytes written.
-func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
+func encodeEntry(e *entry, buf *bytes.Buffer) (int, error) {
 	var h header
 	h.klen = uint32(len(e.Key))
 	h.vlen = uint32(len(e.Value))
@@ -122,7 +122,7 @@ func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 	return len(headerEnc) + len(e.Key) + len(e.Value) + len(crcBuf), nil
 }
 
-func (e Entry) print(prefix string) {
+func (e entry) print(prefix string) {
 	fmt.Printf("%s Key: %s Meta: %d UserMeta: %d Offset: %d len(val)=%d",
 		prefix, e.Key, e.Meta, e.UserMeta, e.offset, len(e.Value))
 }

--- a/transaction.go
+++ b/transaction.go
@@ -147,7 +147,7 @@ type Txn struct {
 	reads  []uint64 // contains fingerprints of keys read.
 	writes []uint64 // contains fingerprints of keys written.
 
-	pendingWrites map[string]*Entry // cache stores any writes done by txn.
+	pendingWrites map[string]*entry // cache stores any writes done by txn.
 
 	gs *globalTxnState
 	kv *KV
@@ -174,7 +174,7 @@ func (txn *Txn) Set(key, val []byte, userMeta byte) error {
 	fp := farm.Fingerprint64(key) // Avoid dealing with byte arrays.
 	txn.writes = append(txn.writes, fp)
 
-	e := &Entry{
+	e := &entry{
 		Key:      key,
 		Value:    val,
 		UserMeta: userMeta,
@@ -198,7 +198,7 @@ func (txn *Txn) Delete(key []byte) error {
 	fp := farm.Fingerprint64(key) // Avoid dealing with byte arrays.
 	txn.writes = append(txn.writes, fp)
 
-	e := &Entry{
+	e := &entry{
 		Key:  key,
 		Meta: BitDelete,
 	}
@@ -270,7 +270,7 @@ func (txn *Txn) Commit(callback func(error)) error {
 	}
 	defer txn.gs.doneCommit(commitTs)
 
-	entries := make([]*Entry, 0, len(txn.pendingWrites)+1)
+	entries := make([]*entry, 0, len(txn.pendingWrites)+1)
 	for _, e := range txn.pendingWrites {
 		// Suffix the keys with commit ts, so the key versions are sorted in
 		// descending order of commit timestamp.
@@ -278,12 +278,12 @@ func (txn *Txn) Commit(callback func(error)) error {
 		e.Meta |= BitTxn
 		entries = append(entries, e)
 	}
-	entry := &Entry{
+	e := &entry{
 		Key:   y.KeyWithTs(txnKey, commitTs),
 		Value: []byte(strconv.FormatUint(commitTs, 10)),
 		Meta:  BitFinTxn,
 	}
-	entries = append(entries, entry)
+	entries = append(entries, e)
 
 	if callback == nil {
 		// If batchSet failed, LSM would not have been updated. So, no need to rollback anything.
@@ -347,7 +347,7 @@ func (kv *KV) NewTransaction(update bool) *Txn {
 		readTs: kv.txnState.readTs(),
 	}
 	if update {
-		txn.pendingWrites = make(map[string]*Entry)
+		txn.pendingWrites = make(map[string]*entry)
 	}
 
 	return txn

--- a/transaction.go
+++ b/transaction.go
@@ -339,7 +339,7 @@ func (txn *Txn) NewIterator(opt IteratorOptions) *Iterator {
 	return res
 }
 
-func (kv *KV) NewTxn(update bool) *Txn {
+func (kv *KV) NewTransaction(update bool) *Txn {
 	txn := &Txn{
 		update: update,
 		gs:     kv.txnState,
@@ -353,8 +353,8 @@ func (kv *KV) NewTxn(update bool) *Txn {
 	return txn
 }
 
-func (kv *KV) NewTxnAt(readTs uint64, update bool) *Txn {
-	txn := kv.NewTxn(update)
+func (kv *KV) NewTransactionAt(readTs uint64, update bool) *Txn {
+	txn := kv.NewTransaction(update)
 	txn.readTs = readTs
 	return txn
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -34,8 +34,7 @@ func TestTxnSimple(t *testing.T) {
 	require.NoError(t, err)
 	defer kv.Close()
 
-	txn, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(true)
 
 	for i := 0; i < 10; i++ {
 		k := []byte(fmt.Sprintf("key=%d", i))
@@ -63,8 +62,7 @@ func TestTxnVersions(t *testing.T) {
 
 	k := []byte("key")
 	for i := 1; i < 10; i++ {
-		txn, err := kv.NewTransaction(true)
-		require.NoError(t, err)
+		txn := kv.NewTransaction(true)
 
 		txn.Set(k, []byte(fmt.Sprintf("valversion=%d", i)), 0)
 		require.NoError(t, txn.Commit(nil))
@@ -89,7 +87,7 @@ func TestTxnVersions(t *testing.T) {
 	}
 
 	for i := 1; i < 10; i++ {
-		txn, err := kv.NewTransaction(true)
+		txn := kv.NewTransaction(true)
 		require.NoError(t, err)
 		txn.readTs = uint64(i) // Read version at i.
 
@@ -114,7 +112,7 @@ func TestTxnVersions(t *testing.T) {
 		itr = txn.NewIterator(opt)
 		checkIterator(itr, i)
 	}
-	txn, err := kv.NewTransaction(true)
+	txn := kv.NewTransaction(true)
 	require.NoError(t, err)
 	item, err := txn.Get(k)
 	require.NoError(t, err)
@@ -138,8 +136,7 @@ func TestTxnWriteSkew(t *testing.T) {
 	ay := []byte("y")
 
 	// Set balance to $100 in each account.
-	txn, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(true)
 	val := []byte(strconv.Itoa(100))
 	txn.Set(ax, val, 0)
 	txn.Set(ay, val, 0)
@@ -160,8 +157,7 @@ func TestTxnWriteSkew(t *testing.T) {
 	}
 
 	// Start two transactions, each would read both accounts and deduct from one account.
-	txn1, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn1 := kv.NewTransaction(true)
 
 	sum := getBal(txn1, ax)
 	sum += getBal(txn1, ay)
@@ -175,8 +171,7 @@ func TestTxnWriteSkew(t *testing.T) {
 	require.Equal(t, 100, sum)
 	// Don't commit yet.
 
-	txn2, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn2 := kv.NewTransaction(true)
 
 	sum = getBal(txn2, ax)
 	sum += getBal(txn2, ay)
@@ -214,31 +209,27 @@ func TestTxnIterationEdgeCase(t *testing.T) {
 	kc := []byte("c")
 
 	// c1
-	txn, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(true)
 	txn.Set(kc, []byte("c1"), 0)
 	require.NoError(t, txn.Commit(nil))
 	require.Equal(t, uint64(1), kv.txnState.readTs())
 
 	// a2, c2
-	txn, err = kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn = kv.NewTransaction(true)
 	txn.Set(ka, []byte("a2"), 0)
 	txn.Set(kc, []byte("c2"), 0)
 	require.NoError(t, txn.Commit(nil))
 	require.Equal(t, uint64(2), kv.txnState.readTs())
 
 	// b3
-	txn, err = kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn = kv.NewTransaction(true)
 	txn.Set(ka, []byte("a3"), 0)
 	txn.Set(kb, []byte("b3"), 0)
 	require.NoError(t, txn.Commit(nil))
 	require.Equal(t, uint64(3), kv.txnState.readTs())
 
 	// b4 (del)
-	txn, err = kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn = kv.NewTransaction(true)
 	txn.Delete(kb)
 	require.NoError(t, txn.Commit(nil))
 	require.Equal(t, uint64(4), kv.txnState.readTs())
@@ -256,8 +247,7 @@ func TestTxnIterationEdgeCase(t *testing.T) {
 		}
 		require.Equal(t, len(expected), i)
 	}
-	txn, err = kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn = kv.NewTransaction(true)
 	itr := txn.NewIterator(DefaultIteratorOptions)
 	checkIterator(itr, []string{"a3", "c2"})
 

--- a/value_test.go
+++ b/value_test.go
@@ -43,19 +43,19 @@ func TestValueBasic(t *testing.T) {
 	const val2 = "samplevalb012345678901234567890123"
 	require.True(t, len(val1) >= kv.opt.ValueThreshold)
 
-	entry := &Entry{
+	e := &entry{
 		Key:   []byte("samplekey"),
 		Value: []byte(val1),
 		Meta:  BitValuePointer,
 	}
-	entry2 := &Entry{
+	e2 := &entry{
 		Key:   []byte("samplekeyb"),
 		Value: []byte(val2),
 		Meta:  BitValuePointer,
 	}
 
 	b := new(request)
-	b.Entries = []*Entry{entry, entry2}
+	b.Entries = []*entry{e, e2}
 
 	log.write([]*request{b})
 	require.Len(t, b.Ptrs, 2)
@@ -74,8 +74,8 @@ func TestValueBasic(t *testing.T) {
 
 	require.NoError(t, err1)
 	require.NoError(t, err2)
-	readEntries := []Entry{valueBytesToEntry(buf1), valueBytesToEntry(buf2)}
-	require.EqualValues(t, []Entry{
+	readEntries := []entry{valueBytesToEntry(buf1), valueBytesToEntry(buf2)}
+	require.EqualValues(t, []entry{
 		{
 			Key:   []byte("samplekey"),
 			Value: []byte(val1),
@@ -302,7 +302,7 @@ func TestChecksums(t *testing.T) {
 	require.True(t, len(v0) >= kv.opt.ValueThreshold)
 
 	// Use a vlog with K0=V0 and a (corrupted) second transaction(k1,k2)
-	buf := createVlog(t, []*Entry{
+	buf := createVlog(t, []*entry{
 		{Key: k0, Value: v0},
 		{Key: k1, Value: v1},
 		{Key: k2, Value: v2},
@@ -371,7 +371,7 @@ func TestPartialAppendToValueLog(t *testing.T) {
 
 	// Create truncated vlog to simulate a partial append.
 	// k0 - single transaction, k1 and k2 in another transaction
-	buf := createVlog(t, []*Entry{
+	buf := createVlog(t, []*entry{
 		{Key: k0, Value: v0},
 		{Key: k1, Value: v1},
 		{Key: k2, Value: v2},
@@ -446,7 +446,7 @@ func TestValueLogTrigger(t *testing.T) {
 	require.Equal(t, ErrRejected, err, "Error should be returned after closing KV.")
 }
 
-func createVlog(t *testing.T, entries []*Entry) []byte {
+func createVlog(t *testing.T, entries []*entry) []byte {
 	dir, err := ioutil.TempDir("", "badger")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -502,11 +502,11 @@ func BenchmarkReadWrite(b *testing.B) {
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {
-					e := new(Entry)
+					e := new(entry)
 					e.Key = make([]byte, 16)
 					e.Value = make([]byte, vsz)
 					bl := new(request)
-					bl.Entries = []*Entry{e}
+					bl.Entries = []*entry{e}
 
 					var ptrs []valuePointer
 

--- a/value_test.go
+++ b/value_test.go
@@ -59,7 +59,7 @@ func TestValueBasic(t *testing.T) {
 
 	log.write([]*request{b})
 	require.Len(t, b.Ptrs, 2)
-	fmt.Printf("Pointer written: %+v %+v\n", b.Ptrs[0], b.Ptrs[1])
+	t.Logf("Pointer written: %+v %+v\n", b.Ptrs[0], b.Ptrs[1])
 
 	var buf1, buf2 []byte
 	var err1, err2 error
@@ -100,16 +100,14 @@ func TestValueGC(t *testing.T) {
 	defer kv.Close()
 
 	sz := 32 << 10
-	txn, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(true)
 	for i := 0; i < 100; i++ {
 		v := make([]byte, sz)
 		rand.Read(v[:rand.Intn(sz)])
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v, 0))
 		if i%20 == 0 {
 			require.NoError(t, txn.Commit(nil))
-			txn, err = kv.NewTransaction(true)
-			require.NoError(t, err)
+			txn = kv.NewTransaction(true)
 		}
 	}
 	require.NoError(t, txn.Commit(nil))
@@ -149,16 +147,14 @@ func TestValueGC2(t *testing.T) {
 	defer kv.Close()
 
 	sz := 32 << 10
-	txn, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(true)
 	for i := 0; i < 100; i++ {
 		v := make([]byte, sz)
 		rand.Read(v[:rand.Intn(sz)])
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v, 0))
 		if i%20 == 0 {
 			require.NoError(t, txn.Commit(nil))
-			txn, err = kv.NewTransaction(true)
-			require.NoError(t, err)
+			txn = kv.NewTransaction(true)
 		}
 	}
 	require.NoError(t, txn.Commit(nil))
@@ -221,8 +217,7 @@ func TestValueGC3(t *testing.T) {
 	valueSize := 32 << 10
 
 	var value3 []byte
-	txn, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(true)
 	for i := 0; i < 100; i++ {
 		v := make([]byte, valueSize) // 32K * 100 will take >=3'276'800 B.
 		if i == 3 {
@@ -233,8 +228,7 @@ func TestValueGC3(t *testing.T) {
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%03d", i)), v, 0))
 		if i%20 == 0 {
 			require.NoError(t, txn.Commit(nil))
-			txn, err = kv.NewTransaction(true)
-			require.NoError(t, err)
+			txn = kv.NewTransaction(true)
 		}
 	}
 	require.NoError(t, txn.Commit(nil))
@@ -246,8 +240,7 @@ func TestValueGC3(t *testing.T) {
 		Reverse:        false,
 	}
 
-	txn, err = kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn = kv.NewTransaction(true)
 	it := txn.NewIterator(itOpt)
 	defer it.Close()
 	// Walk a few keys
@@ -335,8 +328,7 @@ func TestChecksums(t *testing.T) {
 	// last due to checksum failure).
 	kv, err = NewKV(opts)
 	require.NoError(t, err)
-	txn, err := kv.NewTransaction(false)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(false)
 	iter := txn.NewIterator(DefaultIteratorOptions)
 	iter.Seek(k0)
 	require.True(t, iter.Valid())
@@ -419,16 +411,14 @@ func TestValueLogTrigger(t *testing.T) {
 
 	// Write a lot of data, so it creates some work for valug log GC.
 	sz := 32 << 10
-	txn, err := kv.NewTransaction(true)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(true)
 	for i := 0; i < 100; i++ {
 		v := make([]byte, sz)
 		rand.Read(v[:rand.Intn(sz)])
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v, 0))
 		if i%20 == 0 {
 			require.NoError(t, txn.Commit(nil))
-			txn, err = kv.NewTransaction(true)
-			require.NoError(t, err)
+			txn = kv.NewTransaction(true)
 		}
 	}
 	require.NoError(t, txn.Commit(nil))
@@ -467,7 +457,7 @@ func createVlog(t *testing.T, entries []*Entry) []byte {
 	require.NoError(t, err)
 	txnSet(t, kv, entries[0].Key, entries[0].Value, entries[0].Meta)
 	entries = entries[1:]
-	txn, err := kv.NewTransaction(true)
+	txn := kv.NewTransaction(true)
 	for _, entry := range entries {
 		require.NoError(t, txn.Set(entry.Key, entry.Value, entry.Meta))
 	}
@@ -482,8 +472,7 @@ func createVlog(t *testing.T, entries []*Entry) []byte {
 
 func checkKeys(t *testing.T, kv *KV, keys [][]byte) {
 	i := 0
-	txn, err := kv.NewTransaction(false)
-	require.NoError(t, err)
+	txn := kv.NewTransaction(false)
 	iter := txn.NewIterator(IteratorOptions{})
 	for iter.Seek(keys[0]); iter.Valid(); iter.Next() {
 		require.Equal(t, iter.Item().Key(), keys[i])


### PR DESCRIPTION
- Allow a way to specify the read and commit timestamp for a transaction. This would be useful for Dgraph.

Various cleanup:
- Don't return an error while creating a transaction.
- Make Entry struct private, now that BatchSet is no longer public.
- Put all errors in one var block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/252)
<!-- Reviewable:end -->
