### PR TITLE
Add a Jepsen style bank test for Badger

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -163,15 +163,14 @@ func (db *DB) Load(r io.Reader) error {
 			return err
 		}
 	}
-
 	wg.Wait()
-	// Mark all versions done up until nextTxnTs.
-	db.orc.txnMark.Done(db.orc.nextTxnTs - 1)
 
 	select {
 	case err := <-errChan:
 		return err
 	default:
+		// Mark all versions done up until nextTxnTs.
+		db.orc.txnMark.Done(db.orc.nextTxnTs - 1)
 		return nil
 	}
 }

--- a/backup.go
+++ b/backup.go
@@ -165,6 +165,8 @@ func (db *DB) Load(r io.Reader) error {
 	}
 
 	wg.Wait()
+	// Mark all versions done up until nextTxnTs.
+	db.orc.txnMark.Done(db.orc.nextTxnTs - 1)
 
 	select {
 	case err := <-errChan:

--- a/backup.go
+++ b/backup.go
@@ -144,10 +144,10 @@ func (db *DB) Load(r io.Reader) error {
 			UserMeta:  e.UserMeta[0],
 			ExpiresAt: e.ExpiresAt,
 		})
-		// Update nextCommit, memtable stores this timestamp in badger head
+		// Update nextTxnTs, memtable stores this timestamp in badger head
 		// when flushed.
-		if e.Version >= db.orc.commitTs() {
-			db.orc.nextCommit = e.Version + 1
+		if e.Version >= db.orc.nextTxnTs {
+			db.orc.nextTxnTs = e.Version + 1
 		}
 
 		if len(entries) == 1000 {
@@ -170,7 +170,6 @@ func (db *DB) Load(r io.Reader) error {
 	case err := <-errChan:
 		return err
 	default:
-		db.orc.curRead = db.orc.commitTs() - 1
 		return nil
 	}
 }

--- a/backup.go
+++ b/backup.go
@@ -61,7 +61,7 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 				// Ignore versions less than given timestamp
 				continue
 			}
-			val, err := item.Value()
+			valCopy, err := item.ValueCopy(nil)
 			if err != nil {
 				log.Printf("Key [%x]. Error while fetching value [%v]\n", item.Key(), err)
 				continue
@@ -69,7 +69,7 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 
 			entry := &protos.KVPair{
 				Key:       y.Copy(item.Key()),
-				Value:     y.Copy(val),
+				Value:     valCopy,
 				UserMeta:  []byte{item.UserMeta()},
 				Version:   item.Version(),
 				ExpiresAt: item.ExpiresAt(),

--- a/backup_test.go
+++ b/backup_test.go
@@ -95,7 +95,7 @@ func TestDumpLoad(t *testing.T) {
 		var count int
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
-			val, err := item.Value()
+			val, err := item.ValueCopy(nil)
 			if err != nil {
 				return err
 			}
@@ -184,7 +184,7 @@ func Test_BackupRestore(t *testing.T) {
 				}
 				return err
 			}
-			v, err := item.Value()
+			v, err := item.ValueCopy(nil)
 			if err != nil {
 				return err
 			}
@@ -239,7 +239,7 @@ func Test_BackupRestore(t *testing.T) {
 				}
 				return err
 			}
-			v, err := item.Value()
+			v, err := item.ValueCopy(nil)
 			if err != nil {
 				return err
 			}

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/badger/y"
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Run bank test on Badger.",
+	Long: `
+This command runs bank test on Badger, inspired by Jepsen. It creates many
+accounts and moves money among them transactionally. It also reads the sum total
+of all the accounts, to ensure that the total never changes.
+`,
+	RunE: runTest,
+}
+
+var numGoroutines, numAccounts int
+var duration, keyPrefix string
+var blockAll int32
+
+const initialBal uint64 = 100
+
+func init() {
+	RootCmd.AddCommand(testCmd)
+	testCmd.Flags().IntVarP(&numGoroutines, "conc", "c", 10, "Number of concurrent transactions to run.")
+	testCmd.Flags().IntVarP(&numAccounts, "accounts", "a", 1000000, "Number of accounts in the bank.")
+	testCmd.Flags().StringVarP(&duration, "duration", "d", "3m", "How long to run the test.")
+}
+
+func key(account int) []byte {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], uint32(account))
+	return append([]byte(keyPrefix), b[:]...)
+}
+
+func toAccount(key []byte) int {
+	return int(binary.BigEndian.Uint32(key[len(keyPrefix):]))
+}
+
+func toUint64(val []byte) uint64 {
+	return binary.BigEndian.Uint64(val)
+}
+
+func toSlice(bal uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, bal)
+	return b
+}
+
+func getBalance(txn *badger.Txn, account int) (uint64, error) {
+	item, err := txn.Get(key(account))
+	if err != nil {
+		return 0, err
+	}
+
+	var bal uint64
+	err = item.Value(func(v []byte) {
+		bal = toUint64(v)
+	})
+	return bal, err
+	// val, err := item.Value()
+	// if err != nil {
+	// 	return 0, err
+	// }
+	// return toUint64(val), nil
+}
+
+func putBalance(txn *badger.Txn, account int, bal uint64) error {
+	return txn.Set(key(account), toSlice(bal))
+}
+
+func min(a, b uint64) uint64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+var errAbandoned = errors.New("Transaction abandonded due to insufficient balance")
+
+func moveMoney(db *badger.DB, from, to int) error {
+	return db.Update(func(txn *badger.Txn) error {
+		balf, err := getBalance(txn, from)
+		if err != nil {
+			return err
+		}
+		balt, err := getBalance(txn, to)
+		if err != nil {
+			return err
+		}
+
+		floor := min(balf, balt)
+		if floor == 0 {
+			return errAbandoned
+		}
+
+		// Move the money.
+		move := uint64(rand.Int63n(int64(floor)) + 1)
+		balf -= move
+		balt += move
+
+		if err = putBalance(txn, from, balf); err != nil {
+			return err
+		}
+		if err = putBalance(txn, to, balt); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+type account struct {
+	Id  int
+	Bal uint64
+}
+
+func diff(a, b []account) string {
+	var buf bytes.Buffer
+	y.AssertTruef(len(a) == len(b), "len(a)=%d. len(b)=%d\n", len(a), len(b))
+	for i := range a {
+		ai := a[i]
+		bi := b[i]
+		if ai.Id != bi.Id || ai.Bal != bi.Bal {
+			buf.WriteString(fmt.Sprintf("Index: %d. Account [%+v] -> [%+v]\n", i, ai, bi))
+		}
+	}
+	return buf.String()
+}
+
+var errFailure = errors.New("Found an balance mismatch. Test failed.")
+
+// iterateTotal retrives the total of all accounts by iterating over the DB.
+func iterateTotal(db *badger.DB) ([]account, error) {
+	expected := uint64(numAccounts) * uint64(initialBal)
+	var accounts []account
+	err := db.View(func(txn *badger.Txn) error {
+		// start := time.Now()
+		itr := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer itr.Close()
+
+		var total uint64
+		for itr.Seek([]byte(keyPrefix)); itr.ValidForPrefix([]byte(keyPrefix)); itr.Next() {
+			item := itr.Item()
+			val, err := item.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+			acc := account{
+				Id:  toAccount(item.Key()),
+				Bal: toUint64(val),
+			}
+			accounts = append(accounts, acc)
+			total += acc.Bal
+		}
+		if total != expected {
+			log.Printf("Balance did NOT match up. Expected: %d. Received: %d",
+				expected, total)
+			atomic.AddInt32(&blockAll, 1)
+			return errFailure
+		}
+		// log.Printf("totalMoney took: %s\n", time.Since(start).String())
+		return nil
+	})
+	return accounts, err
+}
+
+// seekTotal retrives the total of all accounts by seeking for each account key.
+func seekTotal(db *badger.DB) ([]account, error) {
+	expected := uint64(numAccounts) * uint64(initialBal)
+	var accounts []account
+	err := db.View(func(txn *badger.Txn) error {
+		var total uint64
+		for i := 0; i < numAccounts; i++ {
+			item, err := txn.Get(key(i))
+			if err != nil {
+				return err
+			}
+			val, err := item.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+			acc := account{
+				Id:  i,
+				Bal: toUint64(val),
+			}
+			accounts = append(accounts, acc)
+			total += acc.Bal
+		}
+		if total != expected {
+			log.Printf("Balance did NOT match up. Expected: %d. Received: %d",
+				expected, total)
+			atomic.AddInt32(&blockAll, 1)
+			return errFailure
+		}
+		return nil
+	})
+	return accounts, err
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	// Open DB
+	opts := badger.DefaultOptions
+	opts.Dir = sstDir
+	opts.ValueDir = vlogDir
+	opts.ValueThreshold = 1 // Make all values go to value log.
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	keyPrefix = fmt.Sprintf("a%s:", time.Now().Format(time.RFC3339Nano))
+
+	var wg sync.WaitGroup
+	for i := 0; i < numAccounts; i++ {
+		wg.Add(1)
+		txn := db.NewTransaction(true)
+		y.Check(putBalance(txn, i, initialBal))
+		y.Check(txn.Commit(func(err error) {
+			y.Check(err)
+			wg.Done()
+		}))
+	}
+	wg.Wait()
+	log.Println("Bank initialization OK. Commencing test.")
+	log.Printf("Running with %d accounts, and %d goroutines.\n", numAccounts, numGoroutines)
+	log.Printf("Using keyPrefix: %s\n", keyPrefix)
+
+	dur, err := time.ParseDuration(duration)
+	y.Check(err)
+
+	endTs := time.Now().Add(dur)
+	var total, success, errors, reads uint64
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if atomic.LoadInt32(&blockAll) > 0 {
+				// Do not proceed.
+				continue
+			}
+			log.Printf("Total: %d. Success: %d. Errors: %d Reads: %d.\n",
+				atomic.LoadUint64(&total),
+				atomic.LoadUint64(&success),
+				atomic.LoadUint64(&errors),
+				atomic.LoadUint64(&reads))
+			if time.Now().After(endTs) {
+				return
+			}
+		}
+	}()
+
+	// RW goroutines.
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ticker := time.NewTicker(10 * time.Microsecond)
+			defer ticker.Stop()
+
+			for range ticker.C {
+				if atomic.LoadInt32(&blockAll) > 0 {
+					// Do not proceed.
+					continue
+				}
+				if time.Now().After(endTs) {
+					return
+				}
+				err := moveMoney(db, rand.Intn(numAccounts), rand.Intn(numAccounts))
+				atomic.AddUint64(&total, 1)
+				if err != nil {
+					atomic.AddUint64(&errors, 1)
+				} else {
+					atomic.AddUint64(&success, 1)
+				}
+			}
+		}()
+	}
+
+	// RO goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(10 * time.Microsecond)
+		defer ticker.Stop()
+
+		var lastOk []account
+		for range ticker.C {
+			if atomic.LoadInt32(&blockAll) > 0 {
+				// Do not proceed.
+				continue
+			}
+			if time.Now().After(endTs) {
+				return
+			}
+			current, err := seekTotal(db)
+			if err == errFailure {
+				log.Printf("FAILURE. Diff: %s", diff(lastOk, current))
+
+			} else if err != nil {
+				log.Printf("Error while calculating total: %v", err)
+			} else {
+				lastOk = current
+				atomic.AddUint64(&reads, 1)
+			}
+		}
+	}()
+	wg.Wait()
+
+	_, err = seekTotal(db)
+	y.Check(err) // One last time.
+	log.Println("Test OK")
+	return nil
+}

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -51,8 +51,10 @@ const initialBal uint64 = 100
 
 func init() {
 	RootCmd.AddCommand(testCmd)
-	testCmd.Flags().IntVarP(&numGoroutines, "conc", "c", 10, "Number of concurrent transactions to run.")
-	testCmd.Flags().IntVarP(&numAccounts, "accounts", "a", 1000000, "Number of accounts in the bank.")
+	testCmd.Flags().IntVarP(
+		&numGoroutines, "conc", "c", 10, "Number of concurrent transactions to run.")
+	testCmd.Flags().IntVarP(
+		&numAccounts, "accounts", "a", 1000000, "Number of accounts in the bank.")
 	testCmd.Flags().StringVarP(&duration, "duration", "d", "3m", "How long to run the test.")
 }
 

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -59,7 +59,7 @@ func init() {
 	RootCmd.AddCommand(infoCmd)
 }
 
-func bytes(sz int64) string {
+func hbytes(sz int64) string {
 	return humanize.Bytes(uint64(sz))
 }
 
@@ -139,7 +139,7 @@ func printInfo(dir, valueDir string) error {
 
 		baseTime = manifestInfo.ModTime()
 		fmt.Printf("[%25s] %-12s %6s MA%s\n", manifestInfo.ModTime().Format(time.RFC3339),
-			manifestInfo.Name(), bytes(manifestInfo.Size()), truncatedString)
+			manifestInfo.Name(), hbytes(manifestInfo.Size()), truncatedString)
 	} else {
 		fmt.Printf("%s [MISSING]\n", manifestInfo.Name())
 	}
@@ -172,7 +172,7 @@ func printInfo(dir, valueDir string) error {
 				levelSizes[level] += fileSize
 				// (Put level on every line to make easier to process with sed/perl.)
 				fmt.Printf("[%25s] %-12s %6s L%d%s\n", dur(baseTime, file.ModTime()),
-					tableFile, bytes(fileSize), level, emptyString)
+					tableFile, hbytes(fileSize), level, emptyString)
 			} else {
 				fmt.Printf("%s [MISSING]\n", tableFile)
 				numMissing++
@@ -209,7 +209,7 @@ func printInfo(dir, valueDir string) error {
 		}
 		valueLogSize += fileSize
 		fmt.Printf("[%25s] %-12s %6s VL%s\n", dur(baseTime, file.ModTime()), file.Name(),
-			bytes(fileSize), emptyString)
+			hbytes(fileSize), emptyString)
 
 		fileinfoMarked[file.Name()] = true
 	}
@@ -223,7 +223,7 @@ func printInfo(dir, valueDir string) error {
 			fmt.Print("\n[EXTRA]\n")
 		}
 		fmt.Printf("[%s] %-12s %6s\n", file.ModTime().Format(time.RFC3339),
-			file.Name(), bytes(file.Size()))
+			file.Name(), hbytes(file.Size()))
 		numExtra++
 	}
 
@@ -233,19 +233,19 @@ func printInfo(dir, valueDir string) error {
 			fmt.Print("\n[ValueDir EXTRA]\n")
 		}
 		fmt.Printf("[%s] %-12s %6s\n", file.ModTime().Format(time.RFC3339),
-			file.Name(), bytes(file.Size()))
+			file.Name(), hbytes(file.Size()))
 		numValueDirExtra++
 	}
 
 	fmt.Print("\n[Summary]\n")
 	totalIndexSize := int64(0)
 	for i, sz := range levelSizes {
-		fmt.Printf("Level %d size: %12s\n", i, bytes(sz))
+		fmt.Printf("Level %d size: %12s\n", i, hbytes(sz))
 		totalIndexSize += sz
 	}
 
-	fmt.Printf("Total index size: %8s\n", bytes(totalIndexSize))
-	fmt.Printf("Value log size: %10s\n", bytes(valueLogSize))
+	fmt.Printf("Total index size: %8s\n", hbytes(totalIndexSize))
+	fmt.Printf("Value log size: %10s\n", hbytes(valueLogSize))
 	fmt.Println()
 	totalExtra := numExtra + numValueDirExtra
 	if totalExtra == 0 && numMissing == 0 && numEmpty == 0 && !manifestTruncated {

--- a/db.go
+++ b/db.go
@@ -1046,11 +1046,16 @@ func (seq *Sequence) updateLease() error {
 		} else if err != nil {
 			return err
 		} else {
-			val, err := item.Value()
-			if err != nil {
+			// val, err := item.Value()
+			// if err != nil {
+			// 	return err
+			// }
+			var num uint64
+			if err := item.Value(func(v []byte) {
+				num = binary.BigEndian.Uint64(v)
+			}); err != nil {
 				return err
 			}
-			num := binary.BigEndian.Uint64(val)
 			seq.next = num
 		}
 
@@ -1159,11 +1164,15 @@ func (op *MergeOperator) iterateAndMerge(txn *Txn) (val []byte, err error) {
 				return nil, err
 			}
 		} else {
-			newVal, err := item.Value()
-			if err != nil {
+			// newVal, err := item.Value()
+			// if err != nil {
+			// 	return nil, err
+			// }
+			if err := item.Value(func(newVal []byte) {
+				val = op.f(val, newVal)
+			}); err != nil {
 				return nil, err
 			}
-			val = op.f(val, newVal)
 		}
 		if item.DiscardEarlierVersions() {
 			break

--- a/db_test.go
+++ b/db_test.go
@@ -1432,7 +1432,7 @@ func TestMinReadTs(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 		require.Equal(t, uint64(10), db.orc.readTs())
-		min := db.orc.readMark.MinReadTs()
+		min := db.orc.readMark.DoneUntil()
 		require.Equal(t, uint64(9), min)
 
 		readTxn := db.NewTransaction(false)
@@ -1443,10 +1443,10 @@ func TestMinReadTs(t *testing.T) {
 		}
 		require.Equal(t, uint64(20), db.orc.readTs())
 		time.Sleep(time.Millisecond)
-		require.Equal(t, min, db.orc.readMark.MinReadTs())
+		require.Equal(t, min, db.orc.readMark.DoneUntil())
 		readTxn.Discard()
 		time.Sleep(time.Millisecond)
-		require.Equal(t, uint64(19), db.orc.readMark.MinReadTs())
+		require.Equal(t, uint64(19), db.orc.readMark.DoneUntil())
 
 		for i := 0; i < 10; i++ {
 			db.View(func(txn *Txn) error {
@@ -1454,7 +1454,7 @@ func TestMinReadTs(t *testing.T) {
 			})
 		}
 		time.Sleep(time.Millisecond)
-		require.Equal(t, uint64(20), db.orc.readMark.MinReadTs())
+		require.Equal(t, uint64(20), db.orc.readMark.DoneUntil())
 	})
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -566,8 +566,6 @@ func TestLoad(t *testing.T) {
 				fmt.Printf("Putting i=%d\n", i)
 			}
 			k := []byte(fmt.Sprintf("%09d", i))
-			// One RW transaction would increase the txn ts by 2. One for read,
-			// and one for write.
 			txnSet(t, kv, k, k, 0x00)
 		}
 		kv.Close()
@@ -588,7 +586,6 @@ func TestLoad(t *testing.T) {
 			require.EqualValues(t, k, string(getItemValue(t, item)))
 			return nil
 		}))
-
 	}
 	kv.Close()
 	summary := kv.lc.getSummary()

--- a/integration/testgc/main.go
+++ b/integration/testgc/main.go
@@ -72,7 +72,7 @@ func (s *S) read(db *badger.DB) error {
 		if err != nil {
 			return err
 		}
-		val, err := item.Value()
+		val, err := item.ValueCopy(nil)
 		if err != nil {
 			return err
 		}
@@ -194,7 +194,7 @@ func main() {
 			keyi := binary.BigEndian.Uint64(key)
 			total++
 
-			val, err := item.Value()
+			val, err := item.ValueCopy(nil)
 			if err != nil {
 				return err
 			}

--- a/iterator.go
+++ b/iterator.go
@@ -108,9 +108,6 @@ func (item *Item) Value(fn func(val []byte)) error {
 	if err == nil && fn != nil {
 		fn(buf)
 	}
-	// if cb != nil {
-	// 	item.txn.callbacks = append(item.txn.callbacks, cb)
-	// }
 	return err
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -98,14 +98,14 @@ func (item *Item) Version() uint64 {
 func (item *Item) Value(fn func(val []byte)) error {
 	item.wg.Wait()
 	if item.status == prefetched {
-		if item.err == nil {
+		if item.err == nil && fn != nil {
 			fn(item.val)
 		}
 		return item.err
 	}
 	buf, cb, err := item.yieldItemValue()
 	defer runCallback(cb)
-	if err == nil {
+	if err == nil && fn != nil {
 		fn(buf)
 	}
 	// if cb != nil {

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,6 @@
 l=$(go list ./...)
 for x in $l; do
   echo "Testing package $x"
-  go test -race -v $x
+  # go test -race -v $x
+  go test -v $x || exit 1
 done

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,5 @@
 l=$(go list ./...)
 for x in $l; do
   echo "Testing package $x"
-  # go test -race -v $x
-  go test -v $x || exit 1
+  go test -race -v $x
 done

--- a/transaction.go
+++ b/transaction.go
@@ -55,20 +55,21 @@ func (o *oracle) addRef() {
 }
 
 func (o *oracle) decrRef() {
-	if count := atomic.AddInt64(&o.refCount, -1); count == 0 {
-		// Clear out commits maps to release memory.
-		o.Lock()
-		// Avoids the race where something new is added to commitsMap
-		// after we check refCount and before we take Lock.
-		if atomic.LoadInt64(&o.refCount) != 0 {
-			o.Unlock()
-			return
-		}
-		if len(o.commits) >= 1000 { // If the map is still small, let it slide.
-			o.commits = make(map[uint64]uint64)
-		}
-		o.Unlock()
+	if atomic.AddInt64(&o.refCount, -1) != 0 {
+		return
 	}
+	// Clear out commits maps to release memory.
+	o.Lock()
+	// Avoids the race where something new is added to commitsMap
+	// after we check refCount and before we take Lock.
+	if atomic.LoadInt64(&o.refCount) != 0 {
+		o.Unlock()
+		return
+	}
+	if len(o.commits) >= 1000 { // If the map is still small, let it slide.
+		o.commits = make(map[uint64]uint64)
+	}
+	o.Unlock()
 }
 
 func (o *oracle) readTs() uint64 {

--- a/transaction.go
+++ b/transaction.go
@@ -104,7 +104,7 @@ func (o *oracle) readTs() uint64 {
 	// timestamp and are going through the write to value log and LSM tree
 	// process. Not waiting here could mean that some txns which have been
 	// committed would not be read.
-	o.txnMark.WaitForMark(context.Background(), readTs)
+	y.Check(o.txnMark.WaitForMark(context.Background(), readTs))
 	return readTs
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -445,7 +445,7 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 	item.meta = vs.Meta
 	item.userMeta = vs.UserMeta
 	item.db = txn.db
-	item.vptr = vs.Value
+	item.vptr = vs.Value // TODO: Do we need to copy this over?
 	item.txn = txn
 	item.expiresAt = vs.ExpiresAt
 	return item, nil

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -87,10 +87,11 @@ func TestTxnReadAfterWrite(t *testing.T) {
 func TestTxnCommitAsync(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 
-		txn := db.NewTransaction(true)
 		key := func(i int) []byte {
 			return []byte(fmt.Sprintf("key=%d", i))
 		}
+
+		txn := db.NewTransaction(true)
 		for i := 0; i < 40; i++ {
 			err := txn.Set(key(i), []byte(strconv.Itoa(100)))
 			require.NoError(t, err)

--- a/value.go
+++ b/value.go
@@ -403,12 +403,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 				wb = wb[:0]
 			}
 		} else {
-			pk := y.ParseKey(e.Key)
-			msg := fmt.Sprintf("WARNING: This entry should have been caught. %+v. Ts: %d."+
-				" Entry offset: %d. VP offset: %d\n", pk, y.ParseTs(e.Key), e.offset, vp.Offset)
-			panic(msg)
-			// log.Printf("Entry offset: %d. VP offset: %d\n", e.offset, vp.Offset)
-			// log.Printf("WARNING: This entry should have been caught. %+v\n", e)
+			log.Printf("WARNING: This entry should have been caught. %+v\n", e)
 		}
 		return nil
 	}

--- a/value.go
+++ b/value.go
@@ -756,7 +756,6 @@ func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 	fid := ptr.Fid
 	offset := ptr.Offset + ptr.Len
 	vlog.elog.Printf("Seeking at value pointer: %+v\n", ptr)
-	log.Printf("Replaying from value pointer: %+v\n", ptr)
 
 	fids := vlog.sortedFids()
 
@@ -769,10 +768,10 @@ func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 			of = 0
 		}
 		f := vlog.filesMap[id]
-		log.Printf("Iterating file id: %d", id)
+		vlog.elog.Printf("Iterating file id: %d", id)
 		now := time.Now()
 		err := vlog.iterate(f, of, fn)
-		log.Printf("Iteration took: %s\n", time.Since(now))
+		vlog.elog.Printf("Iteration took: %s\n", time.Since(now))
 		if err != nil {
 			return errors.Wrapf(err, "Unable to replay value log: %q", f.path)
 		}

--- a/value.go
+++ b/value.go
@@ -403,7 +403,12 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 				wb = wb[:0]
 			}
 		} else {
-			log.Printf("WARNING: This entry should have been caught. %+v\n", e)
+			pk := y.ParseKey(e.Key)
+			msg := fmt.Sprintf("WARNING: This entry should have been caught. %+v. Ts: %d."+
+				" Entry offset: %d. VP offset: %d\n", pk, y.ParseTs(e.Key), e.offset, vp.Offset)
+			panic(msg)
+			// log.Printf("Entry offset: %d. VP offset: %d\n", e.offset, vp.Offset)
+			// log.Printf("WARNING: This entry should have been caught. %+v\n", e)
 		}
 		return nil
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -718,13 +718,12 @@ func TestBug578(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				val, err := item.Value()
-				if err != nil {
+				if err := item.Value(func(val []byte) {
+					if !bytes.Equal(val, value) {
+						t.Fatalf("Invalid value for key: %q", key(i))
+					}
+				}); err != nil {
 					return err
-				}
-
-				if !bytes.Equal(val, value) {
-					t.Fatalf("Invalid value for key: %q", key(i))
 				}
 				return nil
 			})

--- a/value_test.go
+++ b/value_test.go
@@ -344,7 +344,7 @@ func TestValueGC3(t *testing.T) {
 	item = it.Item()
 	require.Equal(t, []byte("key003"), item.Key())
 
-	v3, err := item.Value()
+	v3, err := item.ValueCopy(nil)
 	require.NoError(t, err)
 	require.Equal(t, value3, v3)
 }

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -1,23 +1,15 @@
 /*
- * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ * Copyright 2016-2018 Dgraph Labs, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is available under the Apache License, Version 2.0,
+ * with the Commons Clause restriction.
  */
 
 package y
 
 import (
 	"container/heap"
+	"context"
 	"sync/atomic"
 
 	"golang.org/x/net/trace"
@@ -37,94 +29,173 @@ func (u *uint64Heap) Pop() interface{} {
 	return x
 }
 
+// mark contains raft proposal id and a done boolean. It is used to
+// update the WaterMark struct about the status of a proposal.
 type mark struct {
-	readTs uint64
-	done   bool // Set to true if the pending mutation is done.
+	// Either this is an (index, waiter) pair or (index, done) or (indices, done).
+	index   uint64
+	waiter  chan struct{}
+	indices []uint64
+	done    bool // Set to true if the pending mutation is done.
 }
+
+// WaterMark is used to keep track of the minimum un-finished index.  Typically, an index k becomes
+// finished or "done" according to a WaterMark once Done(k) has been called
+//   1. as many times as Begin(k) has, AND
+//   2. a positive number of times.
+//
+// An index may also become "done" by calling SetDoneUntil at a time such that it is not
+// inter-mingled with Begin/Done calls.
 type WaterMark struct {
+	Name      string
 	markCh    chan mark
-	minReadTs uint64
+	doneUntil uint64
+	lastIndex uint64
 	elog      trace.EventLog
 }
 
 // Init initializes a WaterMark struct. MUST be called before using it.
 func (w *WaterMark) Init() {
-	w.markCh = make(chan mark, 1000)
-	w.elog = trace.NewEventLog("Badger", "MinReadTs")
+	w.markCh = make(chan mark, 100)
+	w.elog = trace.NewEventLog("Watermark", w.Name)
 	go w.process()
 }
 
-func (w *WaterMark) Begin(readTs uint64) {
-	w.markCh <- mark{readTs: readTs, done: false}
+func (w *WaterMark) Begin(index uint64) {
+	atomic.StoreUint64(&w.lastIndex, index)
+	w.markCh <- mark{index: index, done: false}
 }
-func (w *WaterMark) Done(readTs uint64) {
-	w.markCh <- mark{readTs: readTs, done: true}
+func (w *WaterMark) BeginMany(indices []uint64) {
+	atomic.StoreUint64(&w.lastIndex, indices[len(indices)-1])
+	w.markCh <- mark{index: 0, indices: indices, done: false}
+}
+
+func (w *WaterMark) Done(index uint64) {
+	w.markCh <- mark{index: index, done: true}
+}
+func (w *WaterMark) DoneMany(indices []uint64) {
+	w.markCh <- mark{index: 0, indices: indices, done: true}
 }
 
 // DoneUntil returns the maximum index until which all tasks are done.
-func (w *WaterMark) MinReadTs() uint64 {
-	return atomic.LoadUint64(&w.minReadTs)
+func (w *WaterMark) DoneUntil() uint64 {
+	return atomic.LoadUint64(&w.doneUntil)
+}
+
+func (w *WaterMark) SetDoneUntil(val uint64) {
+	atomic.StoreUint64(&w.doneUntil, val)
+}
+
+func (w *WaterMark) LastIndex() uint64 {
+	return atomic.LoadUint64(&w.lastIndex)
+}
+
+func (w *WaterMark) WaitForMark(ctx context.Context, index uint64) error {
+	if w.DoneUntil() >= index {
+		return nil
+	}
+	waitCh := make(chan struct{})
+	w.markCh <- mark{index: index, waiter: waitCh}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-waitCh:
+		return nil
+	}
 }
 
 // process is used to process the Mark channel. This is not thread-safe,
 // so only run one goroutine for process. One is sufficient, because
-// all ops in the goroutine use only memory and cpu.
+// all goroutine ops use purely memory and cpu.
+// Each index has to emit atleast one begin watermark in serial order otherwise waiters
+// can get blocked idefinitely. Example: We had an watermark at 100 and a waiter at 101,
+// if no watermark is emitted at index 101 then waiter would get stuck indefinitely as it
+// can't decide whether the task at 101 has decided not to emit watermark or it didn't get
+// scheduled yet.
 func (w *WaterMark) process() {
-	var reads uint64Heap
+	var indices uint64Heap
 	// pending maps raft proposal index to the number of pending mutations for this proposal.
 	pending := make(map[uint64]int)
+	waiters := make(map[uint64][]chan struct{})
 
-	heap.Init(&reads)
+	heap.Init(&indices)
 	var loop uint64
 
-	processOne := func(readTs uint64, done bool) {
+	processOne := func(index uint64, done bool) {
 		// If not already done, then set. Otherwise, don't undo a done entry.
-		prev, present := pending[readTs]
+		prev, present := pending[index]
 		if !present {
-			heap.Push(&reads, readTs)
+			heap.Push(&indices, index)
 		}
 
 		delta := 1
 		if done {
 			delta = -1
 		}
-		pending[readTs] = prev + delta
+		pending[index] = prev + delta
 
 		loop++
-		if len(reads) > 0 && loop%1000 == 0 {
-			min := reads[0]
-			w.elog.Printf("ReadTs: %4d. Size: %4d MinReadTs: %-4d Looking for: %-4d. Value: %d\n",
-				readTs, len(reads), w.MinReadTs(), min, pending[min])
+		if len(indices) > 0 && loop%10000 == 0 {
+			min := indices[0]
+			w.elog.Printf("WaterMark %s: Done entry %4d. Size: %4d Watermark: %-4d Looking for: %-4d. Value: %d\n",
+				w.Name, index, len(indices), w.DoneUntil(), min, pending[min])
 		}
 
-		// Update mark by going through all reads in order; and checking if they have
-		// been done. Stop at the first readTs, which isn't done.
-		minReadTs := w.MinReadTs()
-		// Don't assert that minReadTs < readTs, to avoid any inconsistencies caused by managed
-		// transactions, or testing where we explicitly set the readTs for transactions like in
-		// TestTxnVersions.
-		until := minReadTs
+		// Update mark by going through all indices in order; and checking if they have
+		// been done. Stop at the first index, which isn't done.
+		doneUntil := w.DoneUntil()
+		if doneUntil > index {
+			AssertTruef(false, "Name: %s doneUntil: %d. Index: %d", w.Name, doneUntil, index)
+		}
+
+		until := doneUntil
 		loops := 0
 
-		for len(reads) > 0 {
-			min := reads[0]
-			if done := pending[min]; done != 0 {
-				break // len(reads) will be > 0.
+		for len(indices) > 0 {
+			min := indices[0]
+			if done := pending[min]; done > 0 {
+				break // len(indices) will be > 0.
 			}
-			heap.Pop(&reads)
+			// Even if done is called multiple times causing it to become
+			// negative, we should still pop the index.
+			heap.Pop(&indices)
 			delete(pending, min)
 			until = min
 			loops++
 		}
-		if until != minReadTs {
-			AssertTrue(atomic.CompareAndSwapUint64(&w.minReadTs, minReadTs, until))
-			w.elog.Printf("MinReadTs: %d. Loops: %d\n", until, loops)
+		for i := doneUntil + 1; i <= until; i++ {
+			toNotify := waiters[i]
+			for _, ch := range toNotify {
+				close(ch)
+			}
+		}
+		if until != doneUntil {
+			AssertTrue(atomic.CompareAndSwapUint64(&w.doneUntil, doneUntil, until))
+			w.elog.Printf("%s: Done until %d. Loops: %d\n", w.Name, until, loops)
 		}
 	}
 
 	for mark := range w.markCh {
-		if mark.readTs > 0 {
-			processOne(mark.readTs, mark.done)
+		if mark.waiter != nil {
+			doneUntil := atomic.LoadUint64(&w.doneUntil)
+			if doneUntil >= mark.index {
+				close(mark.waiter)
+			} else {
+				ws, ok := waiters[mark.index]
+				if !ok {
+					waiters[mark.index] = []chan struct{}{mark.waiter}
+				} else {
+					waiters[mark.index] = append(ws, mark.waiter)
+				}
+			}
+		} else {
+			if mark.index > 0 {
+				processOne(mark.index, mark.done)
+			}
+			for _, index := range mark.indices {
+				processOne(index, mark.done)
+			}
 		}
 	}
 }

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -1,8 +1,17 @@
 /*
- * Copyright 2016-2018 Dgraph Labs, Inc.
+ * Copyright 2016-2018 Dgraph Labs, Inc. and Contributors
  *
- * This file is available under the Apache License, Version 2.0,
- * with the Commons Clause restriction.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package y


### PR DESCRIPTION
**Breaking Change**

This change breaks Value API. Instead of Value returning a byte slice, we now expose the byte slice from within a function. This is because when we read a value, we acquire a read lock on the value log. With the previous API it was possible for a transaction to deadlock, if multiple reads are done on the same log file, and those read locks get interleaved with a write lock caused by log file rotation. The new API fixes that by releasing the lock before another value is read; and also makes it obvious to the end user that they must copy the value to be able to use it outside the function.

This change also adds a Jepsen style bank test for Badger, which is currently showing some transaction violations, needing further investigation.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/577)
<!-- Reviewable:end -->
