### PR TITLE
Create Badger directory if it does not exist.

### DIFF
--- a/db.go
+++ b/db.go
@@ -171,7 +171,11 @@ func Open(opt Options) (db *DB, err error) {
 			return nil, y.Wrapf(err, "Invalid Dir: %q", path)
 		}
 		if !dirExists {
-			return nil, ErrInvalidDir
+			// Try to create the directory
+			err = os.Mkdir(path, 0700)
+			if err != nil {
+				return nil, y.Wrapf(err, "Error Creating Dir: %q", path)
+			}
 		}
 	}
 	absDir, err := filepath.Abs(opt.Dir)

--- a/db_test.go
+++ b/db_test.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"sync"
@@ -1220,4 +1221,20 @@ func TestLargeKeys(t *testing.T) {
 			t.Fatalf("#%d: batchSet err: %v", i, err)
 		}
 	}
+}
+
+func TestCreateDirs(t *testing.T) {
+	dir, err := ioutil.TempDir("", "parent")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	opts := DefaultOptions
+	dir = filepath.Join(dir, "badger")
+	opts.Dir = dir
+	opts.ValueDir = dir
+	db, err := Open(opts)
+	require.NoError(t, err)
+	db.Close()
+	_, err = os.Stat(dir)
+	require.NoError(t, err)
 }

--- a/errors.go
+++ b/errors.go
@@ -23,10 +23,6 @@ import (
 )
 
 var (
-	// ErrInvalidDir is returned when Badger cannot find the directory
-	// from where it is supposed to load the key-value store.
-	ErrInvalidDir = errors.New("Invalid Dir, directory does not exist")
-
 	// ErrValueLogSize is returned when opt.ValueLogFileSize option is not within the valid
 	// range.
 	ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 2GB")


### PR DESCRIPTION
Instead of throwing ErrInvalidDir, we try to create a directory that is
specified in the options. We throw an error only if we cannot create the
directory for some reason.

Fixes #312.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/313)
<!-- Reviewable:end -->
