### PR TITLE
Add CLI for Badger backup and restore.

### DIFF
--- a/cmd/badger/cmd/backup.go
+++ b/cmd/badger/cmd/backup.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/dgraph-io/badger"
+	"github.com/spf13/cobra"
+)
+
+var backupFile string
+
+// backupCmd represents the backup command
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Backup Badger database.",
+	Long: `Backup Badger database to a file in a version-agnostic manner.
+
+Iterates over each key-value pair, encodes it along with its metadata and
+version in protocol buffers and writes them to a file. This file can later be
+used by the restore command to create an identical copy of the
+database.`,
+	RunE: doBackup,
+}
+
+func init() {
+	RootCmd.AddCommand(backupCmd)
+	backupCmd.Flags().StringVarP(&backupFile, "backup-file", "f",
+		"badger.bak", "File to backup to")
+}
+
+func doBackup(cmd *cobra.Command, args []string) error {
+	// Open DB
+	opts := badger.DefaultOptions
+	opts.Dir = sstDir
+	opts.ValueDir = vlogDir
+	db, err := badger.Open(opts)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Create File
+	f, err := os.Create(backupFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Run Backup
+	_, err = db.Backup(f, 0)
+	return err
+}

--- a/cmd/badger/cmd/restore.go
+++ b/cmd/badger/cmd/restore.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path"
+
+	"github.com/dgraph-io/badger"
+	"github.com/spf13/cobra"
+)
+
+var restoreFile string
+
+// restoreCmd represents the restore command
+var restoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore Badger database.",
+	Long: `Restore Badger database from a file.
+
+It reads a file generated using the backup command (or by calling the
+DB.Backup() API method) and writes each key-value pair found in the file to
+the Badger database.
+
+Restore creates a new database, and currently does not work on an already
+existing database.`,
+	RunE: doRestore,
+}
+
+func init() {
+	RootCmd.AddCommand(restoreCmd)
+	restoreCmd.Flags().StringVarP(&restoreFile, "backup-file", "f",
+		"badger.bak", "File to restore from")
+}
+
+func doRestore(cmd *cobra.Command, args []string) error {
+	// Check if the DB already exists
+	manifestFile := path.Join(sstDir, badger.ManifestFilename)
+	if _, err := os.Stat(manifestFile); err == nil { // No error. File already exists.
+		return errors.New("Cannot restore to an already existing database")
+	} else if os.IsNotExist(err) {
+		// pass
+	} else { // Return an error if anything other than the error above
+		return err
+	}
+
+	// Open DB
+	opts := badger.DefaultOptions
+	opts.Dir = sstDir
+	opts.ValueDir = vlogDir
+	db, err := badger.Open(opts)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// Open File
+	f, err := os.Open(restoreFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Run restore
+	return db.Load(f)
+}

--- a/cmd/badger/cmd/root.go
+++ b/cmd/badger/cmd/root.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var sstDir, vlogDir string
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:               "badger",
+	Short:             "Tool to manage Badger databases.",
+	PersistentPreRunE: validateRootCmdArgs,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	RootCmd.PersistentFlags().StringVar(&sstDir, "dir", "",
+		"Directory where the LSM tree files are located. (required)")
+
+	RootCmd.PersistentFlags().StringVar(&vlogDir, "vlog-dir", "",
+		"Directory where the value log files are located, if different from --sst-dir")
+}
+
+func validateRootCmdArgs(cmd *cobra.Command, args []string) error {
+	if strings.HasPrefix(cmd.Use, "help ") { // No need to validate if it is help
+		return nil
+	}
+	if sstDir == "" {
+		return errors.New("--sst-dir not specified")
+	}
+	if vlogDir == "" {
+		vlogDir = sstDir
+	}
+	return nil
+}

--- a/cmd/badger/main.go
+++ b/cmd/badger/main.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "github.com/dgraph-io/badger/cmd/badger/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
* `badger backup` creates a backup of the database

* `badger restore` creates a database and restores it from a file
created by the command above. It can also restore backups created using
another version of Badger.

  At the moment, `badger restore` does not support restoring to existing
  databases. This is because we do not want the user to inadvertently get
  into an inconsistent state due to version mismatches. We will re-enable
  this once we have support for incremental restores, by making sure the
  user sets a flag to indicate their intention to do incremental restore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/297)
<!-- Reviewable:end -->
