### PR TITLE
Make DB.Open() take a value instead of pointer.

### DIFF
--- a/db.go
+++ b/db.go
@@ -164,9 +164,7 @@ func replayFunction(out *DB) func(entry, valuePointer) error {
 }
 
 // Open returns a new DB object.
-func Open(optParam *Options) (db *DB, err error) {
-	// Make a copy early and fill in maxBatchSize
-	opt := *optParam
+func Open(opt Options) (db *DB, err error) {
 	opt.maxBatchSize = (15 * opt.MaxTableSize) / 100
 	opt.maxBatchCount = opt.maxBatchSize / int64(skl.MaxNodeSize)
 


### PR DESCRIPTION
* Txn.NewIterator() also takes a value, so this makes the API consistent
in terms of options handling.

* Using values instead of pointers might be a little bit safer, because
we don’t have to worry about the options from changing underneath.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/261)
<!-- Reviewable:end -->
