### PR TITLE
Commit: early callback

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -387,6 +387,13 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 	return item, nil
 }
 
+func (txn *Txn) runCallbacks() {
+	for _, cb := range txn.callbacks {
+		cb()
+	}
+	txn.callbacks = nil
+}
+
 // Discard discards a created transaction. This method is very important and must be called. Commit
 // method calls this internally, however, calling this multiple times doesn't cause any issues. So,
 // this can safely be called via a defer right when transaction is created.
@@ -397,10 +404,8 @@ func (txn *Txn) Discard() {
 		return
 	}
 	txn.discarded = true
+	txn.runCallbacks()
 
-	for _, cb := range txn.callbacks {
-		cb()
-	}
 	if txn.update {
 		txn.db.orc.decrRef()
 	}
@@ -464,6 +469,8 @@ func (txn *Txn) Commit(callback func(error)) error {
 	if err != nil {
 		return err
 	}
+
+	txn.runCallbacks()
 
 	if callback == nil {
 		// If batchSet failed, LSM would not have been updated. So, no need to rollback anything.


### PR DESCRIPTION
The change to transaction.go moves processing of the callbacks to a point at which no writes that might 
cause a new value log file to be opened. It solves #410 for me.

This is based on the assumptions that
1. the callback mechanism is only used for releasing read locks. (Is this correct? Do you have any other use planned?)
2. releasing the read locks before flushing write ops to disk is okay. API-wise, this should be the case, as far as I can see (from looking at `(*Item).Value` documentation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/413)
<!-- Reviewable:end -->
