### PR TITLE
Alloc enough space is better than multi append

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -169,8 +169,10 @@ func (item *Item) yieldItemValue() ([]byte, func(), error) {
 		// move key and read that instead.
 		runCallback(cb)
 		// Do not put badgerMove on the left in append. It seems to cause some sort of manipulation.
-		key = append([]byte{}, badgerMove...)
-		key = append(key, y.KeyWithTs(item.Key(), item.Version())...)
+		keyTs := y.KeyWithTs(item.Key(), item.Version())
+		key = make([]byte, len(badgerMove)+len(keyTs))
+		n := copy(key, badgerMove)
+		copy(key[n:], keyTs)
 		// Note that we can't set item.key to move key, because that would
 		// change the key user sees before and after this call. Also, this move
 		// logic is internal logic and should not impact the external behavior

--- a/value.go
+++ b/value.go
@@ -387,8 +387,9 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 			if bytes.HasPrefix(e.Key, badgerMove) {
 				ne.Key = append([]byte{}, e.Key...)
 			} else {
-				ne.Key = append([]byte{}, badgerMove...)
-				ne.Key = append(ne.Key, e.Key...)
+				ne.Key = make([]byte, len(badgerMove)+len(e.Key))
+				n := copy(ne.Key, badgerMove)
+				copy(ne.Key[n:], e.Key)
 			}
 
 			ne.Value = append([]byte{}, e.Value...)


### PR DESCRIPTION
I do some benchmark for this:

Code: 
```
var (
        v1 = []byte("hello")
        v2 = []byte("world")
)

func Append() {
        v := append([]byte{}, v1...)
        v = append(v, v2...)
}

func Copy() {
        v := make([]byte, len(v1)+len(v2))
        n := copy(v, v1)
        copy(v[n:], v2)
}
```

Bench Code:
```
func BenchmarkAppend(b *testing.B) {
        for i := 0; i < b.N; i++ {
                Append()
        }
}

func BenchmarkCopy(b *testing.B) {
        for i := 0; i < b.N; i++ {
                Copy()
        }
}
```

Bench Reusult:

```
BenchmarkAppend-32      20000000                77.0 ns/op            24 B/op          2 allocs/op
BenchmarkCopy-32        50000000                37.5 ns/op            16 B/op          1 allocs/op
PASS
ok      demo/append     3.537s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/518)
<!-- Reviewable:end -->
