### PR TITLE
Allow setting TTL and User metadata at the same time.

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -75,12 +75,12 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 func (db *DB) Load(r io.Reader) error {
 	br := bufio.NewReaderSize(r, 16<<10)
 	unmarshalBuf := make([]byte, 1<<10)
-	var entries []*entry
+	var entries []*Entry
 	var wg sync.WaitGroup
 	errChan := make(chan error, 1)
 
 	// func to check for pending error before sending off a batch for writing
-	batchSetAsyncIfNoErr := func(entries []*entry) error {
+	batchSetAsyncIfNoErr := func(entries []*Entry) error {
 		select {
 		case err := <-errChan:
 			return err
@@ -118,7 +118,7 @@ func (db *DB) Load(r io.Reader) error {
 		if err = e.Unmarshal(unmarshalBuf[:sz]); err != nil {
 			return err
 		}
-		entries = append(entries, &entry{
+		entries = append(entries, &Entry{
 			Key:       y.KeyWithTs(e.Key, e.Version),
 			Value:     e.Value,
 			UserMeta:  e.UserMeta[0],

--- a/structs.go
+++ b/structs.go
@@ -76,8 +76,8 @@ func (h *header) Decode(buf []byte) {
 	h.userMeta = buf[17]
 }
 
-// entry provides Key, Value, UserMeta and ExpiresAt. This struct can be used by the user to set data.
-type entry struct {
+// Entry provides Key, Value, UserMeta and ExpiresAt. This struct can be used by the user to set data.
+type Entry struct {
 	Key       []byte
 	Value     []byte
 	UserMeta  byte
@@ -88,7 +88,7 @@ type entry struct {
 	offset uint32
 }
 
-func (e *entry) estimateSize(threshold int) int {
+func (e *Entry) estimateSize(threshold int) int {
 	if len(e.Value) < threshold {
 		return len(e.Key) + len(e.Value) + 2 // Meta, UserMeta
 	}
@@ -96,7 +96,7 @@ func (e *entry) estimateSize(threshold int) int {
 }
 
 // Encodes e to buf. Returns number of bytes written.
-func encodeEntry(e *entry, buf *bytes.Buffer) (int, error) {
+func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 	h := header{
 		klen:      uint32(len(e.Key)),
 		vlen:      uint32(len(e.Value)),
@@ -126,7 +126,7 @@ func encodeEntry(e *entry, buf *bytes.Buffer) (int, error) {
 	return len(headerEnc) + len(e.Key) + len(e.Value) + len(crcBuf), nil
 }
 
-func (e entry) print(prefix string) {
+func (e Entry) print(prefix string) {
 	fmt.Printf("%s Key: %s Meta: %d UserMeta: %d Offset: %d len(val)=%d",
 		prefix, e.Key, e.meta, e.UserMeta, e.offset, len(e.Value))
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -584,7 +584,7 @@ func TestIteratorAllVersionsButDeleted(t *testing.T) {
 		err = db.View(func(txn *Txn) error {
 			item, err := txn.Get([]byte("answer1"))
 			require.NoError(t, err)
-			err = txn.db.batchSet([]*entry{
+			err = txn.db.batchSet([]*Entry{
 				{
 					Key:  y.KeyWithTs(item.key, item.version),
 					meta: bitDelete,

--- a/value_test.go
+++ b/value_test.go
@@ -41,19 +41,19 @@ func TestValueBasic(t *testing.T) {
 	const val2 = "samplevalb012345678901234567890123"
 	require.True(t, len(val1) >= kv.opt.ValueThreshold)
 
-	e := &entry{
+	e := &Entry{
 		Key:   []byte("samplekey"),
 		Value: []byte(val1),
 		meta:  bitValuePointer,
 	}
-	e2 := &entry{
+	e2 := &Entry{
 		Key:   []byte("samplekeyb"),
 		Value: []byte(val2),
 		meta:  bitValuePointer,
 	}
 
 	b := new(request)
-	b.Entries = []*entry{e, e2}
+	b.Entries = []*Entry{e, e2}
 
 	log.write([]*request{b})
 	require.Len(t, b.Ptrs, 2)
@@ -66,8 +66,8 @@ func TestValueBasic(t *testing.T) {
 	defer runCallback(cb1)
 	defer runCallback(cb2)
 
-	readEntries := []entry{valueBytesToEntry(buf1), valueBytesToEntry(buf2)}
-	require.EqualValues(t, []entry{
+	readEntries := []Entry{valueBytesToEntry(buf1), valueBytesToEntry(buf2)}
+	require.EqualValues(t, []Entry{
 		{
 			Key:   []byte("samplekey"),
 			Value: []byte(val1),
@@ -375,7 +375,7 @@ func TestChecksums(t *testing.T) {
 	require.True(t, len(v0) >= kv.opt.ValueThreshold)
 
 	// Use a vlog with K0=V0 and a (corrupted) second transaction(k1,k2)
-	buf := createVlog(t, []*entry{
+	buf := createVlog(t, []*Entry{
 		{Key: k0, Value: v0},
 		{Key: k1, Value: v1},
 		{Key: k2, Value: v2},
@@ -458,7 +458,7 @@ func TestPartialAppendToValueLog(t *testing.T) {
 
 	// Create truncated vlog to simulate a partial append.
 	// k0 - single transaction, k1 and k2 in another transaction
-	buf := createVlog(t, []*entry{
+	buf := createVlog(t, []*Entry{
 		{Key: k0, Value: v0},
 		{Key: k1, Value: v1},
 		{Key: k2, Value: v2},
@@ -529,7 +529,7 @@ func TestValueLogTrigger(t *testing.T) {
 	require.Equal(t, ErrRejected, err, "Error should be returned after closing DB.")
 }
 
-func createVlog(t *testing.T, entries []*entry) []byte {
+func createVlog(t *testing.T, entries []*Entry) []byte {
 	dir, err := ioutil.TempDir("", "badger")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -585,11 +585,11 @@ func BenchmarkReadWrite(b *testing.B) {
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {
-					e := new(entry)
+					e := new(Entry)
 					e.Key = make([]byte, 16)
 					e.Value = make([]byte, vsz)
 					bl := new(request)
-					bl.Entries = []*entry{e}
+					bl.Entries = []*Entry{e}
 
 					var ptrs []valuePointer
 


### PR DESCRIPTION
We expose a public struct Entry, which can be used to set the key,
value, user metadata and TTL all at the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/333)
<!-- Reviewable:end -->
