### PR TITLE
Fixes #482 (be careful not to reuse keys and vals arguments of transaction methods)

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -320,7 +320,7 @@ func (txn *Txn) modify(e *Entry) error {
 // with other metadata to the database.
 //
 // The current transaction keeps a reference to the entry passed in argument.
-// Users must not modify the entry the end of the transaction.
+// Users must not modify the entry until the end of the transaction.
 func (txn *Txn) SetEntry(e *Entry) error {
 	return txn.modify(e)
 }


### PR DESCRIPTION
PR to improve documentation as requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/488)
<!-- Reviewable:end -->
