### PR TITLE
Transaction: Change Item.Value api

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -45,7 +45,7 @@ var (
 	ErrReadOnlyTxn = errors.New("No sets or deletes are allowed in a read-only transaction.")
 
 	// ErrDiscardedTxn is returned if a previously discarded transaction is re-used.
-	ErrDiscardedTxn = errors.New("This transaction has been discarded. Recreate a new one.")
+	ErrDiscardedTxn = errors.New("This transaction has been discarded. Create a new one.")
 
 	// ErrEmptyKey is returned if an empty key is passed on an update function.
 	ErrEmptyKey = errors.New("Key cannot be empty.")

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,9 @@ var (
 	// ErrReadOnlyTxn is returned if an update function is called on a read-only transaction.
 	ErrReadOnlyTxn = errors.New("No sets or deletes are allowed in a read-only transaction.")
 
+	// ErrDiscardedTxn is returned if a previously discarded transaction is re-used.
+	ErrDiscardedTxn = errors.New("This transaction has been discarded. Recreate a new one.")
+
 	// ErrEmptyKey is returned if an empty key is passed on an update function.
 	ErrEmptyKey = errors.New("Key cannot be empty.")
 

--- a/iterator.go
+++ b/iterator.go
@@ -47,6 +47,7 @@ type KVItem struct {
 	slice    *y.Slice // Used only during prefetching.
 	next     *KVItem
 	version  uint64
+	txn      *Txn
 }
 
 func (item *KVItem) ToString() string {
@@ -72,15 +73,12 @@ func (item *KVItem) Version() uint64 {
 //
 // Remember to parse or copy it if you need to reuse it. DO NOT modify or
 // append to this slice; it would result in a panic.
-func (item *KVItem) Value(consumer func([]byte) error) error {
+func (item *KVItem) Value() ([]byte, error) {
 	item.wg.Wait()
 	if item.status == prefetched {
-		if item.err != nil {
-			return item.err
-		}
-		return consumer(item.val)
+		return item.val, item.err
 	}
-	return item.kv.yieldItemValue(item, consumer)
+	return item.yieldItemValue()
 }
 
 func (item *KVItem) hasValue() bool {
@@ -95,19 +93,37 @@ func (item *KVItem) hasValue() bool {
 	return true
 }
 
-func (item *KVItem) prefetchValue() {
-	item.err = item.kv.yieldItemValue(item, func(val []byte) error {
-		if val == nil {
-			item.status = prefetched
-			return nil
-		}
+func (item *KVItem) yieldItemValue() ([]byte, error) {
+	if !item.hasValue() {
+		return nil, nil
+	}
 
-		buf := item.slice.Resize(len(val))
-		copy(buf, val)
-		item.val = buf
-		item.status = prefetched
-		return nil
-	})
+	if item.slice == nil {
+		item.slice = new(y.Slice)
+	}
+
+	if (item.meta & BitValuePointer) == 0 {
+		val := item.slice.Resize(len(item.vptr))
+		copy(val, item.vptr)
+		return val, nil
+	}
+
+	var vp valuePointer
+	vp.Decode(item.vptr)
+	return item.kv.vlog.Read(vp, item.txn)
+}
+
+func (item *KVItem) prefetchValue() {
+	val, err := item.yieldItemValue()
+	item.err = err
+	item.status = prefetched
+	if val == nil {
+		return
+	}
+	buf := item.slice.Resize(len(val))
+	copy(buf, val)
+	item.val = buf
+	return
 }
 
 // EstimatedSize returns approximate size of the key-value pair.
@@ -133,6 +149,7 @@ func (item *KVItem) UserMeta() byte {
 	return item.userMeta
 }
 
+// TODO: Switch this to use linked list container in Go.
 type list struct {
 	head *KVItem
 	tail *KVItem
@@ -199,7 +216,7 @@ type Iterator struct {
 func (it *Iterator) newItem() *KVItem {
 	item := it.waste.pop()
 	if item == nil {
-		item = &KVItem{slice: new(y.Slice), kv: it.txn.kv}
+		item = &KVItem{slice: new(y.Slice), kv: it.txn.kv, txn: it.txn}
 	}
 	return item
 }

--- a/kv.go
+++ b/kv.go
@@ -440,30 +440,6 @@ func (s *KV) getMemTables() ([]*skl.Skiplist, func()) {
 	}
 }
 
-func (s *KV) yieldItemValue(item *KVItem, consumer func([]byte) error) error {
-	if !item.hasValue() {
-		return consumer(nil)
-	}
-
-	if item.slice == nil {
-		item.slice = new(y.Slice)
-	}
-
-	if (item.meta & BitValuePointer) == 0 {
-		val := item.slice.Resize(len(item.vptr))
-		copy(val, item.vptr)
-		return consumer(val)
-	}
-
-	var vp valuePointer
-	vp.Decode(item.vptr)
-	err := s.vlog.Read(vp, consumer)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // get returns the value in memtable or disk for given key.
 // Note that value will include meta byte.
 func (s *KV) get(key []byte) (y.ValueStruct, error) {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -59,10 +59,13 @@ func TestManifestBasic(t *testing.T) {
 	kv, err := NewKV(opt)
 	require.NoError(t, err)
 
-	item, err := txnGet(t, kv, []byte("testkey"))
-	require.NoError(t, err)
-	require.EqualValues(t, "testval", string(getItemValue(t, &item)))
-	require.EqualValues(t, byte(0x05), item.UserMeta())
+	require.NoError(t, kv.View(func(txn *Txn) error {
+		item, err := txn.Get([]byte("testkey"))
+		require.NoError(t, err)
+		require.EqualValues(t, "testval", string(getItemValue(t, &item)))
+		require.EqualValues(t, byte(0x05), item.UserMeta())
+		return nil
+	}))
 	require.NoError(t, kv.Close())
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -280,8 +280,7 @@ func (txn *Txn) Get(key []byte) (item KVItem, rerr error) {
 }
 
 func (txn *Txn) Discard() {
-	if txn.discarded {
-		// Avoid a re-run.
+	if txn.discarded { // Avoid a re-run.
 		return
 	}
 	txn.discarded = true

--- a/value_test.go
+++ b/value_test.go
@@ -59,10 +59,12 @@ func TestValueBasic(t *testing.T) {
 	require.Len(t, b.Ptrs, 2)
 	t.Logf("Pointer written: %+v %+v\n", b.Ptrs[0], b.Ptrs[1])
 
-	buf1, err1 := log.readValueBytes(b.Ptrs[0], nil)
-	buf2, err2 := log.readValueBytes(b.Ptrs[1], nil)
+	buf1, cb1, err1 := log.readValueBytes(b.Ptrs[0])
+	buf2, cb2, err2 := log.readValueBytes(b.Ptrs[1])
 	require.NoError(t, err1)
 	require.NoError(t, err2)
+	defer runCallback(cb1)
+	defer runCallback(cb2)
 
 	readEntries := []entry{valueBytesToEntry(buf1), valueBytesToEntry(buf2)}
 	require.EqualValues(t, []entry{
@@ -77,6 +79,7 @@ func TestValueBasic(t *testing.T) {
 			Meta:  BitValuePointer,
 		},
 	}, readEntries)
+
 }
 
 func TestValueGC(t *testing.T) {
@@ -118,11 +121,15 @@ func TestValueGC(t *testing.T) {
 	kv.vlog.rewrite(lf)
 	for i := 45; i < 100; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
-		item, err := txnGet(t, kv, key)
-		require.NoError(t, err)
-		val := getItemValue(t, &item)
-		require.NotNil(t, val)
-		require.True(t, len(val) == sz, "Size found: %d", len(val))
+
+		require.NoError(t, kv.View(func(txn *Txn) error {
+			item, err := txn.Get(key)
+			require.NoError(t, err)
+			val := getItemValue(t, &item)
+			require.NotNil(t, val)
+			require.True(t, len(val) == sz, "Size found: %d", len(val))
+			return nil
+		}))
 	}
 }
 
@@ -170,24 +177,33 @@ func TestValueGC2(t *testing.T) {
 	kv.vlog.rewrite(lf)
 	for i := 0; i < 5; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
-		_, err := txnGet(t, kv, key)
-		require.Error(t, ErrKeyNotFound, err)
+		require.NoError(t, kv.View(func(txn *Txn) error {
+			_, err := txn.Get(key)
+			require.Error(t, ErrKeyNotFound, err)
+			return nil
+		}))
 	}
 	for i := 5; i < 10; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
-		item, err := txnGet(t, kv, key)
-		require.NoError(t, err)
-		val := getItemValue(t, &item)
-		require.NotNil(t, val)
-		require.Equal(t, string(val), fmt.Sprintf("value%d", i))
+		require.NoError(t, kv.View(func(txn *Txn) error {
+			item, err := txn.Get(key)
+			require.NoError(t, err)
+			val := getItemValue(t, &item)
+			require.NotNil(t, val)
+			require.Equal(t, string(val), fmt.Sprintf("value%d", i))
+			return nil
+		}))
 	}
 	for i := 10; i < 100; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
-		item, err := txnGet(t, kv, key)
-		require.NoError(t, err)
-		val := getItemValue(t, &item)
-		require.NotNil(t, val)
-		require.True(t, len(val) == sz, "Size found: %d", len(val))
+		require.NoError(t, kv.View(func(txn *Txn) error {
+			item, err := txn.Get(key)
+			require.NoError(t, err)
+			val := getItemValue(t, &item)
+			require.NotNil(t, val)
+			require.True(t, len(val) == sz, "Size found: %d", len(val))
+			return nil
+		}))
 	}
 }
 
@@ -314,16 +330,22 @@ func TestValueGC4(t *testing.T) {
 
 	for i := 0; i < 8; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
-		_, err := txnGet(t, kv, key)
-		require.Error(t, ErrKeyNotFound, err)
+		require.NoError(t, kv.View(func(txn *Txn) error {
+			_, err := txn.Get(key)
+			require.Equal(t, ErrKeyNotFound, err)
+			return nil
+		}))
 	}
 	for i := 8; i < 16; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
-		item, err := txnGet(t, kv, key)
-		require.NoError(t, err)
-		val := getItemValue(t, &item)
-		require.NotNil(t, val)
-		require.Equal(t, string(val), fmt.Sprintf("value%d", i))
+		require.NoError(t, kv.View(func(txn *Txn) error {
+			item, err := txn.Get(key)
+			require.NoError(t, err)
+			val := getItemValue(t, &item)
+			require.NotNil(t, val)
+			require.Equal(t, string(val), fmt.Sprintf("value%d", i))
+			return nil
+		}))
 	}
 }
 
@@ -364,13 +386,20 @@ func TestChecksums(t *testing.T) {
 	// K1 should exist, but K2 shouldn't.
 	kv, err = NewKV(opts)
 	require.NoError(t, err)
-	item, err := txnGet(t, kv, k0)
-	require.NoError(t, err)
-	require.Equal(t, getItemValue(t, &item), v0)
-	_, err = txnGet(t, kv, k1)
-	require.Error(t, ErrKeyNotFound, err)
-	_, err = txnGet(t, kv, k2)
-	require.Error(t, ErrKeyNotFound, err)
+
+	require.NoError(t, kv.View(func(txn *Txn) error {
+		item, err := txn.Get(k0)
+		require.NoError(t, err)
+		require.Equal(t, getItemValue(t, &item), v0)
+
+		_, err = txn.Get(k1)
+		require.Error(t, ErrKeyNotFound, err)
+
+		_, err = txn.Get(k2)
+		require.Error(t, ErrKeyNotFound, err)
+		return nil
+	}))
+
 	// Write K3 at the end of the vlog.
 	txnSet(t, kv, k3, v3, 0)
 	require.NoError(t, kv.Close())
@@ -379,19 +408,26 @@ func TestChecksums(t *testing.T) {
 	// last due to checksum failure).
 	kv, err = NewKV(opts)
 	require.NoError(t, err)
-	txn := kv.NewTransaction(false)
-	iter := txn.NewIterator(DefaultIteratorOptions)
-	iter.Seek(k0)
-	require.True(t, iter.Valid())
-	it := iter.Item()
-	require.Equal(t, it.Key(), k0)
-	require.Equal(t, getItemValue(t, it), v0)
-	iter.Next()
-	require.True(t, iter.Valid())
-	it = iter.Item()
-	require.Equal(t, it.Key(), k3)
-	require.Equal(t, getItemValue(t, it), v3)
-	iter.Close()
+
+	{
+		txn := kv.NewTransaction(false)
+
+		iter := txn.NewIterator(DefaultIteratorOptions)
+		iter.Seek(k0)
+		require.True(t, iter.Valid())
+		it := iter.Item()
+		require.Equal(t, it.Key(), k0)
+		require.Equal(t, getItemValue(t, it), v0)
+		iter.Next()
+		require.True(t, iter.Valid())
+		it = iter.Item()
+		require.Equal(t, it.Key(), k3)
+		require.Equal(t, getItemValue(t, it), v3)
+
+		iter.Close()
+		txn.Discard()
+	}
+
 	require.NoError(t, kv.Close())
 }
 
@@ -433,13 +469,18 @@ func TestPartialAppendToValueLog(t *testing.T) {
 	// Badger should now start up
 	kv, err = NewKV(opts)
 	require.NoError(t, err)
-	item, err := txnGet(t, kv, k0)
-	require.NoError(t, err)
-	require.Equal(t, v0, getItemValue(t, &item))
-	_, err = txnGet(t, kv, k1)
-	require.Error(t, ErrKeyNotFound, err)
-	_, err = txnGet(t, kv, k2)
-	require.Error(t, ErrKeyNotFound, err)
+
+	require.NoError(t, kv.View(func(txn *Txn) error {
+		item, err := txn.Get(k0)
+		require.NoError(t, err)
+		require.Equal(t, v0, getItemValue(t, &item))
+
+		_, err = txn.Get(k1)
+		require.Error(t, ErrKeyNotFound, err)
+		_, err = txn.Get(k2)
+		require.Error(t, ErrKeyNotFound, err)
+		return nil
+	}))
 
 	// When K3 is set, it should be persisted after a restart.
 	txnSet(t, kv, k3, v3, 0)
@@ -575,7 +616,7 @@ func BenchmarkReadWrite(b *testing.B) {
 							b.Fatalf("Zero length of ptrs")
 						}
 						idx := rand.Intn(ln)
-						buf, err := vl.readValueBytes(ptrs[idx], nil)
+						buf, cb, err := vl.readValueBytes(ptrs[idx])
 						if err != nil {
 							b.Fatalf("Benchmark Read: %v", err)
 						}
@@ -587,6 +628,7 @@ func BenchmarkReadWrite(b *testing.B) {
 						if len(e.Value) != vsz {
 							b.Fatalf("Value is invalid")
 						}
+						cb()
 					}
 				}
 			})


### PR DESCRIPTION
- Make it so that the value returned is valid during the lifetime of transaction.
- We no longer pass in a function to Value().
- During a long-running iteration with prefetch, the callback to unlock value file log is called as soon as the value is copied over, thus freeing the value log files to do GC etc.
- Without prefetch, or if called item.Value directly, the transaction would store the file unlock callback, and would run it on txn.Discard().
- txn.Discard automatically gets called from txn.Commit, for convenience.
- All read only txns must discard the transaction.
- Provide a View function to make read-only txns easier to be called.
- Error out on txn reuse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/254)
<!-- Reviewable:end -->
