### PR TITLE
Add DB.Update() method.

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -414,3 +414,16 @@ func (db *DB) View(fn func(txn *Txn) error) error {
 
 	return fn(txn)
 }
+
+// Update executes a function, creating and managing a read-write transaction
+// for the user. Error returned by the function is relayed by the Update method.
+func (db *DB) Update(fn func(txn *Txn) error) error {
+	txn := db.NewTransaction(true)
+	defer txn.Discard()
+
+	if err := fn(txn); err != nil {
+		return err
+	}
+
+	return txn.Commit(nil)
+}


### PR DESCRIPTION
We already have a DB.View() method for read-only transactions, so it
makes sense to have a corresponding method for read-write txns.

This method is a convenience wrapper around simple read-write
transactions. We create the transcation, and pass it as an argument to
the func that was passed into the method. We also make sure we
commit/discard the transaction without the caller needing to do it
themselves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/258)
<!-- Reviewable:end -->
