### PR TITLE
[RFC] Add option to use sub-second TTL

### DIFF
--- a/options.go
+++ b/options.go
@@ -81,8 +81,9 @@ type Options struct {
 	// ------------------------------
 	DoNotCompact bool // Stops LSM tree from compactions.
 
-	maxBatchCount int64 // max entries in batch
-	maxBatchSize  int64 // max batch size in bytes
+	UseSubsecondTTL bool
+	maxBatchCount   int64 // max entries in batch
+	maxBatchSize    int64 // max batch size in bytes
 }
 
 // DefaultOptions sets a list of recommended options for good performance.

--- a/value.go
+++ b/value.go
@@ -283,7 +283,7 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 		if err != nil {
 			return err
 		}
-		if discardEntry(e, vs) {
+		if discardEntry(e, vs, vlog.opt.UseSubsecondTTL) {
 			return nil
 		}
 
@@ -841,12 +841,12 @@ func (vlog *valueLog) pickLog(head valuePointer) *logFile {
 	return vlog.filesMap[fids[idx]]
 }
 
-func discardEntry(e Entry, vs y.ValueStruct) bool {
+func discardEntry(e Entry, vs y.ValueStruct, useSubsecondTTL bool) bool {
 	if vs.Version != y.ParseTs(e.Key) {
 		// Version not found. Discard.
 		return true
 	}
-	if isDeletedOrExpired(vs) {
+	if isDeletedOrExpired(vs, useSubsecondTTL) {
 		return true
 	}
 	if (vs.Meta & bitValuePointer) == 0 {
@@ -915,7 +915,7 @@ func (vlog *valueLog) doRunGC(gcThreshold float64, head valuePointer) (err error
 		if err != nil {
 			return err
 		}
-		if discardEntry(e, vs) {
+		if discardEntry(e, vs, vlog.opt.UseSubsecondTTL) {
 			r.discard += esz
 			return nil
 		}


### PR DESCRIPTION
This is a first draft of a change based on suggestion by @magik6k in #339.

It is a bit hacky, but not as hacky as some other suggestions that were made earlier. This change also allows use to gracefully drop this hack when we do a major version upgrade (we will still need to provide a viable way to backup the existing data such that it can be imported seamlessly when we do switch to subsecond TTLs by default).

If this approach is acceptable, I will refactor the code a bit more and add tests as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/342)
<!-- Reviewable:end -->
