### PR TITLE
Introduce NumVersionsToKeep

### DIFF
--- a/db.go
+++ b/db.go
@@ -242,7 +242,9 @@ func Open(opt Options) (db *DB, err error) {
 		isManaged:  opt.managedTxns,
 		nextCommit: 1,
 		commits:    make(map[uint64]uint64),
+		readMark:   y.WaterMark{},
 	}
+	orc.readMark.Init()
 
 	db = &DB{
 		imm:           make([]*skl.Skiplist, 0, opt.NumMemtables),

--- a/db_test.go
+++ b/db_test.go
@@ -1642,6 +1642,41 @@ func TestLSMOnly(t *testing.T) {
 	require.NoError(t, db.RunValueLogGC(0.2))
 }
 
+func TestMinReadTs(t *testing.T) {
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		for i := 0; i < 10; i++ {
+			require.NoError(t, db.Update(func(txn *Txn) error {
+				return txn.Set([]byte("x"), []byte("y"))
+			}))
+		}
+		time.Sleep(time.Millisecond)
+		require.Equal(t, uint64(10), db.orc.readTs())
+		min := db.orc.readMark.MinReadTs()
+		require.Equal(t, uint64(9), min)
+
+		readTxn := db.NewTransaction(false)
+		for i := 0; i < 10; i++ {
+			require.NoError(t, db.Update(func(txn *Txn) error {
+				return txn.Set([]byte("x"), []byte("y"))
+			}))
+		}
+		require.Equal(t, uint64(20), db.orc.readTs())
+		time.Sleep(time.Millisecond)
+		require.Equal(t, min, db.orc.readMark.MinReadTs())
+		readTxn.Discard()
+		time.Sleep(time.Millisecond)
+		require.Equal(t, uint64(19), db.orc.readMark.MinReadTs())
+
+		for i := 0; i < 10; i++ {
+			db.View(func(txn *Txn) error {
+				return nil
+			})
+		}
+		time.Sleep(time.Millisecond)
+		require.Equal(t, uint64(20), db.orc.readMark.MinReadTs())
+	})
+}
+
 func ExampleOpen() {
 	dir, err := ioutil.TempDir("", "badger")
 	if err != nil {

--- a/levels.go
+++ b/levels.go
@@ -297,29 +297,25 @@ func (s *levelsController) compactBuildTables(
 
 	it.Rewind()
 
-	readTs := s.kv.orc.readTs()
+	// Pick up the currently pending transactions' min readTs, so we can discard versions below this
+	// readTs. We should never discard any versions starting from above this timestamp, because that
+	// would affect the snapshot view guarantee provided by transactions.
+	readTs := s.kv.orc.readMark.MinReadTs()
+
 	// Start generating new tables.
 	type newTableResult struct {
 		table *table.Table
 		err   error
 	}
 	resultCh := make(chan newTableResult)
-	var numBuilds int
+	var numBuilds, numVersions int
 	var lastKey, skipKey []byte
 	for it.Valid() {
 		timeStart := time.Now()
 		builder := table.NewTableBuilder()
 		var numKeys, numSkips uint64
 		for ; it.Valid(); it.Next() {
-			if !y.SameKey(it.Key(), lastKey) {
-				if builder.ReachedCapacity(s.kv.opt.MaxTableSize) {
-					// Only break if we are on a different key, and have reached capacity. We want
-					// to ensure that all versions of the key are stored in the same sstable, and
-					// not divided across multiple tables at the same level.
-					break
-				}
-				lastKey = y.SafeCopy(lastKey, it.Key())
-			}
+			// See if we need to skip this key.
 			if len(skipKey) > 0 {
 				if y.SameKey(it.Key(), skipKey) {
 					numSkips++
@@ -329,9 +325,23 @@ func (s *levelsController) compactBuildTables(
 				}
 			}
 
+			if !y.SameKey(it.Key(), lastKey) {
+				if builder.ReachedCapacity(s.kv.opt.MaxTableSize) {
+					// Only break if we are on a different key, and have reached capacity. We want
+					// to ensure that all versions of the key are stored in the same sstable, and
+					// not divided across multiple tables at the same level.
+					break
+				}
+				lastKey = y.SafeCopy(lastKey, it.Key())
+				numVersions = 0
+			}
+			numVersions++ // Keep track of the number of versions encountered for this key.
+
 			vs := it.Value()
 			version := y.ParseTs(it.Key())
-			if version < readTs && isDeletedOrExpired(vs.Meta, vs.ExpiresAt) {
+			discard := isDeletedOrExpired(vs.Meta, vs.ExpiresAt) ||
+				numVersions > s.kv.opt.NumVersionsToKeep
+			if version < readTs && discard {
 				// If this version of the key is deleted or expired, skip all the rest of the
 				// versions. Ensure that we're only removing versions below readTs.
 				skipKey = y.SafeCopy(skipKey, it.Key())

--- a/levels.go
+++ b/levels.go
@@ -300,7 +300,7 @@ func (s *levelsController) compactBuildTables(
 	// Pick up the currently pending transactions' min readTs, so we can discard versions below this
 	// readTs. We should never discard any versions starting from above this timestamp, because that
 	// would affect the snapshot view guarantee provided by transactions.
-	readTs := s.kv.orc.readMark.MinReadTs()
+	minReadTs := s.kv.orc.readMark.MinReadTs()
 
 	// Start generating new tables.
 	type newTableResult struct {
@@ -338,7 +338,7 @@ func (s *levelsController) compactBuildTables(
 
 			vs := it.Value()
 			version := y.ParseTs(it.Key())
-			if version < readTs {
+			if version < minReadTs {
 				// Keep track of the number of versions encountered for this key. Only consider the
 				// versions which are below the minReadTs, otherwise, we might end up discarding the
 				// only valid version for a running transaction.

--- a/levels.go
+++ b/levels.go
@@ -338,7 +338,7 @@ func (s *levelsController) compactBuildTables(
 
 			vs := it.Value()
 			version := y.ParseTs(it.Key())
-			if version < minReadTs {
+			if version <= minReadTs {
 				// Keep track of the number of versions encountered for this key. Only consider the
 				// versions which are below the minReadTs, otherwise, we might end up discarding the
 				// only valid version for a running transaction.

--- a/options.go
+++ b/options.go
@@ -46,8 +46,11 @@ type Options struct {
 	// How should LSM tree be accessed.
 	TableLoadingMode options.FileLoadingMode
 
-	// How should value log be accessed
+	// How should value log be accessed.
 	ValueLogLoadingMode options.FileLoadingMode
+
+	// How many versions to keep per key.
+	NumVersionsToKeep int
 
 	// 3. Flags that user might want to review
 	// ----------------------------------------
@@ -114,6 +117,7 @@ var DefaultOptions = Options{
 	NumLevelZeroTablesStall: 10,
 	NumMemtables:            5,
 	SyncWrites:              true,
+	NumVersionsToKeep:       1,
 	// Nothing to read/write value log using standard File I/O
 	// MemoryMap to mmap() the value log files
 	ValueLogFileSize: 1 << 30,

--- a/value.go
+++ b/value.go
@@ -326,7 +326,7 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 	maxFid := atomic.LoadUint32(&vlog.maxFid)
 	y.AssertTruef(uint32(f.fid) < maxFid, "fid to move: %d. Current max fid: %d", f.fid, maxFid)
 
-	elog := trace.NewEventLog("badger", "vlog-rewrite")
+	elog := trace.NewEventLog("Badger", "vlog-rewrite")
 	defer elog.Finish()
 	elog.Printf("Rewriting fid: %d", f.fid)
 

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -1,0 +1,113 @@
+package y
+
+import (
+	"container/heap"
+	"sync/atomic"
+
+	"golang.org/x/net/trace"
+)
+
+type uint64Heap []uint64
+
+func (u uint64Heap) Len() int               { return len(u) }
+func (u uint64Heap) Less(i int, j int) bool { return u[i] < u[j] }
+func (u uint64Heap) Swap(i int, j int)      { u[i], u[j] = u[j], u[i] }
+func (u *uint64Heap) Push(x interface{})    { *u = append(*u, x.(uint64)) }
+func (u *uint64Heap) Pop() interface{} {
+	old := *u
+	n := len(old)
+	x := old[n-1]
+	*u = old[0 : n-1]
+	return x
+}
+
+type mark struct {
+	readTs uint64
+	done   bool // Set to true if the pending mutation is done.
+}
+type WaterMark struct {
+	markCh    chan mark
+	minReadTs uint64
+	elog      trace.EventLog
+}
+
+// Init initializes a WaterMark struct. MUST be called before using it.
+func (w *WaterMark) Init() {
+	w.markCh = make(chan mark, 1000)
+	w.elog = trace.NewEventLog("Badger", "MinReadTs")
+	go w.process()
+}
+
+func (w *WaterMark) Begin(readTs uint64) {
+	w.markCh <- mark{readTs: readTs, done: false}
+}
+func (w *WaterMark) Done(readTs uint64) {
+	w.markCh <- mark{readTs: readTs, done: true}
+}
+
+// DoneUntil returns the maximum index until which all tasks are done.
+func (w *WaterMark) MinReadTs() uint64 {
+	return atomic.LoadUint64(&w.minReadTs)
+}
+
+// process is used to process the Mark channel. This is not thread-safe,
+// so only run one goroutine for process. One is sufficient, because
+// all ops in the goroutine use only memory and cpu.
+func (w *WaterMark) process() {
+	var reads uint64Heap
+	// pending maps raft proposal index to the number of pending mutations for this proposal.
+	pending := make(map[uint64]int)
+
+	heap.Init(&reads)
+	var loop uint64
+
+	processOne := func(readTs uint64, done bool) {
+		// If not already done, then set. Otherwise, don't undo a done entry.
+		prev, present := pending[readTs]
+		if !present {
+			heap.Push(&reads, readTs)
+		}
+
+		delta := 1
+		if done {
+			delta = -1
+		}
+		pending[readTs] = prev + delta
+
+		loop++
+		if len(reads) > 0 && loop%1000 == 0 {
+			min := reads[0]
+			w.elog.Printf("ReadTs: %4d. Size: %4d MinReadTs: %-4d Looking for: %-4d. Value: %d\n",
+				readTs, len(reads), w.MinReadTs(), min, pending[min])
+		}
+
+		// Update mark by going through all reads in order; and checking if they have
+		// been done. Stop at the first readTs, which isn't done.
+		minReadTs := w.MinReadTs()
+		AssertTrue(minReadTs <= readTs)
+
+		until := minReadTs
+		loops := 0
+
+		for len(reads) > 0 {
+			min := reads[0]
+			if done := pending[min]; done != 0 {
+				break // len(reads) will be > 0.
+			}
+			heap.Pop(&reads)
+			delete(pending, min)
+			until = min
+			loops++
+		}
+		if until != minReadTs {
+			AssertTrue(atomic.CompareAndSwapUint64(&w.minReadTs, minReadTs, until))
+			w.elog.Printf("MinReadTs: %d. Loops: %d\n", until, loops)
+		}
+	}
+
+	for mark := range w.markCh {
+		if mark.readTs > 0 {
+			processOne(mark.readTs, mark.done)
+		}
+	}
+}

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -100,8 +100,9 @@ func (w *WaterMark) process() {
 		// Update mark by going through all reads in order; and checking if they have
 		// been done. Stop at the first readTs, which isn't done.
 		minReadTs := w.MinReadTs()
-		AssertTrue(minReadTs <= readTs)
-
+		// Don't assert that minReadTs < readTs, to avoid any inconsistencies caused by managed
+		// transactions, or testing where we explicitly set the readTs for transactions like in
+		// TestTxnVersions.
 		until := minReadTs
 		loops := 0
 

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package y
 
 import (


### PR DESCRIPTION
Allow users to specify how many versions to store per key. By default, this is set to one, because most users are only interested in the latest version of the key.

Fix: Instead of using the readTs by Oracle, we should be using the minimum readTs of any pending transaction. We should never discard any versions starting > `minReadTs`, only versions which are below `minReadTs`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/474)
<!-- Reviewable:end -->
