### PR TITLE
Modify backup to dump timestamps as nanoseconds.

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/dgraph-io/badger/y"
 
@@ -52,7 +53,7 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 				Value:     y.Copy(val),
 				UserMeta:  []byte{item.UserMeta()},
 				Version:   item.Version(),
-				ExpiresAt: item.ExpiresAt(),
+				ExpiresAt: uint64(time.Unix(int64(item.ExpiresAt()), 0).UnixNano()),
 			}
 
 			// Write entries to disk

--- a/backup_test.go
+++ b/backup_test.go
@@ -55,7 +55,7 @@ func TestDumpLoad(t *testing.T) {
 
 	bak, err := ioutil.TempFile(dir, "badgerbak")
 	require.NoError(t, err)
-	ts, err := db.Backup(bak, 0)
+	ts, err := db.Backup(bak, 0, false)
 	t.Logf("New ts: %d\n", ts)
 	require.NoError(t, err)
 	require.NoError(t, bak.Close())

--- a/cmd/badger/cmd/backup.go
+++ b/cmd/badger/cmd/backup.go
@@ -24,6 +24,7 @@ import (
 )
 
 var backupFile string
+var backupForV2 bool
 
 // backupCmd represents the backup command
 var backupCmd = &cobra.Command{
@@ -42,6 +43,7 @@ func init() {
 	RootCmd.AddCommand(backupCmd)
 	backupCmd.Flags().StringVarP(&backupFile, "backup-file", "f",
 		"badger.bak", "File to backup to")
+	backupCmd.Flags().BoolVar(&backupForV2, "for_v2", false, "Write in v2.x format")
 }
 
 func doBackup(cmd *cobra.Command, args []string) error {
@@ -63,6 +65,6 @@ func doBackup(cmd *cobra.Command, args []string) error {
 	defer f.Close()
 
 	// Run Backup
-	_, err = db.Backup(f, 0)
+	_, err = db.Backup(f, 0, backupForV2)
 	return err
 }


### PR DESCRIPTION
We will release this change as v1.3.1, user can backup in v2.0 format using the backup tool of this version.
And then restore using badger restore tool of v2.0.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/353)
<!-- Reviewable:end -->
