### PR TITLE
Item::ValueCopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,11 +441,12 @@ and [#315](https://github.com/dgraph-io/badger/issues/315).
 
 There are multiple workarounds during iteration:
 
+1. Use `Item::ValueCopy` instead of `Item::Value` when retrieving value.
 1. Set `Prefetch` to true. Badger would then copy over the value and release the
    file lock immediately.
-2. When `Prefetch` is false, don't call `Item::Value` and do a pure key-only
+1. When `Prefetch` is false, don't call `Item::Value` and do a pure key-only
    iteration. This might be useful if you just want to delete a lot of keys.
-3. Do the writes in a separate transaction after the reads.
+1. Do the writes in a separate transaction after the reads.
 
 - **My writes are really slow. Why?**
 

--- a/db.go
+++ b/db.go
@@ -941,7 +941,7 @@ func (db *DB) PurgeOlderVersions() error {
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
 			if !bytes.Equal(lastKey, item.Key()) {
-				lastKey = y.Safecopy(lastKey, item.Key())
+				lastKey = y.SafeCopy(lastKey, item.Key())
 				continue
 			}
 			// Found an older version. Mark for deletion

--- a/db_test.go
+++ b/db_test.go
@@ -53,7 +53,7 @@ func getItemValue(t *testing.T, item *Item) (val []byte) {
 	if v == nil {
 		return nil
 	}
-	another, err := item.ValueCopy()
+	another, err := item.ValueCopy(nil)
 	require.NoError(t, err)
 	require.Equal(t, v, another)
 	return v
@@ -1279,7 +1279,9 @@ func TestWriteDeadlock(t *testing.T) {
 
 			// Using Value() would cause deadlock.
 			// item.Value()
-			item.ValueCopy()
+			out, err := item.ValueCopy(nil)
+			require.NoError(t, err)
+			require.Equal(t, len(val), len(out))
 
 			key := y.Copy(item.Key())
 			rand.Read(val)

--- a/db_test.go
+++ b/db_test.go
@@ -1241,7 +1241,8 @@ func TestWriteDeadlock(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger")
 	fmt.Println(dir)
 	require.NoError(t, err)
-	// defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
+
 	opt := DefaultOptions
 	opt.Dir = dir
 	opt.ValueDir = dir

--- a/iterator.go
+++ b/iterator.go
@@ -86,10 +86,11 @@ func (item *Item) Value() ([]byte, error) {
 	return buf, err
 }
 
-// ValueCopy returns a copy of the value of the item from the value log.
+// ValueCopy returns a copy of the value of the item from the value log, writing it to dst slice.
+// If nil is passed, or capacity of dst isn't sufficient, a new slice would be allocated and
+// returned. Tip: It might make sense to reuse the returned slice as dst argument for the next call.
 //
-// The returned value is valid for usage anywhere. This function is useful in
-// long running iterate/update transactions to avoid a write deadlock.
+// This function is useful in long running iterate/update transactions to avoid a write deadlock.
 // See Github issue: https://github.com/dgraph-io/badger/issues/315
 func (item *Item) ValueCopy(dst []byte) ([]byte, error) {
 	item.wg.Wait()

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -123,7 +123,7 @@ func (itr *blockIterator) parseKV(h header) {
 			itr.pos, h.klen, h.vlen, len(itr.data), h)
 		return
 	}
-	itr.val = y.Safecopy(itr.val, itr.data[itr.pos:itr.pos+uint32(h.vlen)])
+	itr.val = y.SafeCopy(itr.val, itr.data[itr.pos:itr.pos+uint32(h.vlen)])
 	itr.pos += uint32(h.vlen)
 }
 

--- a/y/y.go
+++ b/y/y.go
@@ -75,8 +75,8 @@ func OpenTruncFile(filename string, sync bool) (*os.File, error) {
 	return os.OpenFile(filename, flags, 0666)
 }
 
-// Safecopy does append(a[:0], src...).
-func Safecopy(a []byte, src []byte) []byte {
+// SafeCopy does append(a[:0], src...).
+func SafeCopy(a []byte, src []byte) []byte {
 	return append(a[:0], src...)
 }
 


### PR DESCRIPTION
Add a ValueCopy function to avoid deadlocks in long running iterations.

Helps solve #315.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/316)
<!-- Reviewable:end -->
