### PR TITLE
Store TTL in nanoseconds

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/dgraph-io/badger/y"
 
@@ -52,7 +53,7 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 				Value:     y.Copy(val),
 				UserMeta:  []byte{item.UserMeta()},
 				Version:   item.Version(),
-				ExpiresAt: item.ExpiresAt(),
+				ExpiresAt: uint64(time.Unix(int64(item.ExpiresAt()), 0).UnixNano()),
 			}
 
 			// Write entries to disk

--- a/iterator.go
+++ b/iterator.go
@@ -345,7 +345,7 @@ func isDeletedOrExpired(meta byte, expiresAt uint64) bool {
 	if expiresAt == 0 {
 		return false
 	}
-	return expiresAt <= uint64(time.Now().Unix())
+	return expiresAt <= uint64(time.Now().UnixNano())
 }
 
 // parseItem is a complex function because it needs to handle both forward and reverse iteration

--- a/manifest.go
+++ b/manifest.go
@@ -211,7 +211,7 @@ func (mf *manifestFile) addChanges(changesParam []*protos.ManifestChange) error 
 var magicText = [4]byte{'B', 'd', 'g', 'r'}
 
 // The magic version number.
-const magicVersion = 4
+const magicVersion = 5
 
 func helpRewrite(dir string, m *Manifest) (*os.File, int, error) {
 	rewritePath := filepath.Join(dir, manifestRewriteFilename)

--- a/structs.go
+++ b/structs.go
@@ -86,7 +86,7 @@ type Entry struct {
 	Key       []byte
 	Value     []byte
 	UserMeta  byte
-	ExpiresAt uint64 // time.Unix
+	ExpiresAt uint64 // time.UnixNano
 	meta      byte
 
 	// Fields maintained internally.

--- a/transaction.go
+++ b/transaction.go
@@ -275,7 +275,7 @@ func (txn *Txn) SetWithMeta(key, val []byte, meta byte) error {
 // (TTL) setting. A key stored with with a TTL would automatically expire after
 // the time has elapsed , and be eligible for garbage collection.
 func (txn *Txn) SetWithTTL(key, val []byte, dur time.Duration) error {
-	expire := time.Now().Add(dur).Unix()
+	expire := time.Now().Add(dur).UnixNano()
 	e := &Entry{Key: key, Value: val, ExpiresAt: uint64(expire)}
 	return txn.SetEntry(e)
 }


### PR DESCRIPTION
This involves a change in the way Badger stores data on disk, so
we need to increment the magic version as well.

This is basically #337 resurrected, with a magic version number change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/393)
<!-- Reviewable:end -->
