### PR TITLE
BeforeCommit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/bookmarks.json

--- a/options.go
+++ b/options.go
@@ -102,6 +102,9 @@ type Options struct {
 
 	// Truncate value log to delete corrupt data, if any. Would not truncate if ReadOnly is set.
 	Truncate bool
+
+	// If provided, will be called inside (*DB) Update(...) right before txn.Commit(nil).
+	BeforeCommit func(txn *Txn, key, val []byte) error
 }
 
 // DefaultOptions sets a list of recommended options for good performance.


### PR DESCRIPTION
A `BeforeCommit func(txn *Txn, key, val []byte) error` function added to database options. This allows interesting scenarios for performing extra stuff inside the same transaction.

I have implemented this because I wanted to implement an embedded document database based on `badger`.

Using `BeforeCommit(...)` function, it is very easy to implement secondary indexes and even arbitrary indexes like views in CouchDB (I am taking this path).

And if `BeforeCommit` is not provided (being `nil`) or if `len(txn.pendingWrites) == 0`, then it will be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/486)
<!-- Reviewable:end -->
