### PR TITLE
Share max batch count and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Below is a list of known projects that use Badger:
 * [go-ipfs](https://github.com/ipfs/go-ipfs) - Go client for the InterPlanetary File System (IPFS), a new hypermedia distribution protocol.
 * [gorush](https://github.com/appleboy/gorush) - A push notification server written in Go.
 * [emitter](https://github.com/emitter-io/emitter) - Scalable, low latency, distributed pub/sub broker with message storage, uses MQTT, gossip and badger.
+* [GarageMQ](https://github.com/valinurovam/garagemq) - AMQP server written in Go.
 
 If you are using Badger in a project please send a pull request to add it to the list.
 

--- a/db.go
+++ b/db.go
@@ -1091,6 +1091,16 @@ func (db *DB) Tables() []TableInfo {
 	return db.lc.getTableInfo()
 }
 
+// MaxBatchCount returns max possible entries in batch
+func (db *DB) MaxBatchCount() int64 {
+	return db.opt.maxBatchCount
+}
+
+// MaxBatchCount returns max possible batch size
+func (db *DB) MaxBatchSize() int64 {
+	return db.opt.maxBatchSize
+}
+
 // MergeOperator represents a Badger merge operator.
 type MergeOperator struct {
 	sync.RWMutex


### PR DESCRIPTION
Cause badger can exec batch transactions, it should be easy to know current max batch size and count. Otherwise user (for me for example) take an error like
ErrTxnTooBig = errors.New("Txn is too big to fit into one request")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/561)
<!-- Reviewable:end -->
