### PR TITLE
Add a DropAll method in ManagedDB

### DIFF
--- a/db.go
+++ b/db.go
@@ -856,7 +856,12 @@ func (db *DB) flushMemtable(lc *y.Closer) error {
 
 		// Update s.imm. Need a lock.
 		db.Lock()
-		y.AssertTrue(ft.mt == db.imm[0]) //For now, single threaded.
+		// This is a single-threaded operation. ft.mt corresponds to the head of
+		// db.imm list. Once we flush it, we advance db.imm. The next ft.mt
+		// which would arrive here would match db.imm[0], because we acquire a
+		// lock over DB when pushing to flushChan.
+		// TODO: This logic is dirty AF. Any change and this could easily break.
+		y.AssertTrue(ft.mt == db.imm[0])
 		db.imm = db.imm[1:]
 		ft.mt.DecrRef() // Return memory.
 		db.Unlock()

--- a/db_test.go
+++ b/db_test.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"math"
 	"math/rand"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1574,4 +1575,14 @@ func ExampleTxn_NewIterator() {
 	fmt.Printf("Counted %d elements", count)
 	// Output:
 	// Counted 1000 elements
+}
+
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+	go func() {
+		if err := http.ListenAndServe("localhost:8080", nil); err != nil {
+			log.Fatalf("Unable to open http port at 8080")
+		}
+	}()
+	os.Exit(m.Run())
 }

--- a/errors.go
+++ b/errors.go
@@ -96,6 +96,10 @@ var (
 	// ErrTruncateNeeded is returned when the value log gets corrupt, and requires truncation of
 	// corrupt data to allow Badger to run properly.
 	ErrTruncateNeeded = errors.New("Value log truncate required to run DB. This might result in data loss.")
+
+	// ErrBlockedWrites is returned if the user called DropAll. During the process of dropping all
+	// data from Badger, we stop accepting new writes, by returning this error.
+	ErrBlockedWrites = errors.New("Writes are blocked possibly due to DropAll")
 )
 
 // Key length can't be more than uint16, as determined by table::header.

--- a/levels.go
+++ b/levels.go
@@ -208,8 +208,10 @@ func (s *levelsController) deleteLSMTree() (int, error) {
 
 	for _, l := range s.levels {
 		l.Lock()
+		l.totalSize = 0
 		if l.level == 0 && len(l.tables) > 1 {
 			l.tables = []*table.Table{keepOne}
+			l.totalSize += keepOne.Size()
 		} else {
 			l.tables = l.tables[:0]
 		}

--- a/managed_db.go
+++ b/managed_db.go
@@ -17,7 +17,6 @@
 package badger
 
 import (
-	"fmt"
 	"math"
 	"sync/atomic"
 	"time"
@@ -128,10 +127,8 @@ func (db *ManagedDB) DropAll() error {
 	atomic.StoreInt32(&db.blockWrites, 0)
 	// Need compactions to happen so deletes below can be flushed out.
 	if db.closers.compactors != nil {
-		fmt.Println("Starting compactions.")
 		db.closers.compactors = y.NewCloser(1)
 		db.lc.startCompact(db.closers.compactors)
-		fmt.Println("Done")
 	}
 	if err != nil {
 		return err

--- a/managed_db.go
+++ b/managed_db.go
@@ -98,13 +98,9 @@ var errDone = errors.New("Done deleting keys")
 
 // DropAll would drop all the data stored in Badger. It does this in the following way.
 // - Stop accepting new writes.
-// - Flush out all memtables.
-// - Push one update, and flush memtables again.
 // - Pause the compactions.
 // - Pick all tables from all levels, create a changeset to delete all these tables and apply it to
 // manifest. DO not pick up the latest table from level 0, to preserve the (persistent) badgerHead key.
-// - Iterate over DB, we should have zero KVs.
-// - TODO: Update logic to use flushChan.
 // - Iterate over the KVs in Level 0, and run deletes on them via transactions.
 //
 // NOTE: The timestamp used for writes must be greater than the max timestamp of

--- a/managed_db.go
+++ b/managed_db.go
@@ -99,8 +99,9 @@ var errDone = errors.New("Done deleting keys")
 // DropAll would drop all the data stored in Badger. It does this in the following way.
 // - Stop accepting new writes.
 // - Pause the compactions.
-// - Pick all tables from all levels, create a changeset to delete all these tables and apply it to
-// manifest. DO not pick up the latest table from level 0, to preserve the (persistent) badgerHead key.
+// - Pick all tables from all levels, create a changeset to delete all these
+// tables and apply it to manifest. DO not pick up the latest table from level
+// 0, to preserve the (persistent) badgerHead key.
 // - Iterate over the KVs in Level 0, and run deletes on them via transactions.
 //
 // NOTE: The timestamp used for writes must be greater than the max timestamp of

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -1,0 +1,137 @@
+package badger
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/y"
+	"github.com/stretchr/testify/require"
+)
+
+func val(large bool) []byte {
+	var buf []byte
+	if large {
+		buf = make([]byte, 64)
+	} else {
+		buf = make([]byte, 16)
+	}
+	rand.Read(buf)
+	return buf
+}
+
+func numKeys(mdb *ManagedDB, readTs uint64) int {
+	txn := mdb.NewTransactionAt(readTs, false)
+	defer txn.Discard()
+
+	itr := txn.NewIterator(DefaultIteratorOptions)
+	defer itr.Close()
+
+	var count int
+	for itr.Rewind(); itr.Valid(); itr.Next() {
+		count++
+	}
+	fmt.Println("itr done for numkeys")
+	return count
+}
+
+func TestDropAll(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	opts := getTestOptions(dir)
+	mdb, err := OpenManaged(opts)
+	require.NoError(t, err)
+
+	N := uint64(20000)
+	populate := func(db *ManagedDB, start uint64) {
+		var wg sync.WaitGroup
+		for i := start; i < start+N; i++ {
+			wg.Add(1)
+			txn := db.NewTransactionAt(math.MaxUint64, true)
+			require.NoError(t, txn.Set([]byte(key("key", int(i))), val(false)))
+			require.NoError(t, txn.CommitAt(uint64(i), func(err error) {
+				require.NoError(t, err)
+				wg.Done()
+			}))
+		}
+		wg.Wait()
+	}
+
+	populate(mdb, 1)
+	require.Equal(t, int(N), numKeys(mdb, math.MaxUint64))
+
+	require.NoError(t, mdb.DropAll())
+	fmt.Println("Now checking num keys")
+	require.Equal(t, 0, numKeys(mdb, math.MaxUint64))
+
+	// Check that we can still write to mdb.
+	populate(mdb, N+1)
+	require.Equal(t, int(N), numKeys(mdb, math.MaxUint64))
+	mdb.Close()
+
+	// Ensure that value log is correctly replayed, that we are preserving badgerHead.
+	mdb2, err := OpenManaged(opts)
+	require.NoError(t, err)
+	require.Equal(t, int(N), numKeys(mdb2, math.MaxUint64))
+	mdb2.Close()
+}
+
+func TestDropAllRace(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	opts := getTestOptions(dir)
+	mdb, err := OpenManaged(opts)
+	require.NoError(t, err)
+
+	N := 10000
+	// Start a goroutine to keep trying to write to DB while DropAll happens.
+	closer := y.NewCloser(1)
+	go func() {
+		defer closer.Done()
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+
+		i := N + 1 // Writes would happen above N.
+		for {
+			select {
+			case <-ticker.C:
+				i++
+				txn := mdb.NewTransactionAt(math.MaxUint64, true)
+				require.NoError(t, txn.Set([]byte(key("key", i)), val(false)))
+				_ = txn.CommitAt(uint64(i), nil)
+			case <-closer.HasBeenClosed():
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 1; i <= N; i++ {
+		wg.Add(1)
+		txn := mdb.NewTransactionAt(math.MaxUint64, true)
+		require.NoError(t, txn.Set([]byte(key("key", i)), val(false)))
+		require.NoError(t, txn.CommitAt(uint64(i), func(err error) {
+			require.NoError(t, err)
+			wg.Done()
+		}))
+	}
+	wg.Wait()
+
+	before := numKeys(mdb, math.MaxUint64)
+	require.True(t, before > N)
+
+	require.NoError(t, mdb.DropAll())
+	closer.SignalAndWait()
+
+	after := numKeys(mdb, math.MaxUint64)
+	t.Logf("Before: %d. After dropall: %d\n", before, after)
+	require.True(t, after < before)
+	mdb.Close()
+}

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -1,7 +1,6 @@
 package badger
 
 import (
-	"fmt"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -36,7 +35,6 @@ func numKeys(mdb *ManagedDB, readTs uint64) int {
 	for itr.Rewind(); itr.Valid(); itr.Next() {
 		count++
 	}
-	fmt.Println("itr done for numkeys")
 	return count
 }
 
@@ -48,7 +46,7 @@ func TestDropAll(t *testing.T) {
 	mdb, err := OpenManaged(opts)
 	require.NoError(t, err)
 
-	N := uint64(20000)
+	N := uint64(10000)
 	populate := func(db *ManagedDB, start uint64) {
 		var wg sync.WaitGroup
 		for i := start; i < start+N; i++ {
@@ -67,7 +65,6 @@ func TestDropAll(t *testing.T) {
 	require.Equal(t, int(N), numKeys(mdb, math.MaxUint64))
 
 	require.NoError(t, mdb.DropAll())
-	fmt.Println("Now checking num keys")
 	require.Equal(t, 0, numKeys(mdb, math.MaxUint64))
 
 	// Check that we can still write to mdb.


### PR DESCRIPTION
This method drops all tables from the LSM tree, except one to maintain the persistence of `badgerHead` key. This is important to avoid value log being replayed from scratch.

It then iterates over the rest of the keys and marks them as deleted. The end result should be that all keys are considered deleted.

NOTE to users: The timestamp used for writes must be greater than the max timestamp of writes before DropAll, to ensure that new writes are not lower than the delete markers in terms of versioning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/525)
<!-- Reviewable:end -->
