### PR TITLE
Added atomic loadUint32 due to race condition 

### DIFF
--- a/value.go
+++ b/value.go
@@ -929,7 +929,8 @@ func (vlog *valueLog) getFileRLocked(fid uint32) (*logFile, error) {
 // TODO: Make this read private.
 func (vlog *valueLog) Read(vp valuePointer, s *y.Slice) ([]byte, func(), error) {
 	// Check for valid offset if we are reading to writable log.
-	if vp.Fid == vlog.maxFid && vp.Offset >= vlog.writableOffset() {
+  maxFid := atomic.LoadUint32(&vlog.maxFid)
+	if vp.Fid == maxFid && vp.Offset >= vlog.writableOffset() {
 		return nil, nil, errors.Errorf(
 			"Invalid value pointer offset: %d greater than current offset: %d",
 			vp.Offset, vlog.writableOffset())


### PR DESCRIPTION
When running a badger app with -race flag the following error below was emitted. This fix wraps an atomic load around the maxFid variable. 

==================
WARNING: DATA RACE
Write at 0x00c42045a218 by goroutine 289:
  sync/atomic.AddInt32()
      /usr/local/go/src/runtime/race_amd64.s:269 +0xb
  foobar/vendor/github.com/dgraph-io/badger.(*valueLog).write.func1()
      /mnt/billybob/golang/src/foobar/vendor/github.com/dgraph-io/badger/value.go:859 +0x5a0
  foobar/vendor/github.com/dgraph-io/badger.(*valueLog).write()
      /mnt/billybob/golang/src/foobar/vendor/github.com/dgraph-io/badger/value.go:899 +0x70d
  foobar/vendor/github.com/dgraph-io/badger.(*DB).writeRequests()
      /mnt/billybob/golang/src/foobar/vendor/github.com/dgraph-io/badger/db.go:588 +0x160
  foobar/vendor/github.com/dgraph-io/badger.(*DB).doWrites.func1()
      /mnt/billybob/golang/src/foobar/vendor/github.com/dgraph-io/badger/db.go:657 +0x6f

Previous read at 0x00c42045a218 by goroutine 144:
  foobar/vendor/github.com/dgraph-io/badger.(*valueLog).Read()
      /mnt/billybob/golang/src/foobar/vendor/github.com/dgraph-io/badger/value.go:928 +0x57
  foobar/vendor/github.com/dgraph-io/badger.(*Item).yieldItemValue()
      /mnt/billybob/golang/src/foobar/vendor/github.com/dgraph-io/badger/iterator.go:162 +0x20e
  foobar/vendor/github.com/dgraph-io/badger.(*Item).Value()
      /mnt/billybob/golang/src/foobar/vendor/github.com/dgraph-io/badger/iterator.go:103 +0x84

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/571)
<!-- Reviewable:end -->
