### PR TITLE
add Iterator.Close to each examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ err := db.View(func(txn *badger.Txn) error {
     }
     fmt.Printf("key=%s, value=%s\n", k, v)
   }
+  it.Close()
   return nil
 })
 ```
@@ -366,6 +367,7 @@ db.View(func(txn *badger.Txn) error {
     }
     fmt.Printf("key=%s, value=%s\n", k, v)
   }
+  it.Close()
   return nil
 })
 ```
@@ -388,6 +390,7 @@ err := db.View(func(txn *badger.Txn) error {
     k := item.Key()
     fmt.Printf("key=%s\n", k)
   }
+  it.Close()
   return nil
 })
 ```

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ err := db.View(func(txn *badger.Txn) error {
   opts := badger.DefaultIteratorOptions
   opts.PrefetchSize = 10
   it := txn.NewIterator(opts)
+  defer it.Close()
   for it.Rewind(); it.Valid(); it.Next() {
     item := it.Item()
     k := item.Key()
@@ -337,7 +338,6 @@ err := db.View(func(txn *badger.Txn) error {
     }
     fmt.Printf("key=%s, value=%s\n", k, v)
   }
-  it.Close()
   return nil
 })
 ```
@@ -357,6 +357,7 @@ To iterate over a key prefix, you can combine `Seek()` and `ValidForPrefix()`:
 ```go
 db.View(func(txn *badger.Txn) error {
   it := txn.NewIterator(badger.DefaultIteratorOptions)
+  defer it.Close()
   prefix := []byte("1234")
   for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
     item := it.Item()
@@ -367,7 +368,6 @@ db.View(func(txn *badger.Txn) error {
     }
     fmt.Printf("key=%s, value=%s\n", k, v)
   }
-  it.Close()
   return nil
 })
 ```
@@ -385,12 +385,12 @@ err := db.View(func(txn *badger.Txn) error {
   opts := badger.DefaultIteratorOptions
   opts.PrefetchValues = false
   it := txn.NewIterator(opts)
+  defer it.Close()
   for it.Rewind(); it.Valid(); it.Next() {
     item := it.Item()
     k := item.Key()
     fmt.Printf("key=%s\n", k)
   }
-  it.Close()
   return nil
 })
 ```


### PR DESCRIPTION
Iterator must be closed, otherwise, serious memory leak might happen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/423)
<!-- Reviewable:end -->
