### PR TITLE
Merge ManagedDB back into DB

### DIFF
--- a/db.go
+++ b/db.go
@@ -242,7 +242,7 @@ func Open(opt Options) (db *DB, err error) {
 	}()
 
 	orc := &oracle{
-		isManaged:  opt.managedTxns,
+		isManaged:  opt.ManagedTxns,
 		nextCommit: 1,
 		commits:    make(map[uint64]uint64),
 		readMark:   y.WaterMark{},
@@ -1069,7 +1069,13 @@ func (seq *Sequence) updateLease() error {
 // available, in the database. Sequence can be used to get a list of monotonically increasing
 // integers. Multiple sequences can be created by providing different keys. Bandwidth sets the
 // size of the lease, determining how many Next() requests can be served from memory.
+//
+// GetSequence is not supported on ManagedDB. Calling this would result in a panic.
 func (db *DB) GetSequence(key []byte, bandwidth uint64) (*Sequence, error) {
+	if db.opt.ManagedTxns {
+		panic("Cannot use GetSequence with ManagedTxns=true.")
+	}
+
 	switch {
 	case len(key) == 0:
 		return nil, ErrEmptyKey

--- a/db_test.go
+++ b/db_test.go
@@ -290,7 +290,8 @@ func TestForceCompactL0(t *testing.T) {
 
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 15 << 20
-	db, err := OpenManaged(opts)
+	opts.ManagedTxns = true
+	db, err := Open(opts)
 	require.NoError(t, err)
 
 	data := func(i int) []byte {
@@ -310,7 +311,8 @@ func TestForceCompactL0(t *testing.T) {
 	}
 	db.Close()
 
-	db, err = OpenManaged(opts)
+	opts.ManagedTxns = true
+	db, err = Open(opts)
 	defer db.Close()
 	require.Equal(t, len(db.lc.levels[0].tables), 0)
 }

--- a/managed_db.go
+++ b/managed_db.go
@@ -26,72 +26,40 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ManagedDB allows end users to manage the transactions themselves. Transaction
-// start and commit timestamps are set by end-user.
-//
-// This is only useful for databases built on top of Badger (like Dgraph), and
-// can be ignored by most users.
-//
-// WARNING: This is an experimental feature and may be changed significantly in
-// a future release. So please proceed with caution.
-type ManagedDB struct {
-	*DB
-}
-
-// OpenManaged returns a new ManagedDB, which allows more control over setting
-// transaction timestamps.
-//
-// This is only useful for databases built on top of Badger (like Dgraph), and
-// can be ignored by most users.
-func OpenManaged(opts Options) (*ManagedDB, error) {
-	opts.managedTxns = true
-	db, err := Open(opts)
-	if err != nil {
-		return nil, err
-	}
-	return &ManagedDB{db}, nil
-}
-
-// NewTransaction overrides DB.NewTransaction() and panics when invoked. Use
-// NewTransactionAt() instead.
-func (db *ManagedDB) NewTransaction(update bool) {
-	panic("Cannot use NewTransaction() for ManagedDB. Use NewTransactionAt() instead.")
-}
-
 // NewTransactionAt follows the same logic as DB.NewTransaction(), but uses the
 // provided read timestamp.
 //
 // This is only useful for databases built on top of Badger (like Dgraph), and
 // can be ignored by most users.
-func (db *ManagedDB) NewTransactionAt(readTs uint64, update bool) *Txn {
-	txn := db.DB.NewTransaction(update)
+func (db *DB) NewTransactionAt(readTs uint64, update bool) *Txn {
+	if !db.opt.ManagedTxns {
+		panic("Cannot use NewTransactionAt with ManagedTxns=false. Use NewTransaction instead.")
+	}
+	txn := db.NewTransaction(update)
 	txn.readTs = readTs
 	return txn
 }
 
 // CommitAt commits the transaction, following the same logic as Commit(), but
-// at the given commit timestamp. This will panic if not used with ManagedDB.
+// at the given commit timestamp. This will panic if not used with managed transactions.
 //
 // This is only useful for databases built on top of Badger (like Dgraph), and
 // can be ignored by most users.
 func (txn *Txn) CommitAt(commitTs uint64, callback func(error)) error {
-	if !txn.db.opt.managedTxns {
-		return ErrManagedTxn
+	if !txn.db.opt.ManagedTxns {
+		panic("Cannot use CommitAt with ManagedTxns=false. Use Commit instead.")
 	}
 	txn.commitTs = commitTs
 	return txn.Commit(callback)
 }
 
-// GetSequence is not supported on ManagedDB. Calling this would result
-// in a panic.
-func (db *ManagedDB) GetSequence(_ []byte, _ uint64) (*Sequence, error) {
-	panic("Cannot use GetSequence for ManagedDB.")
-}
-
 // SetDiscardTs sets a timestamp at or below which, any invalid or deleted
 // versions can be discarded from the LSM tree, and thence from the value log to
-// reclaim disk space.
-func (db *ManagedDB) SetDiscardTs(ts uint64) {
+// reclaim disk space. Can only be used with managed transactions.
+func (db *DB) SetDiscardTs(ts uint64) {
+	if !db.opt.ManagedTxns {
+		panic("Cannot use SetDiscardTs with ManagedTxns=false.")
+	}
 	db.orc.setDiscardTs(ts)
 }
 
@@ -106,7 +74,12 @@ var errDone = errors.New("Done deleting keys")
 // - Iterate over the KVs in Level 0, and run deletes on them via transactions.
 // - The deletions are done at the same timestamp as the latest version of the
 // key. Thus, we could write the keys back at the same timestamp as before.
-func (db *ManagedDB) DropAll() error {
+//
+// DropAll is only available with managed transactions.
+func (db *DB) DropAll() error {
+	if !db.opt.ManagedTxns {
+		panic("DropAll is only available with ManagedTxns=true.")
+	}
 	// Stop accepting new writes.
 	atomic.StoreInt32(&db.blockWrites, 1)
 

--- a/managed_db.go
+++ b/managed_db.go
@@ -26,6 +26,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// OpenManaged returns a new DB, which allows more control over setting
+// transaction timestamps, by setting ManagedTxns=true.
+//
+// This is only useful for databases built on top of Badger (like Dgraph), and
+// can be ignored by most users.
+func OpenManaged(opts Options) (*DB, error) {
+	opts.ManagedTxns = true
+	return Open(opts)
+}
+
 // NewTransactionAt follows the same logic as DB.NewTransaction(), but uses the
 // provided read timestamp.
 //

--- a/options.go
+++ b/options.go
@@ -83,9 +83,10 @@ type Options struct {
 	// Number of compaction workers to run concurrently.
 	NumCompactors int
 
-	// Transaction start and commit timestamps are manaVgedTxns by end-user. This
-	// is a private option used by ManagedDB.
-	managedTxns bool
+	// Transaction start and commit timestamps are managed by end-user.
+	// This is only useful for databases built on top of Badger (like Dgraph).
+	// Not recommended for most users.
+	ManagedTxns bool
 
 	// 4. Flags for testing purposes
 	// ------------------------------

--- a/value.go
+++ b/value.go
@@ -467,7 +467,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 	return nil
 }
 
-func (vlog *valueLog) deleteMoveKeysFor(fid uint32, tr trace.Trace) {
+func (vlog *valueLog) deleteMoveKeysFor(fid uint32, tr trace.Trace) error {
 	db := vlog.kv
 	var result []*Entry
 	var count, pointers uint64
@@ -498,7 +498,7 @@ func (vlog *valueLog) deleteMoveKeysFor(fid uint32, tr trace.Trace) {
 	if err != nil {
 		tr.LazyPrintf("Got error while iterating move keys: %v", err)
 		tr.SetError()
-		return
+		return err
 	}
 	tr.LazyPrintf("Num total move keys: %d. Num pointers: %d", count, pointers)
 	tr.LazyPrintf("Number of invalid move keys found: %d", len(result))
@@ -516,12 +516,12 @@ func (vlog *valueLog) deleteMoveKeysFor(fid uint32, tr trace.Trace) {
 			}
 			tr.LazyPrintf("Error while doing batchSet: %v", err)
 			tr.SetError()
-			return
+			return err
 		}
 		i += batchSize
 	}
 	tr.LazyPrintf("Move keys deletion done.")
-	return
+	return nil
 }
 
 func (vlog *valueLog) incrIteratorCount() {
@@ -1215,8 +1215,7 @@ func (vlog *valueLog) runGC(discardRatio float64, head valuePointer) error {
 			tried[lf.fid] = true
 			err = vlog.doRunGC(lf, discardRatio, tr)
 			if err == nil {
-				vlog.deleteMoveKeysFor(lf.fid, tr)
-				return nil
+				return vlog.deleteMoveKeysFor(lf.fid, tr)
 			}
 		}
 		return err


### PR DESCRIPTION
Remove the extra ManagedDB struct, which was causing maintenance headaches, due to the way Go handles polymorphism. Instead just expose the ManagedTxns option, and use it directly within the codebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/568)
<!-- Reviewable:end -->
