### PR TITLE
Add method to delete older versions of a specific key.

### DIFF
--- a/db.go
+++ b/db.go
@@ -865,6 +865,33 @@ func (db *DB) updateSize(lc *y.Closer) {
 	}
 }
 
+// PurgeVersionsBelow will delete all versions of a key below the specified version
+func (db *DB) PurgeVersionsBelow(key []byte, ts uint64) error {
+	return db.View(func(txn *Txn) error {
+		opts := DefaultIteratorOptions
+		opts.AllVersions = true
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+
+		var entries []*entry
+
+		for it.Seek(key); it.ValidForPrefix(key); it.Next() {
+			item := it.Item()
+			if !bytes.Equal(key, item.Key()) || item.Version() >= ts {
+				continue
+			}
+
+			// Found an older version. Mark for deletion
+			entries = append(entries,
+				&entry{
+					Key:  y.KeyWithTs(key, item.version),
+					Meta: bitDelete,
+				})
+		}
+		return db.batchSet(entries)
+	})
+}
+
 // PurgeOlderVersions deletes older versions of all keys.
 //
 // This function could be called prior to doing garbage collection to clean up

--- a/db_test.go
+++ b/db_test.go
@@ -848,6 +848,63 @@ func TestGetSetRace(t *testing.T) {
 	wg.Wait()
 }
 
+func TestPurgeVersionsBelow(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	db, err := Open(getTestOptions(dir))
+	require.NoError(t, err)
+
+	// Write 4 versions of the same key
+	for i := 0; i < 4; i++ {
+		err = db.Update(func(txn *Txn) error {
+			return txn.Set([]byte("answer"), []byte(fmt.Sprintf("%d", i)), 0)
+		})
+		require.NoError(t, err)
+	}
+
+	opts := DefaultIteratorOptions
+	opts.AllVersions = true
+	opts.PrefetchValues = false
+
+	// Verify that there are 4 versions, and record 3rd version (2nd from top in iteration)
+	var ts uint64
+	db.View(func(txn *Txn) error {
+		it := txn.NewIterator(opts)
+		var count int
+		for it.Rewind(); it.Valid(); it.Next() {
+			count++
+			item := it.Item()
+			if count == 2 {
+				ts = item.Version()
+			}
+			require.Equal(t, []byte("answer"), item.Key())
+		}
+		require.Equal(t, 4, count)
+		return nil
+	})
+
+	// Delete all versions below the 3rd version
+	err = db.PurgeVersionsBelow([]byte("answer"), ts)
+	require.NoError(t, err)
+
+	// Verify that there are only 2 versions left
+	db.View(func(txn *Txn) error {
+		it := txn.NewIterator(opts)
+		var count int
+		for it.Rewind(); it.Valid(); it.Next() {
+			count++
+			item := it.Item()
+			require.True(t, item.Version() >= ts,
+				"item version: %d older than ts: %d",
+				item.Version(), ts)
+			require.Equal(t, []byte("answer"), item.Key())
+		}
+		require.Equal(t, 2, count)
+		return nil
+	})
+}
+
 func TestPurgeOlderVersions(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger")
 	require.NoError(t, err)


### PR DESCRIPTION
Added DB.PurgeKeyVersionsBelow(), which will delete any versions of the
specified key in the store older than the specified version.

Fixes #268

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/270)
<!-- Reviewable:end -->
