### PR TITLE
Add a new SetWithDiscard method.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -314,64 +314,6 @@ func TestForceCompactL0(t *testing.T) {
 	require.Equal(t, len(db.lc.levels[0].tables), 0)
 }
 
-func TestGetAfterPurge(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	opts := getTestOptions(dir)
-	opts.ValueLogFileSize = 15 << 20
-	db, err := OpenManaged(opts)
-	require.NoError(t, err)
-	defer db.Close()
-
-	data := func(i int) []byte {
-		return []byte(fmt.Sprintf("%b", i))
-	}
-	n := 80
-	m := 45 // Increasing would cause ErrTxnTooBig
-	sz := 32 << 10
-	v := make([]byte, sz)
-	for i := 0; i < n; i += 2 {
-		version := uint64(i)
-		txn := db.NewTransactionAt(version, true)
-		for j := 0; j < m; j++ {
-			require.NoError(t, txn.Set(data(j), v))
-		}
-		require.NoError(t, txn.CommitAt(version+1, nil))
-	}
-
-	for j := 10; j < m; j++ {
-		err := db.PurgeVersionsBelow(data(j), uint64(80))
-		require.NoError(t, err)
-	}
-	for i := 0; i < 10; i++ {
-		txn := db.NewTransactionAt(80, false)
-		item, err := txn.Get(data(i))
-		require.NoError(t, err)
-		require.Equal(t, item.Version(), uint64(79))
-		txn.Discard()
-	}
-	err = db.RunValueLogGC(0.2)
-	require.NoError(t, err)
-
-	for i := 10; i < m; i++ {
-		txn := db.NewTransactionAt(80, false)
-		_, err := txn.Get(data(i))
-		require.Equal(t, err, ErrKeyNotFound)
-		txn.Discard()
-	}
-
-	for i := 0; i < 10; i++ {
-		txn := db.NewTransactionAt(80, false)
-		item, err := txn.Get(data(i))
-		require.NoError(t, err)
-		require.Equal(t, item.Version(), uint64(79))
-		txn.Discard()
-	}
-
-}
-
 // Put a lot of data to move some data to disk.
 // WARNING: This test might take a while but it should pass!
 func TestGetMore(t *testing.T) {
@@ -903,12 +845,12 @@ func TestGetSetRace(t *testing.T) {
 	})
 }
 
-func TestPurgeVersionsBelow(t *testing.T) {
+func TestDiscardVersionsBelow(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		// Write 4 versions of the same key
 		for i := 0; i < 4; i++ {
 			err := db.Update(func(txn *Txn) error {
-				return txn.Set([]byte("answer"), []byte(fmt.Sprintf("%25d", i)))
+				return txn.Set([]byte("answer"), []byte(fmt.Sprintf("%d", i)))
 			})
 			require.NoError(t, err)
 		}
@@ -918,26 +860,26 @@ func TestPurgeVersionsBelow(t *testing.T) {
 		opts.PrefetchValues = false
 
 		// Verify that there are 4 versions, and record 3rd version (2nd from top in iteration)
-		var ts uint64
 		db.View(func(txn *Txn) error {
 			it := txn.NewIterator(opts)
 			var count int
 			for it.Rewind(); it.Valid(); it.Next() {
 				count++
 				item := it.Item()
-				if count == 2 {
-					ts = item.Version()
-				}
 				require.Equal(t, []byte("answer"), item.Key())
+				if item.DiscardEarlierVersions() {
+					break
+				}
 			}
 			require.Equal(t, 4, count)
 			return nil
 		})
 
-		// Delete all versions below the 3rd version
-		err := db.PurgeVersionsBelow([]byte("answer"), ts)
+		// Set new version and discard older ones.
+		err := db.Update(func(txn *Txn) error {
+			return txn.SetWithDiscard([]byte("answer"), []byte("5"), 0)
+		})
 		require.NoError(t, err)
-		require.NotEmpty(t, db.vlog.lfDiscardStats.m)
 
 		// Verify that there are only 2 versions left, and versions
 		// below ts have been deleted.
@@ -945,187 +887,14 @@ func TestPurgeVersionsBelow(t *testing.T) {
 			it := txn.NewIterator(opts)
 			var count int
 			for it.Rewind(); it.Valid(); it.Next() {
-				item := it.Item()
-				if item.Version() < ts {
-					require.True(t, item.meta&bitDelete > 0)
-				} else {
-					count++
-				}
-				require.Equal(t, []byte("answer"), item.Key())
-			}
-			require.Equal(t, 2, count)
-			return nil
-		})
-	})
-}
-
-func TestPurgeVersionsBelow2(t *testing.T) {
-	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
-		// Do a set and delete of same key
-		err := db.Update(func(txn *Txn) error {
-			return txn.Set([]byte("key"), []byte("value"))
-		})
-		require.NoError(t, err)
-
-		err = db.Update(func(txn *Txn) error {
-			return txn.Delete([]byte("key"))
-		})
-		require.NoError(t, err)
-
-		opts := DefaultIteratorOptions
-		opts.AllVersions = true
-		opts.PrefetchValues = false
-		// Verify that there are 2 versions and record highest version
-		var ts uint64
-		db.View(func(txn *Txn) error {
-			it := txn.NewIterator(opts)
-			var count int
-			for it.Rewind(); it.Valid(); it.Next() {
-				count++
-				item := it.Item()
-				require.Equal(t, []byte("key"), item.Key())
-				if count == 1 {
-					ts = item.Version()
-					require.True(t, item.meta&bitDelete > 0)
-					continue
-				}
-				val, err := item.Value()
-				require.NoError(t, err)
-				require.Equal(t, val, []byte("value"))
-			}
-			require.Equal(t, 2, count)
-			return nil
-		})
-
-		// Delete all versions
-		err = db.PurgeVersionsBelow([]byte("key"), ts)
-		require.NoError(t, err)
-
-		// Verify everything has been deleted
-		db.View(func(txn *Txn) error {
-			it := txn.NewIterator(opts)
-			var count int
-			for it.Rewind(); it.Valid(); it.Next() {
-				item := it.Item()
-				require.Equal(t, []byte("key"), item.Key())
-				require.True(t, item.meta&bitDelete > 0)
-				count++
-			}
-			require.Equal(t, 2, count)
-			return nil
-		})
-	})
-}
-
-func TestPurgeOlderVersions(t *testing.T) {
-	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
-		// Write two versions of a key
-		err := db.Update(func(txn *Txn) error {
-			return txn.Set([]byte("answer"), []byte("42"))
-		})
-		require.NoError(t, err)
-
-		err = db.Update(func(txn *Txn) error {
-			return txn.Set([]byte("answer"), []byte("43"))
-		})
-		require.NoError(t, err)
-
-		opts := DefaultIteratorOptions
-		opts.AllVersions = true
-		opts.PrefetchValues = false
-
-		// Verify that two versions are found during iteration
-		err = db.View(func(txn *Txn) error {
-			it := txn.NewIterator(opts)
-			var count int
-			for it.Rewind(); it.Valid(); it.Next() {
 				count++
 				item := it.Item()
 				require.Equal(t, []byte("answer"), item.Key())
-			}
-			require.Equal(t, 2, count)
-			return nil
-		})
-		require.NoError(t, err)
-
-		// Invoke DeleteOlderVersions() to delete older version
-		err = db.PurgeOlderVersions()
-		require.NoError(t, err)
-
-		// Verify that only one non-deleted version is found
-		err = db.View(func(txn *Txn) error {
-			it := txn.NewIterator(opts)
-			var count int
-			for it.Rewind(); it.Valid(); it.Next() {
-				count++
-				item := it.Item()
-				require.Equal(t, []byte("answer"), item.Key())
-				if count == 1 {
-					val, err := item.Value()
-					require.NoError(t, err)
-					require.Equal(t, []byte("43"), val)
-				} else {
-					require.True(t, item.meta&bitDelete > 0)
+				if item.DiscardEarlierVersions() {
+					break
 				}
 			}
-			require.Equal(t, 2, count)
-			return nil
-		})
-		require.NoError(t, err)
-	})
-}
-
-func TestPurgeOlderVersions2(t *testing.T) {
-	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
-		// Do a set and delete of same key
-		err := db.Update(func(txn *Txn) error {
-			return txn.Set([]byte("key"), []byte("value"))
-		})
-		require.NoError(t, err)
-
-		err = db.Update(func(txn *Txn) error {
-			return txn.Delete([]byte("key"))
-		})
-		require.NoError(t, err)
-
-		opts := DefaultIteratorOptions
-		opts.AllVersions = true
-		opts.PrefetchValues = false
-		// Verify that there are 2 versions
-		db.View(func(txn *Txn) error {
-			it := txn.NewIterator(opts)
-			var count int
-			for it.Rewind(); it.Valid(); it.Next() {
-				count++
-				item := it.Item()
-				require.Equal(t, []byte("key"), item.Key())
-				if count == 1 {
-					require.True(t, item.meta&bitDelete > 0)
-					continue
-				}
-				val, err := item.Value()
-				require.NoError(t, err)
-				require.Equal(t, val, []byte("value"))
-			}
-			require.Equal(t, 2, count)
-			return nil
-		})
-
-		// Delete all versions
-		err = db.PurgeOlderVersions()
-		require.NoError(t, err)
-
-		// Verify everything has been deleted
-		db.View(func(txn *Txn) error {
-			it := txn.NewIterator(opts)
-			var count int
-			for it.Rewind(); it.Valid(); it.Next() {
-				item := it.Item()
-				require.Equal(t, []byte("key"), item.Key())
-				require.True(t, item.meta&bitDelete > 0)
-				count++
-			}
-			require.Equal(t, 2, count)
+			require.Equal(t, 1, count)
 			return nil
 		})
 	})

--- a/iterator.go
+++ b/iterator.go
@@ -135,6 +135,10 @@ func (item *Item) IsDeletedOrExpired() bool {
 	return isDeletedOrExpired(item.meta, item.expiresAt)
 }
 
+func (item *Item) DiscardEarlierVersions() bool {
+	return item.meta&bitDiscardEarlierVersions > 0
+}
+
 func (item *Item) yieldItemValue() ([]byte, func(), error) {
 	if !item.hasValue() {
 		return nil, nil, nil

--- a/managed_db.go
+++ b/managed_db.go
@@ -72,13 +72,6 @@ func (txn *Txn) CommitAt(commitTs uint64, callback func(error)) error {
 	return txn.Commit(callback)
 }
 
-// PurgeVersionsBelow will delete all versions of a key below the specified version
-func (db *ManagedDB) PurgeVersionsBelow(key []byte, ts uint64) error {
-	txn := db.NewTransactionAt(ts, false)
-	defer txn.Discard()
-	return db.purgeVersionsBelow(txn, key, ts)
-}
-
 // GetSequence is not supported on ManagedDB. Calling this would result
 // in a panic.
 func (db *ManagedDB) GetSequence(_ []byte, _ uint64) (*Sequence, error) {

--- a/value.go
+++ b/value.go
@@ -1011,7 +1011,6 @@ func (vlog *valueLog) doRunGC(gcThreshold float64, head valuePointer) (err error
 		}
 		if discardEntry(e, vs) {
 			r.discard += esz
-			fmt.Println("discard")
 			return nil
 		}
 

--- a/value.go
+++ b/value.go
@@ -45,8 +45,9 @@ import (
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.
 const (
-	bitDelete       byte = 1 << 0 // Set if the key has been deleted.
-	bitValuePointer byte = 1 << 1 // Set if the value is NOT stored directly next to key.
+	bitDelete                 byte = 1 << 0 // Set if the key has been deleted.
+	bitValuePointer           byte = 1 << 1 // Set if the value is NOT stored directly next to key.
+	bitDiscardEarlierVersions byte = 1 << 2 // Set if earlier versions can be discarded.
 
 	// The MSB 2 bits are for transactions.
 	bitTxn    byte = 1 << 6 // Set if the entry is part of a txn.
@@ -1010,6 +1011,7 @@ func (vlog *valueLog) doRunGC(gcThreshold float64, head valuePointer) (err error
 		}
 		if discardEntry(e, vs) {
 			r.discard += esz
+			fmt.Println("discard")
 			return nil
 		}
 

--- a/value_test.go
+++ b/value_test.go
@@ -564,51 +564,12 @@ func TestValueLogTrigger(t *testing.T) {
 		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
 	}
 
-	require.NoError(t, kv.PurgeOlderVersions())
 	require.NoError(t, kv.RunValueLogGC(0.5))
 
 	require.NoError(t, kv.Close())
 
 	err = kv.RunValueLogGC(0.5)
 	require.Equal(t, ErrRejected, err, "Error should be returned after closing DB.")
-}
-
-func TestValueLogGC(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	opt := getTestOptions(dir)
-	opt.ValueLogFileSize = 15 << 20
-	runBadgerTest(t, &opt, func(t *testing.T, kv *DB) {
-		sz := 32 << 10
-		for j := 0; j < 40; j++ {
-			err := kv.Update(func(txn *Txn) error {
-				for i := 0; i < 45; i++ {
-					v := make([]byte, sz)
-					rand.Read(v[:rand.Intn(sz)])
-					require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v))
-				}
-				return nil
-			})
-			require.NoError(t, err)
-		}
-		fids := kv.vlog.sortedFids()
-		require.NoError(t, kv.PurgeOlderVersions())
-		require.NoError(t, kv.RunValueLogGC(0.3))
-		newFids := kv.vlog.sortedFids()
-		// No. of value log files after GC should be less than before.
-		// We should have GC-ed more than one value log file.
-		require.True(t, (len(fids)-len(newFids)) > 2)
-		for i, fid := range fids {
-			if i < len(newFids) && newFids[i] == fid {
-				continue
-			}
-			// Check that vlog is deleted.
-			_, err = os.Stat(fmt.Sprintf("dir%c%06d.vlog", os.PathSeparator, fid))
-			require.Error(t, err)
-		}
-	})
 }
 
 func createVlog(t *testing.T, entries []*Entry) []byte {


### PR DESCRIPTION
Add a new SetWithDiscard method, which indicates discarding of earlier versions. This information is used by compaction to discard versions. Value log GC can then discard key-value pairs which are no longer in the LSM tree (due to removal by compactions). Thus, this simple change removes the need to have PurgeBelowTs and other PurgeOlderVersions methods. Note that PurgeOlderVersions method is already made obsolete by NumVersionsToKeep option.

Only the flip side, this would make the prediction of which value log can be removed harder. Though, compaction can tackle that by updating the discard stats for value log. Maybe in another PR.

Also simplifies MergeOperator code.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/475)
<!-- Reviewable:end -->
