### PR TITLE
Discard key versions during compaction

### DIFF
--- a/cmd/badger/cmd/info.go
+++ b/cmd/badger/cmd/info.go
@@ -72,7 +72,7 @@ func tableInfo(dir, valueDir string) error {
 	opts := badger.DefaultOptions
 	opts.Dir = sstDir
 	opts.ValueDir = vlogDir
-	// opts.ReadOnly = true // TODO: Make this readonly.
+	opts.ReadOnly = true
 
 	db, err := badger.Open(opts)
 	if err != nil {

--- a/cmd/badger/main.go
+++ b/cmd/badger/main.go
@@ -16,8 +16,23 @@
 
 package main
 
-import "github.com/dgraph-io/badger/cmd/badger/cmd"
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dgraph-io/badger/cmd/badger/cmd"
+)
 
 func main() {
+	go func() {
+		for i := 8080; i < 9080; i++ {
+			fmt.Printf("Listening for /debug HTTP requests at port: %d\n", i)
+			if err := http.ListenAndServe(fmt.Sprintf("localhost:%d", i), nil); err != nil {
+				fmt.Println("Port busy. Trying another one...")
+				continue
+
+			}
+		}
+	}()
 	cmd.Execute()
 }

--- a/compaction.go
+++ b/compaction.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"math"
 	"sync"
 
 	"golang.org/x/net/trace"
@@ -37,7 +38,7 @@ type keyRange struct {
 var infRange = keyRange{inf: true}
 
 func (r keyRange) String() string {
-	return fmt.Sprintf("[left=%q, right=%q, inf=%v]", r.left, r.right, r.inf)
+	return fmt.Sprintf("[left=%x, right=%x, inf=%v]", r.left, r.right, r.inf)
 }
 
 func (r keyRange) equals(dst keyRange) bool {
@@ -75,7 +76,10 @@ func getKeyRange(tables []*table.Table) keyRange {
 			biggest = tables[i].Biggest()
 		}
 	}
-	return keyRange{left: smallest, right: biggest}
+	return keyRange{
+		left:  y.KeyWithTs(y.ParseKey(smallest), math.MaxUint64),
+		right: y.KeyWithTs(y.ParseKey(biggest), 0),
+	}
 }
 
 type levelCompactStatus struct {

--- a/db.go
+++ b/db.go
@@ -1207,6 +1207,10 @@ func (db *DB) GetSequence(key []byte, bandwidth uint64) (*Sequence, error) {
 	return seq, err
 }
 
+func (db *DB) Tables() []TableInfo {
+	return db.lc.getTableInfo()
+}
+
 // MergeOperator represents a Badger merge operator.
 type MergeOperator struct {
 	sync.RWMutex

--- a/levels.go
+++ b/levels.go
@@ -313,9 +313,9 @@ func (s *levelsController) compactBuildTables(
 		for ; it.Valid(); it.Next() {
 			if !y.SameKey(it.Key(), lastKey) {
 				if builder.ReachedCapacity(s.kv.opt.MaxTableSize) {
-					// Only break if we are on a different key, and have reached capacity. We want to
-					// ensure that all versions of the key are stored in the same sstable, and not
-					// divided across multiple tables at the same level.
+					// Only break if we are on a different key, and have reached capacity. We want
+					// to ensure that all versions of the key are stored in the same sstable, and
+					// not divided across multiple tables at the same level.
 					break
 				}
 				lastKey = y.SafeCopy(lastKey, it.Key())
@@ -342,13 +342,15 @@ func (s *levelsController) compactBuildTables(
 				if !hasOverlap {
 					// If no overlap, we can skip all the versions, by continuing here.
 					numSkips++
-					cd.elog.LazyPrintf("Skipping key and all lower versions: %x. Version: %d.", dst, version)
+					cd.elog.LazyPrintf("Skipping key and all lower versions: %x. Version: %d.",
+						dst, version)
 					continue // Skip adding this key.
 				} else {
 					// If this key range has overlap with lower levels, then keep the deletion
 					// marker with the latest version, discarding the rest. This logic here
 					// would not continue, but has set the skipKey for the future iterations.
-					cd.elog.LazyPrintf("Skipping all lower versions: %x. Version: %d.", dst, version)
+					cd.elog.LazyPrintf("Skipping all lower versions for %x. Version: %d.",
+						dst, version)
 				}
 			}
 			numKeys++

--- a/levels.go
+++ b/levels.go
@@ -336,21 +336,14 @@ func (s *levelsController) compactBuildTables(
 				// versions. Ensure that we're only removing versions below readTs.
 				skipKey = y.SafeCopy(skipKey, it.Key())
 
-				var dst []byte
-				dst = append(dst, it.Key()...)
-
 				if !hasOverlap {
 					// If no overlap, we can skip all the versions, by continuing here.
 					numSkips++
-					cd.elog.LazyPrintf("Skipping key and all lower versions: %x. Version: %d.",
-						dst, version)
 					continue // Skip adding this key.
 				} else {
 					// If this key range has overlap with lower levels, then keep the deletion
 					// marker with the latest version, discarding the rest. This logic here
 					// would not continue, but has set the skipKey for the future iterations.
-					cd.elog.LazyPrintf("Skipping all lower versions for %x. Version: %d.",
-						dst, version)
 				}
 			}
 			numKeys++


### PR DESCRIPTION
- In response to #464 .
- If a key version has deletion marker or is expired, we can safely drop all the older versions of that key.
- If there's no overlap from lower levels, we can even drop the first such version.
- To avoid an edge case bug, we need to ensure that all versions of the same key are contained by the same SSTable. This is reflected by not closing a table as long as more versions are found. And by picking key ranges to include all versions of the keys. Both these measures ensure that all versions at the same level get compacted together.
- To avoid another edge case bug, we need to ensure that we don't drop versions above the current `readTs`. Note that managed DB would therefore not result in any version being discarded. Handling that is an open problem.

Badger Info:
- Print out the key ranges for each SSTable via `badger info`.
- Open an available port when running `badger` tool, so one can view the `/debug/request` and `/debug/events` links to understand what's going on behind the scenes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/471)
<!-- Reviewable:end -->
