### PR TITLE
Enable skiplist values that are up to 32 bits in length

### DIFF
--- a/skl/skl.go
+++ b/skl/skl.go
@@ -53,9 +53,8 @@ type node struct {
 	// Multiple parts of the value are encoded as a single uint64 so that it
 	// can be atomically loaded and stored:
 	//   value offset: uint32 (bits 0-31)
-	//   value size  : uint16 (bits 32-47)
-	// 12 bytes are allocated to ensure 8 byte alignment also on 32bit systems.
-	value [12]byte
+	//   value size  : uint32 (bits 32-63)
+	value uint64
 
 	// A byte slice is 24 bytes. We are trying to save space here.
 	keyOffset uint32 // Immutable. No need to lock to access key.
@@ -109,17 +108,17 @@ func newNode(arena *Arena, key []byte, v y.ValueStruct, height int) *node {
 	node.keyOffset = arena.putKey(key)
 	node.keySize = uint16(len(key))
 	node.height = uint16(height)
-	*node.value64BitAlignedPtr() = encodeValue(arena.putVal(v), v.EncodedSize())
+	node.value = encodeValue(arena.putVal(v), v.EncodedSize())
 	return node
 }
 
-func encodeValue(valOffset uint32, valSize uint16) uint64 {
+func encodeValue(valOffset uint32, valSize uint32) uint64 {
 	return uint64(valSize)<<32 | uint64(valOffset)
 }
 
-func decodeValue(value uint64) (valOffset uint32, valSize uint16) {
+func decodeValue(value uint64) (valOffset uint32, valSize uint32) {
 	valOffset = uint32(value)
-	valSize = uint16(value >> 32)
+	valSize = uint32(value >> 32)
 	return
 }
 
@@ -135,15 +134,8 @@ func NewSkiplist(arenaSize int64) *Skiplist {
 	}
 }
 
-func (s *node) value64BitAlignedPtr() *uint64 {
-	if uintptr(unsafe.Pointer(&s.value))%8 == 0 {
-		return (*uint64)(unsafe.Pointer(&s.value))
-	}
-	return (*uint64)(unsafe.Pointer(&s.value[4]))
-}
-
-func (s *node) getValueOffset() (uint32, uint16) {
-	value := atomic.LoadUint64(s.value64BitAlignedPtr())
+func (s *node) getValueOffset() (uint32, uint32) {
+	value := atomic.LoadUint64(&s.value)
 	return decodeValue(value)
 }
 
@@ -154,7 +146,7 @@ func (s *node) key(arena *Arena) []byte {
 func (s *node) setValue(arena *Arena, v y.ValueStruct) {
 	valOffset := arena.putVal(v)
 	value := encodeValue(valOffset, v.EncodedSize())
-	atomic.StoreUint64(s.value64BitAlignedPtr(), value)
+	atomic.StoreUint64(&s.value, value)
 }
 
 func (s *node) getNextOffset(h int) uint32 {

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -47,14 +47,14 @@ func sizeVarint(x uint64) (n int) {
 }
 
 // EncodedSize is the size of the ValueStruct when encoded
-func (v *ValueStruct) EncodedSize() uint16 {
+func (v *ValueStruct) EncodedSize() uint32 {
 	sz := len(v.Value) + 2 // meta, usermeta.
 	if v.ExpiresAt == 0 {
-		return uint16(sz + 1)
+		return uint32(sz + 1)
 	}
 
 	enc := sizeVarint(v.ExpiresAt)
-	return uint16(sz + enc)
+	return uint32(sz + enc)
 }
 
 // Decode uses the length of the slice to infer the length of the Value field.


### PR DESCRIPTION
Currently, inline skiplist values are limited to a length of 16 bits.
This commit increases that limit to 32 bits. It does this by making
node.value a uint64, and then packing the value offset and size into
it, as two uint32 values.

Because node.value is accessed with atomic.LoadUint64, it must be
aligned on a 64-bit boundary. This is guaranteed by Arena.putNode,
which is changed to always align on a 64-bit boundary rather than
on a pointer boundary (which would incorrectly align on 32-bit
boundary on a 32-bit machine).