### PR TITLE
Check specifically for `errNoRoom` when calling `ensureRoomForWrite`

### DIFF
--- a/db.go
+++ b/db.go
@@ -593,7 +593,7 @@ func (db *DB) writeRequests(reqs []*request) error {
 		}
 		count += len(b.Entries)
 		var i uint64
-		for err := db.ensureRoomForWrite(); err != nil; err = db.ensureRoomForWrite() {
+		for err := db.ensureRoomForWrite(); err == errNoRoom; err = db.ensureRoomForWrite() {
 			i++
 			if i%100 == 0 {
 				db.elog.Printf("Making room for writes")


### PR DESCRIPTION
Other errors should be handled outside the `for` loop (in the next [`if`](https://github.com/dgraph-io/badger/compare/master...schomatis:fix/write/errnoroom-check?expand=1#diff-7a117cbfd5485ed35efcbb2995c37aa0L606) which now appears to be dead code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/445)
<!-- Reviewable:end -->
