### PR TITLE
Introduce ManagedDB struct to perform managed transactions.

### DIFF
--- a/db.go
+++ b/db.go
@@ -222,7 +222,7 @@ func Open(opt Options) (db *DB, err error) {
 	}()
 
 	orc := &oracle{
-		isManaged:      opt.ManagedTxns,
+		isManaged:      opt.managedTxns,
 		nextCommit:     1,
 		pendingCommits: make(map[uint64]struct{}),
 		commits:        make(map[uint64]uint64),

--- a/errors.go
+++ b/errors.go
@@ -71,9 +71,10 @@ var (
 	// ErrInvalidRequest is returned if the user request is invalid.
 	ErrInvalidRequest = errors.New("Invalid request")
 
-	// ErrManagedTxn is returned if the user tries to use an API which isn't allowed due to
-	// external management of transactions.
-	ErrManagedTxn = errors.New("Invalid API request for managed transaction")
+	// ErrManagedTxn is returned if the user tries to use an API which isn't
+	// allowed due toV external management of transactions, when using ManagedDB.
+	ErrManagedTxn = errors.New(
+		"Invalid API request. Not allowed to perform this action using ManagedDB")
 )
 
 const maxKeySize = 1 << 20

--- a/managed_db.go
+++ b/managed_db.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package badger
+
+// ManagedDB allows end users to manage the transactions themselves. Transaction
+// start and commit timestamps are set by end-user.
+//
+// This is only useful for databases built on top of Badger (like Dgraph), and
+// can be ignored by most users.
+//
+// WARNING: This is an experimental feature and may be changed significantly in
+// a future release. So please proceed with caution.
+type ManagedDB struct {
+	*DB
+}
+
+// OpenManaged returns a new ManagedDB, which allows more control over setting
+// transaction timestamps.
+//
+// This is only useful for databases built on top of Badger (like Dgraph), and
+// can be ignored by most users.
+func OpenManaged(opts Options) (*ManagedDB, error) {
+	opts.managedTxns = true
+	db, err := Open(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &ManagedDB{db}, nil
+}
+
+// NewTransaction overrides DB.NewTransaction() and panics when invoked. Use
+// NewTransactionAt() instead.
+func (db *ManagedDB) NewTransaction(update bool) {
+	panic("Cannot use NewTransaction() for ManagedDB. Use NewTransactionAt() instead.")
+}
+
+// NewTransactionAt follows the same logic as DB.NewTransaction(), but uses the
+// provided read timestamp.
+//
+// This is only useful for databases built on top of Badger (like Dgraph), and
+// can be ignored by most users.
+func (db *ManagedDB) NewTransactionAt(readTs uint64, update bool) *Txn {
+	txn := db.DB.NewTransaction(update)
+	txn.readTs = readTs
+	return txn
+}
+
+// CommitAt commits the transaction, following the same logic as Commit(), but
+// at the given commit timestamp. This will panic if not used with ManagedDB.
+//
+// This is only useful for databases built on top of Badger (like Dgraph), and
+// can be ignored by most users.
+func (txn *Txn) CommitAt(commitTs uint64, callback func(error)) error {
+	if !txn.db.opt.managedTxns {
+		panic("CommitAt() can only be used with ManagedDB. Use Commit() instead.")
+	}
+	txn.commitTs = commitTs
+	return txn.Commit(callback)
+}

--- a/options.go
+++ b/options.go
@@ -73,8 +73,9 @@ type Options struct {
 	// Number of compaction workers to run concurrently.
 	NumCompactors int
 
-	// Transaction start and commit timestamps are managed by end-user.
-	ManagedTxns bool
+	// Transaction start and commit timestamps are manaVgedTxns by end-user. This
+	// is a private option used by ManagedDB.
+	managedTxns bool
 
 	// 4. Flags for testing purposes
 	// ------------------------------


### PR DESCRIPTION
This is a bit of a cleanup of #280 (committed as
1d8f9b1e82bcf4ec5e146e5f1672e8ddeab6f548)

* Make ManagedTxns option private, so that it can be set only within the
package.

* Introduce a separate struct ManagedDB, which embeds badger.DB.

* Introduce ManagedDB.NewTransaction() and ManagedDB.NewTransactionAt()
methods.

* Introduce Txn.CommitAt, applicable only to ManageDB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/283)
<!-- Reviewable:end -->
