### PR TITLE
create table with smaller initial buffer size

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -85,8 +85,8 @@ type Builder struct {
 // NewTableBuilder makes a new TableBuilder.
 func NewTableBuilder() *Builder {
 	return &Builder{
-		keyBuf:     newBuffer(32 << 20),
-		buf:        newBuffer(64 << 20),
+		keyBuf:     newBuffer(1 << 20),
+		buf:        newBuffer(1 << 20),
 		prevOffset: math.MaxUint32, // Used for the first element!
 	}
 }


### PR DESCRIPTION
In my case,  I created 100 badger instances, write some data to them, and then close them. Every thing looks good when data writing, but memory usage exploded when DB closing, triggered an oom, I set Options.MaxTableSize to 4MB, but the problem still exists. After profiling, I find the the memory usage comes from calling NewTableBuilder, and the buffer is hard coded to 64MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/281)
<!-- Reviewable:end -->
