### PR TITLE
correct fix for #350

### DIFF
--- a/y/file_dsync.go
+++ b/y/file_dsync.go
@@ -1,4 +1,4 @@
-// +build !dragonfly,!freebsd,!windows,!darwin
+// +build !dragonfly,!freebsd,!windows
 
 /*
  * Copyright 2017 Dgraph Labs, Inc. and Contributors
@@ -18,8 +18,8 @@
 
 package y
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 func init() {
-	datasyncFileFlag = syscall.O_DSYNC
+	datasyncFileFlag = unix.O_DSYNC
 }

--- a/y/file_nodsync.go
+++ b/y/file_nodsync.go
@@ -1,4 +1,4 @@
-// +build dragonfly freebsd windows darwin
+// +build dragonfly freebsd windows
 
 /*
  * Copyright 2017 Dgraph Labs, Inc. and Contributors


### PR DESCRIPTION
Re-enables DSYNC on MacOS and iOS. As far as I can tell, these platforms *do*
support DSYNC, it's just that the constant is missing from
syscall (semi-deprecated and frozen).

I have neither an iPhone nor a Mac so someone should test this. However, it
appears to build (tested by manually building with `GOOS` and `GOARCH`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/378)
<!-- Reviewable:end -->
