### PR TITLE
[WIP] Export block size option

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -288,6 +288,7 @@ func (s *levelsController) compactBuildTables(
 	for ; it.Valid(); i++ {
 		timeStart := time.Now()
 		builder := table.NewTableBuilder()
+		builder.SetBlockSize(s.kv.opt.BlockSize)
 		for ; it.Valid(); it.Next() {
 			if builder.ReachedCapacity(s.kv.opt.MaxTableSize) {
 				break

--- a/options.go
+++ b/options.go
@@ -80,6 +80,10 @@ type Options struct {
 	// is a private option used by ManagedDB.
 	managedTxns bool
 
+	// Number of key-value entries per block when flushing an
+	// in-memory Skiplist to the in-file Table (SST).
+	BlockSize int
+
 	// 4. Flags for testing purposes
 	// ------------------------------
 	DoNotCompact bool // Stops LSM tree from compactions.
@@ -115,4 +119,5 @@ var DefaultOptions = Options{
 	// MemoryMap to mmap() the value log files
 	ValueLogFileSize: 1 << 30,
 	ValueThreshold:   20,
+	BlockSize: 100,
 }

--- a/table/builder.go
+++ b/table/builder.go
@@ -78,6 +78,10 @@ type Builder struct {
 
 	restarts []uint32 // Base offsets of every block.
 
+	// Offsets of every entry within the current block being built.
+	// The offsets are relative to the start of the block.
+	entryOffsets []uint32
+
 	// Tracks offset for the previous key-value pair. Offset is relative to block base offset.
 	prevOffset uint32
 
@@ -144,6 +148,8 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	}
 	b.prevOffset = uint32(b.buf.Len()) - b.baseOffset // Remember current offset for the next Add call.
 
+	b.entryOffsets = append(b.entryOffsets, uint32(b.buf.Len()) - b.baseOffset)
+
 	// Layout: header, diffKey, value.
 	var hbuf [10]byte
 	h.Encode(hbuf[:])
@@ -158,6 +164,11 @@ func (b *Builder) finishBlock() {
 	// When we are at the end of the block and Valid=false, and the user wants to do a Prev,
 	// we need a dummy header to tell us the offset of the previous key-value pair.
 	b.addHelper([]byte{}, y.ValueStruct{})
+
+	b.buf.Write(b.entryIndex())
+	// Reset the entry offsets of the block for the next build.
+	b.entryOffsets = nil
+
 }
 
 // SetBlockSize configures the block size used for the builder, should
@@ -209,6 +220,32 @@ func (b *Builder) blockIndex() []byte {
 	}
 	binary.BigEndian.PutUint32(buf[:4], uint32(len(b.restarts)))
 	return out
+}
+
+// entryIndex generates the entry index for the block
+// (in a analogous way to `blockIndex`).
+// It is mainly a list of all the entry offsets.
+func (b *Builder) entryIndex() []byte {
+	// Remove the last (dummy) header added in `finishBlock`, it
+	// is used for the reverse iteration system and is not necessary
+	// in the entry offsets vector that will be used by the block iterator's
+	// `seek`.
+	// TODO: Remove this once the `Prev` and related fuctions are modified
+	// to leverage this entry index (and the dummy header is not added anymore).
+	b.entryOffsets = b.entryOffsets[:len(b.entryOffsets) - 1]
+
+	// Add 4 because we want to write out the length of the index at the end.
+	index := make([]byte, 4 * len(b.entryOffsets) + 4)
+	buf := index
+	for _, offset := range b.entryOffsets {
+		binary.BigEndian.PutUint32(buf[:4], offset)
+		buf = buf[4:]
+	}
+	// Write the number of entry offsets (not the number of bytes),
+	// to be read in `loadEntryIndex`.
+	binary.BigEndian.PutUint32(buf[:4], uint32(len(b.entryOffsets)))
+
+	return index
 }
 
 // Finish finishes the table by appending the index.

--- a/table/table.go
+++ b/table/table.go
@@ -98,7 +98,9 @@ type block struct {
 }
 
 func (b block) NewIterator() *blockIterator {
-	return &blockIterator{data: b.data}
+	bi := &blockIterator{data: b.data}
+	bi.loadEntryIndex()
+	return bi
 }
 
 // OpenTable assumes file has only one table and opens it.  Takes ownership of fd upon function


### PR DESCRIPTION
This is a work in progress, do not merge. It addresses issue #446.

It exports the number of entries per block (block size) configuration to Badger's options. There was no direct way for the table builder to reach the database general options so a temporal solution was used (passing the block size as a parameter and setting it with `SetBlockSize`).

The added test is a PoC benchmark to measure the performance impact of different block sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/447)
<!-- Reviewable:end -->
