### PR TITLE
Use a helper method to setup Badger before running test.

### DIFF
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -34,269 +34,249 @@ import (
 )
 
 func TestTxnSimple(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kv, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-	defer kv.Close()
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 
-	txn := kv.NewTransaction(true)
+		txn := db.NewTransaction(true)
 
-	for i := 0; i < 10; i++ {
-		k := []byte(fmt.Sprintf("key=%d", i))
-		v := []byte(fmt.Sprintf("val=%d", i))
-		txn.Set(k, v)
-	}
+		for i := 0; i < 10; i++ {
+			k := []byte(fmt.Sprintf("key=%d", i))
+			v := []byte(fmt.Sprintf("val=%d", i))
+			txn.Set(k, v)
+		}
 
-	item, err := txn.Get([]byte("key=8"))
-	require.NoError(t, err)
+		item, err := txn.Get([]byte("key=8"))
+		require.NoError(t, err)
 
-	val, err := item.Value()
-	require.NoError(t, err)
-	require.Equal(t, []byte("val=8"), val)
+		val, err := item.Value()
+		require.NoError(t, err)
+		require.Equal(t, []byte("val=8"), val)
 
-	require.Error(t, ErrManagedTxn, txn.CommitAt(100, nil))
-	require.NoError(t, txn.Commit(nil))
+		require.Error(t, ErrManagedTxn, txn.CommitAt(100, nil))
+		require.NoError(t, txn.Commit(nil))
+	})
 }
 
 func TestTxnCommitAsync(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kv, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-	defer kv.Close()
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 
-	txn := kv.NewTransaction(true)
-	key := func(i int) []byte {
-		return []byte(fmt.Sprintf("key=%d", i))
-	}
-	for i := 0; i < 40; i++ {
-		err := txn.Set(key(i), []byte(strconv.Itoa(100)))
-		require.NoError(t, err)
-	}
-	require.NoError(t, txn.Commit(nil))
-	txn.Discard()
-
-	var done uint64
-	go func() {
-		// Keep checking balance variant
-		for atomic.LoadUint64(&done) == 0 {
-			txn := kv.NewTransaction(false)
-			totalBalance := 0
-			for i := 0; i < 40; i++ {
-				item, err := txn.Get(key(i))
-				require.NoError(t, err)
-				val, err := item.Value()
-				require.NoError(t, err)
-				bal, err := strconv.Atoi(string(val))
-				require.NoError(t, err)
-				totalBalance += bal
-			}
-			require.Equal(t, totalBalance, 4000)
-			txn.Discard()
+		txn := db.NewTransaction(true)
+		key := func(i int) []byte {
+			return []byte(fmt.Sprintf("key=%d", i))
 		}
-	}()
+		for i := 0; i < 40; i++ {
+			err := txn.Set(key(i), []byte(strconv.Itoa(100)))
+			require.NoError(t, err)
+		}
+		require.NoError(t, txn.Commit(nil))
+		txn.Discard()
 
-	var wg sync.WaitGroup
-	wg.Add(100)
-	for i := 0; i < 100; i++ {
+		var done uint64
 		go func() {
-			txn := kv.NewTransaction(true)
-			delta := rand.Intn(100)
-			for i := 0; i < 20; i++ {
-				err := txn.Set(key(i), []byte(strconv.Itoa(100-delta)))
-				require.NoError(t, err)
+			// Keep checking balance variant
+			for atomic.LoadUint64(&done) == 0 {
+				txn := db.NewTransaction(false)
+				totalBalance := 0
+				for i := 0; i < 40; i++ {
+					item, err := txn.Get(key(i))
+					require.NoError(t, err)
+					val, err := item.Value()
+					require.NoError(t, err)
+					bal, err := strconv.Atoi(string(val))
+					require.NoError(t, err)
+					totalBalance += bal
+				}
+				require.Equal(t, totalBalance, 4000)
+				txn.Discard()
 			}
-			for i := 20; i < 40; i++ {
-				err := txn.Set(key(i), []byte(strconv.Itoa(100+delta)))
-				require.NoError(t, err)
-			}
-			// We are only doing writes, so there won't be any conflicts.
-			require.NoError(t, txn.Commit(func(err error) {}))
-			txn.Discard()
-			wg.Done()
 		}()
-	}
-	wg.Wait()
-	atomic.StoreUint64(&done, 1)
-	time.Sleep(time.Millisecond * 10) // allow goroutine to complete.
+
+		var wg sync.WaitGroup
+		wg.Add(100)
+		for i := 0; i < 100; i++ {
+			go func() {
+				txn := db.NewTransaction(true)
+				delta := rand.Intn(100)
+				for i := 0; i < 20; i++ {
+					err := txn.Set(key(i), []byte(strconv.Itoa(100-delta)))
+					require.NoError(t, err)
+				}
+				for i := 20; i < 40; i++ {
+					err := txn.Set(key(i), []byte(strconv.Itoa(100+delta)))
+					require.NoError(t, err)
+				}
+				// We are only doing writes, so there won't be any conflicts.
+				require.NoError(t, txn.Commit(func(err error) {}))
+				txn.Discard()
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		atomic.StoreUint64(&done, 1)
+		time.Sleep(time.Millisecond * 10) // allow goroutine to complete.
+	})
 }
 
 func TestTxnVersions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kv, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-	defer kv.Close()
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		k := []byte("key")
+		for i := 1; i < 10; i++ {
+			txn := db.NewTransaction(true)
 
-	k := []byte("key")
-	for i := 1; i < 10; i++ {
-		txn := kv.NewTransaction(true)
-
-		txn.Set(k, []byte(fmt.Sprintf("valversion=%d", i)))
-		require.NoError(t, txn.Commit(nil))
-		require.Equal(t, uint64(i), kv.orc.readTs())
-	}
-
-	checkIterator := func(itr *Iterator, i int) {
-		count := 0
-		for itr.Rewind(); itr.Valid(); itr.Next() {
-			item := itr.Item()
-			require.Equal(t, k, item.Key())
-
-			val, err := item.Value()
-			require.NoError(t, err)
-			exp := fmt.Sprintf("valversion=%d", i)
-			require.Equal(t, exp, string(val), "i=%d", i)
-			count++
-		}
-		require.Equal(t, 1, count, "i=%d", i) // Should only loop once.
-	}
-
-	checkAllVersions := func(itr *Iterator, i int) {
-		var version uint64
-		if itr.opt.Reverse {
-			version = 1
-		} else {
-			version = uint64(i)
+			txn.Set(k, []byte(fmt.Sprintf("valversion=%d", i)))
+			require.NoError(t, txn.Commit(nil))
+			require.Equal(t, uint64(i), db.orc.readTs())
 		}
 
-		count := 0
-		for itr.Rewind(); itr.Valid(); itr.Next() {
-			item := itr.Item()
-			require.Equal(t, k, item.Key())
-			require.Equal(t, version, item.Version())
+		checkIterator := func(itr *Iterator, i int) {
+			count := 0
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				item := itr.Item()
+				require.Equal(t, k, item.Key())
 
-			val, err := item.Value()
-			require.NoError(t, err)
-			exp := fmt.Sprintf("valversion=%d", version)
-			require.Equal(t, exp, string(val), "v=%d", version)
-			count++
-
-			if itr.opt.Reverse {
-				version++
-			} else {
-				version--
+				val, err := item.Value()
+				require.NoError(t, err)
+				exp := fmt.Sprintf("valversion=%d", i)
+				require.Equal(t, exp, string(val), "i=%d", i)
+				count++
 			}
+			require.Equal(t, 1, count, "i=%d", i) // Should only loop once.
 		}
-		require.Equal(t, i, count, "i=%d", i) // Should loop as many times as i.
-	}
 
-	for i := 1; i < 10; i++ {
-		txn := kv.NewTransaction(true)
-		require.NoError(t, err)
-		txn.readTs = uint64(i) // Read version at i.
+		checkAllVersions := func(itr *Iterator, i int) {
+			var version uint64
+			if itr.opt.Reverse {
+				version = 1
+			} else {
+				version = uint64(i)
+			}
 
+			count := 0
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				item := itr.Item()
+				require.Equal(t, k, item.Key())
+				require.Equal(t, version, item.Version())
+
+				val, err := item.Value()
+				require.NoError(t, err)
+				exp := fmt.Sprintf("valversion=%d", version)
+				require.Equal(t, exp, string(val), "v=%d", version)
+				count++
+
+				if itr.opt.Reverse {
+					version++
+				} else {
+					version--
+				}
+			}
+			require.Equal(t, i, count, "i=%d", i) // Should loop as many times as i.
+		}
+
+		for i := 1; i < 10; i++ {
+			txn := db.NewTransaction(true)
+			txn.readTs = uint64(i) // Read version at i.
+
+			item, err := txn.Get(k)
+			require.NoError(t, err)
+
+			val, err := item.Value()
+			require.NoError(t, err)
+			require.Equal(t, []byte(fmt.Sprintf("valversion=%d", i)), val,
+				"Expected versions to match up at i=%d", i)
+
+			// Try retrieving the latest version forward and reverse.
+			itr := txn.NewIterator(DefaultIteratorOptions)
+			checkIterator(itr, i)
+
+			opt := DefaultIteratorOptions
+			opt.Reverse = true
+			itr = txn.NewIterator(opt)
+			checkIterator(itr, i)
+
+			// Now try retrieving all versions forward and reverse.
+			opt = DefaultIteratorOptions
+			opt.AllVersions = true
+			itr = txn.NewIterator(opt)
+			checkAllVersions(itr, i)
+
+			opt = DefaultIteratorOptions
+			opt.AllVersions = true
+			opt.Reverse = true
+			itr = txn.NewIterator(opt)
+			checkAllVersions(itr, i)
+
+			txn.Discard()
+		}
+		txn := db.NewTransaction(true)
+		defer txn.Discard()
 		item, err := txn.Get(k)
 		require.NoError(t, err)
 
 		val, err := item.Value()
 		require.NoError(t, err)
-		require.Equal(t, []byte(fmt.Sprintf("valversion=%d", i)), val,
-			"Expected versions to match up at i=%d", i)
-
-		// Try retrieving the latest version forward and reverse.
-		itr := txn.NewIterator(DefaultIteratorOptions)
-		checkIterator(itr, i)
-
-		opt := DefaultIteratorOptions
-		opt.Reverse = true
-		itr = txn.NewIterator(opt)
-		checkIterator(itr, i)
-
-		// Now try retrieving all versions forward and reverse.
-		opt = DefaultIteratorOptions
-		opt.AllVersions = true
-		itr = txn.NewIterator(opt)
-		checkAllVersions(itr, i)
-
-		opt = DefaultIteratorOptions
-		opt.AllVersions = true
-		opt.Reverse = true
-		itr = txn.NewIterator(opt)
-		checkAllVersions(itr, i)
-
-		txn.Discard()
-	}
-	txn := kv.NewTransaction(true)
-	defer txn.Discard()
-	require.NoError(t, err)
-	item, err := txn.Get(k)
-	require.NoError(t, err)
-
-	val, err := item.Value()
-	require.NoError(t, err)
-	require.Equal(t, []byte("valversion=9"), val)
+		require.Equal(t, []byte("valversion=9"), val)
+	})
 }
 
 func TestTxnWriteSkew(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kv, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-	defer kv.Close()
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		// Accounts
+		ax := []byte("x")
+		ay := []byte("y")
 
-	// Accounts
-	ax := []byte("x")
-	ay := []byte("y")
+		// Set balance to $100 in each account.
+		txn := db.NewTransaction(true)
+		defer txn.Discard()
+		val := []byte(strconv.Itoa(100))
+		txn.Set(ax, val)
+		txn.Set(ay, val)
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(1), db.orc.readTs())
 
-	// Set balance to $100 in each account.
-	txn := kv.NewTransaction(true)
-	defer txn.Discard()
-	val := []byte(strconv.Itoa(100))
-	txn.Set(ax, val)
-	txn.Set(ay, val)
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(1), kv.orc.readTs())
+		getBal := func(txn *Txn, key []byte) (bal int) {
+			item, err := txn.Get(key)
+			require.NoError(t, err)
 
-	getBal := func(txn *Txn, key []byte) (bal int) {
-		item, err := txn.Get(key)
-		require.NoError(t, err)
+			val, err := item.Value()
+			require.NoError(t, err)
+			bal, err = strconv.Atoi(string(val))
+			require.NoError(t, err)
+			return bal
+		}
 
-		val, err := item.Value()
-		require.NoError(t, err)
-		bal, err = strconv.Atoi(string(val))
-		require.NoError(t, err)
-		return bal
-	}
+		// Start two transactions, each would read both accounts and deduct from one account.
+		txn1 := db.NewTransaction(true)
 
-	// Start two transactions, each would read both accounts and deduct from one account.
-	txn1 := kv.NewTransaction(true)
+		sum := getBal(txn1, ax)
+		sum += getBal(txn1, ay)
+		require.Equal(t, 200, sum)
+		txn1.Set(ax, []byte("0")) // Deduct 100 from ax.
 
-	sum := getBal(txn1, ax)
-	sum += getBal(txn1, ay)
-	require.Equal(t, 200, sum)
-	txn1.Set(ax, []byte("0")) // Deduct 100 from ax.
+		// Let's read this back.
+		sum = getBal(txn1, ax)
+		require.Equal(t, 0, sum)
+		sum += getBal(txn1, ay)
+		require.Equal(t, 100, sum)
+		// Don't commit yet.
 
-	// Let's read this back.
-	sum = getBal(txn1, ax)
-	require.Equal(t, 0, sum)
-	sum += getBal(txn1, ay)
-	require.Equal(t, 100, sum)
-	// Don't commit yet.
+		txn2 := db.NewTransaction(true)
 
-	txn2 := kv.NewTransaction(true)
+		sum = getBal(txn2, ax)
+		sum += getBal(txn2, ay)
+		require.Equal(t, 200, sum)
+		txn2.Set(ay, []byte("0")) // Deduct 100 from ay.
 
-	sum = getBal(txn2, ax)
-	sum += getBal(txn2, ay)
-	require.Equal(t, 200, sum)
-	txn2.Set(ay, []byte("0")) // Deduct 100 from ay.
+		// Let's read this back.
+		sum = getBal(txn2, ax)
+		require.Equal(t, 100, sum)
+		sum += getBal(txn2, ay)
+		require.Equal(t, 100, sum)
 
-	// Let's read this back.
-	sum = getBal(txn2, ax)
-	require.Equal(t, 100, sum)
-	sum += getBal(txn2, ay)
-	require.Equal(t, 100, sum)
+		// Commit both now.
+		require.NoError(t, txn1.Commit(nil))
+		require.Error(t, txn2.Commit(nil)) // This should fail.
 
-	// Commit both now.
-	require.NoError(t, txn1.Commit(nil))
-	require.Error(t, txn2.Commit(nil)) // This should fail.
-
-	require.Equal(t, uint64(2), kv.orc.readTs())
+		require.Equal(t, uint64(2), db.orc.readTs())
+	})
 }
 
 // a3, a2, b4 (del), b3, c2, c1
@@ -306,92 +286,87 @@ func TestTxnWriteSkew(t *testing.T) {
 // Read at ts=2 -> a2, c2
 // Read at ts=1 -> c1
 func TestTxnIterationEdgeCase(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kv, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-	defer kv.Close()
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		ka := []byte("a")
+		kb := []byte("b")
+		kc := []byte("c")
 
-	ka := []byte("a")
-	kb := []byte("b")
-	kc := []byte("c")
+		// c1
+		txn := db.NewTransaction(true)
+		txn.Set(kc, []byte("c1"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(1), db.orc.readTs())
 
-	// c1
-	txn := kv.NewTransaction(true)
-	txn.Set(kc, []byte("c1"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(1), kv.orc.readTs())
+		// a2, c2
+		txn = db.NewTransaction(true)
+		txn.Set(ka, []byte("a2"))
+		txn.Set(kc, []byte("c2"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(2), db.orc.readTs())
 
-	// a2, c2
-	txn = kv.NewTransaction(true)
-	txn.Set(ka, []byte("a2"))
-	txn.Set(kc, []byte("c2"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(2), kv.orc.readTs())
+		// b3
+		txn = db.NewTransaction(true)
+		txn.Set(ka, []byte("a3"))
+		txn.Set(kb, []byte("b3"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(3), db.orc.readTs())
 
-	// b3
-	txn = kv.NewTransaction(true)
-	txn.Set(ka, []byte("a3"))
-	txn.Set(kb, []byte("b3"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(3), kv.orc.readTs())
+		// b4, c4(del) (Uncomitted)
+		txn4 := db.NewTransaction(true)
+		require.NoError(t, txn4.Set(kb, []byte("b4")))
+		require.NoError(t, txn4.Delete(kc))
+		require.Equal(t, uint64(3), db.orc.readTs())
 
-	// b4, c4(del) (Uncomitted)
-	txn4 := kv.NewTransaction(true)
-	require.NoError(t, txn4.Set(kb, []byte("b4")))
-	require.NoError(t, txn4.Delete(kc))
-	require.Equal(t, uint64(3), kv.orc.readTs())
+		// b4 (del)
+		txn = db.NewTransaction(true)
+		txn.Delete(kb)
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(4), db.orc.readTs())
 
-	// b4 (del)
-	txn = kv.NewTransaction(true)
-	txn.Delete(kb)
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(4), kv.orc.readTs())
-
-	checkIterator := func(itr *Iterator, expected []string) {
-		var i int
-		for itr.Rewind(); itr.Valid(); itr.Next() {
-			item := itr.Item()
-			val, err := item.Value()
-			require.NoError(t, err)
-			require.Equal(t, expected[i], string(val), "readts=%d", itr.readTs)
-			i++
+		checkIterator := func(itr *Iterator, expected []string) {
+			var i int
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				item := itr.Item()
+				val, err := item.Value()
+				require.NoError(t, err)
+				require.Equal(t, expected[i], string(val), "readts=%d", itr.readTs)
+				i++
+			}
+			require.Equal(t, len(expected), i)
 		}
-		require.Equal(t, len(expected), i)
-	}
 
-	txn = kv.NewTransaction(true)
-	defer txn.Discard()
-	itr := txn.NewIterator(DefaultIteratorOptions)
-	itr5 := txn4.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"a3", "c2"})
-	checkIterator(itr5, []string{"a3", "b4"})
+		txn = db.NewTransaction(true)
+		defer txn.Discard()
+		itr := txn.NewIterator(DefaultIteratorOptions)
+		itr5 := txn4.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"a3", "c2"})
+		checkIterator(itr5, []string{"a3", "b4"})
 
-	rev := DefaultIteratorOptions
-	rev.Reverse = true
-	itr = txn.NewIterator(rev)
-	itr5 = txn4.NewIterator(rev)
-	checkIterator(itr, []string{"c2", "a3"})
-	checkIterator(itr5, []string{"b4", "a3"})
+		rev := DefaultIteratorOptions
+		rev.Reverse = true
+		itr = txn.NewIterator(rev)
+		itr5 = txn4.NewIterator(rev)
+		checkIterator(itr, []string{"c2", "a3"})
+		checkIterator(itr5, []string{"b4", "a3"})
 
-	txn.readTs = 3
-	itr = txn.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"a3", "b3", "c2"})
-	itr = txn.NewIterator(rev)
-	checkIterator(itr, []string{"c2", "b3", "a3"})
+		txn.readTs = 3
+		itr = txn.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"a3", "b3", "c2"})
+		itr = txn.NewIterator(rev)
+		checkIterator(itr, []string{"c2", "b3", "a3"})
 
-	txn.readTs = 2
-	itr = txn.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"a2", "c2"})
-	itr = txn.NewIterator(rev)
-	checkIterator(itr, []string{"c2", "a2"})
+		txn.readTs = 2
+		itr = txn.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"a2", "c2"})
+		itr = txn.NewIterator(rev)
+		checkIterator(itr, []string{"c2", "a2"})
 
-	txn.readTs = 1
-	itr = txn.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"c1"})
-	itr = txn.NewIterator(rev)
-	checkIterator(itr, []string{"c1"})
+		txn.readTs = 1
+		itr = txn.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"c1"})
+		itr = txn.NewIterator(rev)
+		checkIterator(itr, []string{"c1"})
+	})
 }
 
 // a2, a3, b4 (del), b3, c2, c1
@@ -400,258 +375,244 @@ func TestTxnIterationEdgeCase(t *testing.T) {
 // Read at ts=2 -> a2, c2
 // Read at ts=1 -> c1
 func TestTxnIterationEdgeCase2(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kv, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-	defer kv.Close()
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		ka := []byte("a")
+		kb := []byte("aa")
+		kc := []byte("aaa")
 
-	ka := []byte("a")
-	kb := []byte("aa")
-	kc := []byte("aaa")
+		// c1
+		txn := db.NewTransaction(true)
+		txn.Set(kc, []byte("c1"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(1), db.orc.readTs())
 
-	// c1
-	txn := kv.NewTransaction(true)
-	txn.Set(kc, []byte("c1"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(1), kv.orc.readTs())
+		// a2, c2
+		txn = db.NewTransaction(true)
+		txn.Set(ka, []byte("a2"))
+		txn.Set(kc, []byte("c2"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(2), db.orc.readTs())
 
-	// a2, c2
-	txn = kv.NewTransaction(true)
-	txn.Set(ka, []byte("a2"))
-	txn.Set(kc, []byte("c2"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(2), kv.orc.readTs())
+		// b3
+		txn = db.NewTransaction(true)
+		txn.Set(ka, []byte("a3"))
+		txn.Set(kb, []byte("b3"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(3), db.orc.readTs())
 
-	// b3
-	txn = kv.NewTransaction(true)
-	txn.Set(ka, []byte("a3"))
-	txn.Set(kb, []byte("b3"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(3), kv.orc.readTs())
+		// b4 (del)
+		txn = db.NewTransaction(true)
+		txn.Delete(kb)
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(4), db.orc.readTs())
 
-	// b4 (del)
-	txn = kv.NewTransaction(true)
-	txn.Delete(kb)
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(4), kv.orc.readTs())
-
-	checkIterator := func(itr *Iterator, expected []string) {
-		var i int
-		for itr.Rewind(); itr.Valid(); itr.Next() {
-			item := itr.Item()
-			val, err := item.Value()
-			require.NoError(t, err)
-			require.Equal(t, expected[i], string(val), "readts=%d", itr.readTs)
-			i++
+		checkIterator := func(itr *Iterator, expected []string) {
+			var i int
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				item := itr.Item()
+				val, err := item.Value()
+				require.NoError(t, err)
+				require.Equal(t, expected[i], string(val), "readts=%d", itr.readTs)
+				i++
+			}
+			require.Equal(t, len(expected), i)
 		}
-		require.Equal(t, len(expected), i)
-	}
-	txn = kv.NewTransaction(true)
-	defer txn.Discard()
-	rev := DefaultIteratorOptions
-	rev.Reverse = true
+		txn = db.NewTransaction(true)
+		defer txn.Discard()
+		rev := DefaultIteratorOptions
+		rev.Reverse = true
 
-	itr := txn.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"a3", "c2"})
-	itr = txn.NewIterator(rev)
-	checkIterator(itr, []string{"c2", "a3"})
+		itr := txn.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"a3", "c2"})
+		itr = txn.NewIterator(rev)
+		checkIterator(itr, []string{"c2", "a3"})
 
-	txn.readTs = 5
-	itr = txn.NewIterator(DefaultIteratorOptions)
-	itr.Seek(ka)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), ka)
-	itr.Seek(kc)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
+		txn.readTs = 5
+		itr = txn.NewIterator(DefaultIteratorOptions)
+		itr.Seek(ka)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), ka)
+		itr.Seek(kc)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
 
-	itr = txn.NewIterator(rev)
-	itr.Seek(ka)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), ka)
-	itr.Seek(kc)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
+		itr = txn.NewIterator(rev)
+		itr.Seek(ka)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), ka)
+		itr.Seek(kc)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
 
-	txn.readTs = 3
-	itr = txn.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"a3", "b3", "c2"})
-	itr = txn.NewIterator(rev)
-	checkIterator(itr, []string{"c2", "b3", "a3"})
+		txn.readTs = 3
+		itr = txn.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"a3", "b3", "c2"})
+		itr = txn.NewIterator(rev)
+		checkIterator(itr, []string{"c2", "b3", "a3"})
 
-	txn.readTs = 2
-	itr = txn.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"a2", "c2"})
-	itr = txn.NewIterator(rev)
-	checkIterator(itr, []string{"c2", "a2"})
+		txn.readTs = 2
+		itr = txn.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"a2", "c2"})
+		itr = txn.NewIterator(rev)
+		checkIterator(itr, []string{"c2", "a2"})
 
-	txn.readTs = 1
-	itr = txn.NewIterator(DefaultIteratorOptions)
-	checkIterator(itr, []string{"c1"})
-	itr = txn.NewIterator(rev)
-	checkIterator(itr, []string{"c1"})
+		txn.readTs = 1
+		itr = txn.NewIterator(DefaultIteratorOptions)
+		checkIterator(itr, []string{"c1"})
+		itr = txn.NewIterator(rev)
+		checkIterator(itr, []string{"c1"})
+	})
 }
 
 func TestTxnIterationEdgeCase3(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	kv, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-	defer kv.Close()
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		kb := []byte("abc")
+		kc := []byte("acd")
+		kd := []byte("ade")
 
-	kb := []byte("abc")
-	kc := []byte("acd")
-	kd := []byte("ade")
+		// c1
+		txn := db.NewTransaction(true)
+		txn.Set(kc, []byte("c1"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(1), db.orc.readTs())
 
-	// c1
-	txn := kv.NewTransaction(true)
-	txn.Set(kc, []byte("c1"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(1), kv.orc.readTs())
+		// b2
+		txn = db.NewTransaction(true)
+		txn.Set(kb, []byte("b2"))
+		require.NoError(t, txn.Commit(nil))
+		require.Equal(t, uint64(2), db.orc.readTs())
 
-	// b2
-	txn = kv.NewTransaction(true)
-	txn.Set(kb, []byte("b2"))
-	require.NoError(t, txn.Commit(nil))
-	require.Equal(t, uint64(2), kv.orc.readTs())
+		txn2 := db.NewTransaction(true)
+		require.NoError(t, txn2.Set(kd, []byte("d2")))
+		require.NoError(t, txn2.Delete(kc))
 
-	txn2 := kv.NewTransaction(true)
-	require.NoError(t, txn2.Set(kd, []byte("d2")))
-	require.NoError(t, txn2.Delete(kc))
+		txn = db.NewTransaction(true)
+		defer txn.Discard()
+		rev := DefaultIteratorOptions
+		rev.Reverse = true
 
-	txn = kv.NewTransaction(true)
-	defer txn.Discard()
-	rev := DefaultIteratorOptions
-	rev.Reverse = true
+		itr := txn.NewIterator(DefaultIteratorOptions)
+		itr.Seek([]byte("ab"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ac"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
+		itr.Seek(nil)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ac"))
+		itr.Rewind()
+		itr.Seek(nil)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ac"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
 
-	itr := txn.NewIterator(DefaultIteratorOptions)
-	itr.Seek([]byte("ab"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ac"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
-	itr.Seek(nil)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ac"))
-	itr.Rewind()
-	itr.Seek(nil)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ac"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
+		//  Keys: "abc", "ade"
+		// Read pending writes.
+		itr = txn2.NewIterator(DefaultIteratorOptions)
+		itr.Seek([]byte("ab"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ac"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kd)
+		itr.Seek(nil)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ac"))
+		itr.Rewind()
+		itr.Seek(nil)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ad"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kd)
 
-	//  Keys: "abc", "ade"
-	// Read pending writes.
-	itr = txn2.NewIterator(DefaultIteratorOptions)
-	itr.Seek([]byte("ab"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ac"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kd)
-	itr.Seek(nil)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ac"))
-	itr.Rewind()
-	itr.Seek(nil)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ad"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kd)
+		itr = txn.NewIterator(rev)
+		itr.Seek([]byte("ac"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ad"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
+		itr.Seek(nil)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
+		itr.Seek([]byte("ac"))
+		itr.Rewind()
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
+		itr.Seek([]byte("ad"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kc)
 
-	itr = txn.NewIterator(rev)
-	itr.Seek([]byte("ac"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ad"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
-	itr.Seek(nil)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
-	itr.Seek([]byte("ac"))
-	itr.Rewind()
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
-	itr.Seek([]byte("ad"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kc)
-
-	//  Keys: "abc", "ade"
-	itr = txn2.NewIterator(rev)
-	itr.Seek([]byte("ad"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
-	itr.Seek([]byte("ae"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kd)
-	itr.Seek(nil)
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kd)
-	itr.Seek([]byte("ab"))
-	itr.Rewind()
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kd)
-	itr.Seek([]byte("ac"))
-	require.True(t, itr.Valid())
-	require.Equal(t, itr.item.Key(), kb)
+		//  Keys: "abc", "ade"
+		itr = txn2.NewIterator(rev)
+		itr.Seek([]byte("ad"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+		itr.Seek([]byte("ae"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kd)
+		itr.Seek(nil)
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kd)
+		itr.Seek([]byte("ab"))
+		itr.Rewind()
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kd)
+		itr.Seek([]byte("ac"))
+		require.True(t, itr.Valid())
+		require.Equal(t, itr.item.Key(), kb)
+	})
 }
 
 func TestIteratorAllVersionsButDeleted(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	db, err := Open(getTestOptions(dir))
-	require.NoError(t, err)
-
-	// Write two keys
-	err = db.Update(func(txn *Txn) error {
-		txn.Set([]byte("answer1"), []byte("42"))
-		txn.Set([]byte("answer2"), []byte("43"))
-		return nil
-	})
-	require.NoError(t, err)
-
-	// Delete the specific key version from underlying db directly
-	err = db.View(func(txn *Txn) error {
-		item, err := txn.Get([]byte("answer1"))
-		require.NoError(t, err)
-		err = txn.db.batchSet([]*entry{
-			{
-				Key:  y.KeyWithTs(item.key, item.version),
-				meta: bitDelete,
-			},
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		// Write two keys
+		err := db.Update(func(txn *Txn) error {
+			txn.Set([]byte("answer1"), []byte("42"))
+			txn.Set([]byte("answer2"), []byte("43"))
+			return nil
 		})
 		require.NoError(t, err)
-		return err
-	})
-	require.NoError(t, err)
 
-	opts := DefaultIteratorOptions
-	opts.AllVersions = true
-	opts.PrefetchValues = false
+		// Delete the specific key version from underlying db directly
+		err = db.View(func(txn *Txn) error {
+			item, err := txn.Get([]byte("answer1"))
+			require.NoError(t, err)
+			err = txn.db.batchSet([]*entry{
+				{
+					Key:  y.KeyWithTs(item.key, item.version),
+					meta: bitDelete,
+				},
+			})
+			require.NoError(t, err)
+			return err
+		})
+		require.NoError(t, err)
 
-	// Verify that deleted key does not show up when AllVersions is set.
-	err = db.View(func(txn *Txn) error {
-		it := txn.NewIterator(opts)
-		var count int
-		for it.Rewind(); it.Valid(); it.Next() {
-			count++
-			item := it.Item()
-			require.Equal(t, []byte("answer2"), item.Key())
-		}
-		require.Equal(t, 1, count)
-		return nil
+		opts := DefaultIteratorOptions
+		opts.AllVersions = true
+		opts.PrefetchValues = false
+
+		// Verify that deleted key does not show up when AllVersions is set.
+		err = db.View(func(txn *Txn) error {
+			it := txn.NewIterator(opts)
+			var count int
+			for it.Rewind(); it.Valid(); it.Next() {
+				count++
+				item := it.Item()
+				require.Equal(t, []byte("answer2"), item.Key())
+			}
+			require.Equal(t, 1, count)
+			return nil
+		})
+		require.NoError(t, err)
 	})
-	require.NoError(t, err)
 }
 
 func TestManagedDB(t *testing.T) {


### PR DESCRIPTION
Most of the tests just setup a temporary directory, open Badger
and then run the test. This commit refactors the repeated code
in each test into a helper method.

Some tests have been left alone because they do something extra
like setting different options, closing/re-opening the DB etc.

Fixes #304.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/329)
<!-- Reviewable:end -->
