### PR TITLE
fix goroutine leak caused by log file lock

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -51,6 +51,9 @@ var (
 	// operation needs to be retried.
 	ErrRetry = errors.New("Unable to find log file. Please retry")
 
+	// ErrClosed is returned when a log file has already been closed
+	ErrClosed = errors.New("Log file closed")
+
 	// ErrThresholdZero is returned if threshold is set to zero, and value log GC is called.
 	// In such a case, GC can't be run.
 	ErrThresholdZero = errors.New(

--- a/value.go
+++ b/value.go
@@ -574,7 +574,8 @@ func (vlog *valueLog) Close() error {
 		if closeErr := f.fd.Close(); closeErr != nil && err == nil {
 			err = closeErr
 		}
-
+		f.fd = nil      // indicate the logFile has been closed
+		f.lock.Unlock() // unlock to release prefetch goroutines
 	}
 	return err
 }
@@ -752,6 +753,10 @@ func (vlog *valueLog) getFileRLocked(fid uint32) (*logFile, error) {
 		return nil, ErrRetry
 	}
 	ret.lock.RLock()
+	if ret.fd == nil {
+		ret.lock.RUnlock()
+		return nil, ErrClosed
+	}
 	return ret, nil
 }
 


### PR DESCRIPTION
This commit fixes a goroutine leak caused by log file lock (part of #421).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/426)
<!-- Reviewable:end -->
