### PR TITLE
Change TTL resolution to nanoseconds and allow subsecond TTLs

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -334,7 +334,7 @@ func isDeletedOrExpired(vs y.ValueStruct) bool {
 	if vs.ExpiresAt == 0 {
 		return false
 	}
-	return vs.ExpiresAt <= uint64(time.Now().Unix())
+	return vs.ExpiresAt <= uint64(time.Now().UnixNano())
 }
 
 // parseItem is a complex function because it needs to handle both forward and reverse iteration

--- a/structs.go
+++ b/structs.go
@@ -81,7 +81,7 @@ type Entry struct {
 	Key       []byte
 	Value     []byte
 	UserMeta  byte
-	ExpiresAt uint64 // time.Unix
+	ExpiresAt uint64 // time.UnixNano
 	meta      byte
 
 	// Fields maintained internally.

--- a/transaction.go
+++ b/transaction.go
@@ -306,7 +306,7 @@ func (txn *Txn) SetWithMeta(key, val []byte, meta byte) error {
 // (TTL) setting. A key stored with with a TTL would automatically expire after
 // the time has elapsed , and be eligible for garbage collection.
 func (txn *Txn) SetWithTTL(key, val []byte, dur time.Duration) error {
-	expire := time.Now().Add(dur).Unix()
+	expire := time.Now().Add(dur).UnixNano()
 	e := &Entry{Key: key, Value: val, ExpiresAt: uint64(expire)}
 	return txn.SetEntry(e)
 }
@@ -380,7 +380,7 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 			if e.meta&bitDelete > 0 {
 				return nil, ErrKeyNotFound
 			}
-			if e.ExpiresAt > 0 && e.ExpiresAt <= uint64(time.Now().Unix()) {
+			if e.ExpiresAt > 0 && e.ExpiresAt <= uint64(time.Now().UnixNano()) {
 				return nil, ErrKeyNotFound
 			}
 			// Fulfill from cache.


### PR DESCRIPTION
Currently if we set a key with a subsecond TTL the entry is automatically expired because the TTL resolution is in seconds.

This change allows setting subsecond TTLS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/337)
<!-- Reviewable:end -->
