### PR TITLE
Add Sequence.Release()

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,11 @@ bandwidth provided to `DB.GetSequence`. The frequency at which disk writes are
 done is determined by this lease bandwidth and the frequency of `Next`
 invocations. Setting a bandwith too low would do more disk writes, setting it
 too high would result in wasted integers if Badger is closed or crashes.
+To avoid wasted integers, call `Release` before closing Badger.
 
 ```go
 seq, err := db.GetSequence(key, 1000)
+defer seq.Release()
 for {
   num, err := seq.Next()
 }


### PR DESCRIPTION
> Release the leased sequence to avoid wasted integers. This should be done right before closing the associated DB. However it is valid to use the sequence after it was released, causing a new lease with full bandwidth.

Changes:

- Add new method `Release() error` on `Sequence`
- Add defer example to readme
- Test release and use after release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/362)
<!-- Reviewable:end -->
