### PR TITLE
Allow multiple iterators to run concurrently for the same RO txn.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -50,6 +50,10 @@ var (
 	// ErrEmptyKey is returned if an empty key is passed on an update function.
 	ErrEmptyKey = errors.New("Key cannot be empty")
 
+	// ErrInvalidKey is returned if the key has a special !badger! prefix,
+	// reserved for internal usage.
+	ErrInvalidKey = errors.New("Key is using a reserved !badger! prefix")
+
 	// ErrRetry is returned when a log file containing the value is not found.
 	// This usually indicates that it may have been garbage collected, and the
 	// operation needs to be retried.


### PR DESCRIPTION
- Support multiple read-only iterators, as per request from https://github.com/blevesearch/bleve/issues/591.
- Disallow the public APIs from accepting keys prefixed with `!badger!`, fixing https://github.com/dgraph-io/badger/issues/582.
- Disallow closing iterator twice, fixing https://github.com/dgraph-io/badger/issues/588.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/591)
<!-- Reviewable:end -->
