### PR TITLE
block iterator: seek with binary search

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -98,7 +98,9 @@ type block struct {
 }
 
 func (b block) NewIterator() *blockIterator {
-	return &blockIterator{data: b.data}
+	bi := &blockIterator{data: b.data}
+	bi.loadEntryIndex()
+	return bi
 }
 
 // OpenTable assumes file has only one table and opens it.  Takes ownership of fd upon function


### PR DESCRIPTION
Add entry offsets to the block iterator to use a binary search algorithm
in `Seek` instead of the linear search (with repetitive calls to `Next`). The
entire object can benefit from this index, but in this first iteration the
code is modified as less as possible, just the `Seek` function uses it. Because
of this the binary search still uses the `Next` logic to parse the tested
element to keep the consistency in the `pos` and `err` internal attributes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/481)
<!-- Reviewable:end -->
