### PR TITLE
Fix size in mb in exceed errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -76,10 +76,10 @@ const maxKeySize = 1 << 20
 
 func exceedsMaxKeySizeError(key []byte) error {
 	return errors.Errorf("Key with size %d exceeded %dMB limit. Key:\n%s",
-		len(key), maxKeySize<<20, hex.Dump(key[:1<<10]))
+		len(key), maxKeySize>>20, hex.Dump(key[:1<<10]))
 }
 
 func exceedsMaxValueSizeError(value []byte, maxValueSize int64) error {
 	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMB). Key:\n%s",
-		len(value), maxValueSize<<20, hex.Dump(value[:1<<10]))
+		len(value), maxValueSize>>20, hex.Dump(value[:1<<10]))
 }

--- a/errors.go
+++ b/errors.go
@@ -75,11 +75,11 @@ var (
 const maxKeySize = 1 << 20
 
 func exceedsMaxKeySizeError(key []byte) error {
-	return errors.Errorf("Key with size %d exceeded %dMB limit. Key:\n%s",
+	return errors.Errorf("Key with size %d exceeded %dMiB limit. Key:\n%s",
 		len(key), maxKeySize>>20, hex.Dump(key[:1<<10]))
 }
 
 func exceedsMaxValueSizeError(value []byte, maxValueSize int64) error {
-	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMB). Key:\n%s",
+	return errors.Errorf("Value with size %d exceeded ValueLogFileSize (%dMiB). Key:\n%s",
 		len(value), maxValueSize>>20, hex.Dump(value[:1<<10]))
 }


### PR DESCRIPTION
This is a fix for converting key and value size in exceeding errors from bytes to mebibytes.
Please refer https://en.wikipedia.org/wiki/Mebibyte for mebibyte, not megabyte.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/271)
<!-- Reviewable:end -->
