### PR TITLE
Fixing 64-bit alignment in structs that use sync.atomic

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -328,7 +328,7 @@ func TestGetMore(t *testing.T) {
 	}
 	//	n := 500000
 	n := 10000
-	m := 49 // Increasing would cause ErrTxnTooBig
+	m := 45 // Increasing would cause ErrTxnTooBig
 	for i := 0; i < n; i += m {
 		txn := kv.NewTransaction(true)
 		for j := i; j < i+m && j < n; j++ {
@@ -432,7 +432,7 @@ func TestExistsMore(t *testing.T) {
 
 	//	n := 500000
 	n := 10000
-	m := 49
+	m := 45
 	for i := 0; i < n; i += m {
 		if (i % 1000) == 0 {
 			t.Logf("Putting i=%d\n", i)

--- a/levels.go
+++ b/levels.go
@@ -32,13 +32,12 @@ import (
 )
 
 type levelsController struct {
-	elog trace.EventLog
+	nextFileID uint64 // Atomic
+	elog       trace.EventLog
 
 	// The following are initialized once and const.
 	levels []*levelHandler
 	kv     *DB
-
-	nextFileID uint64 // Atomic
 
 	cstatus compactStatus
 }


### PR DESCRIPTION
This change fixes segmentation faults on Arm v7.

From https://golang.org/pkg/sync/atomic/:

> On both ARM and x86-32, it is the caller's responsibility to arrange
for 64-bit alignment of 64-bit words accessed atomically. The first word
in a variable or in an allocated struct, array, or slice can be relied
upon to be 64-bit aligned.

Fixes #311.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/318)
<!-- Reviewable:end -->
