### PR TITLE
Fix for a transaction violation in Badger

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -59,7 +59,7 @@ failure of the total invariant.
 	RunE: runDisect,
 }
 
-var numGoroutines, numAccounts int
+var numGoroutines, numAccounts, numPrevious int
 var duration string
 var stopAll int32
 
@@ -77,6 +77,8 @@ func init() {
 	bankTest.Flags().IntVarP(
 		&numGoroutines, "conc", "c", 16, "Number of concurrent transactions to run.")
 	bankTest.Flags().StringVarP(&duration, "duration", "d", "3m", "How long to run the test.")
+	bankDisect.Flags().IntVarP(&numPrevious, "previous", "p", 5,
+		"Starting from the violation txn, how many previous versions to retrieve.")
 }
 
 func key(account int) []byte {
@@ -341,9 +343,9 @@ func runDisect(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	compareTwo(db, ts-1, ts)
-	compareTwo(db, ts-2, ts-1)
-	compareTwo(db, ts-3, ts-2)
+	for i := 0; i < numPrevious; i++ {
+		compareTwo(db, ts-1-uint64(i), ts-uint64(i))
+	}
 	return nil
 }
 

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -73,7 +73,7 @@ func init() {
 	testCmd.AddCommand(bankDisect)
 
 	testCmd.Flags().IntVarP(
-		&numAccounts, "accounts", "a", 100000, "Number of accounts in the bank.")
+		&numAccounts, "accounts", "a", 1000, "Number of accounts in the bank.")
 	bankTest.Flags().IntVarP(
 		&numGoroutines, "conc", "c", 16, "Number of concurrent transactions to run.")
 	bankTest.Flags().StringVarP(&duration, "duration", "d", "3m", "How long to run the test.")

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -350,6 +350,8 @@ func runDisect(cmd *cobra.Command, args []string) error {
 }
 
 func runTest(cmd *cobra.Command, args []string) error {
+	rand.Seed(time.Now().UnixNano())
+
 	// Open DB
 	opts := badger.DefaultOptions
 	opts.Dir = sstDir

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -63,7 +63,7 @@ var numGoroutines, numAccounts, numPrevious int
 var duration string
 var stopAll int32
 
-var keyPrefix = "account:"
+const keyPrefix = "account:"
 
 const initialBal uint64 = 100
 

--- a/db.go
+++ b/db.go
@@ -516,7 +516,7 @@ func (db *DB) get(key []byte) (y.ValueStruct, error) {
 		// Found a version of the key. For user keyspace, return immediately. For move keyspace,
 		// continue iterating, unless we found a version == given key version.
 		if maxVs == nil || vs.Version == version {
-			return vs, nil
+			return vs.Copy(), nil
 		}
 		if maxVs.Version < vs.Version {
 			*maxVs = vs

--- a/level_handler.go
+++ b/level_handler.go
@@ -261,7 +261,7 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 			}
 		}
 	}
-	return maxVs, decr()
+	return maxVs.Copy(), decr()
 }
 
 // appendIterators appends iterators to an array of iterators, for merging.

--- a/levels.go
+++ b/levels.go
@@ -781,7 +781,7 @@ func (s *levelsController) get(key []byte, maxVs *y.ValueStruct) (y.ValueStruct,
 	// number.)
 	version := y.ParseTs(key)
 	for _, h := range s.levels {
-		vs, err := h.get(key) // Calls h.RLock() and h.RUnlock().
+		vs, err := h.get(key) // Calls h.RLock() and h.RUnlock(). // This returns a copy of valuestruct.
 		if err != nil {
 			return y.ValueStruct{}, errors.Wrapf(err, "get key: %q", key)
 		}
@@ -796,7 +796,7 @@ func (s *levelsController) get(key []byte, maxVs *y.ValueStruct) (y.ValueStruct,
 		}
 	}
 	if maxVs != nil {
-		return *maxVs, nil
+		return maxVs.Copy(), nil
 	}
 	return y.ValueStruct{}, nil
 }

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -35,6 +35,19 @@ type ValueStruct struct {
 	Version uint64 // This field is not serialized. Only for internal usage.
 }
 
+func (vs *ValueStruct) Copy() ValueStruct {
+	out := ValueStruct{
+		Meta:      vs.Meta,
+		UserMeta:  vs.UserMeta,
+		ExpiresAt: vs.ExpiresAt,
+		Version:   vs.Version,
+	}
+	if vs.Value != nil {
+		out.Value = append([]byte{}, vs.Value...)
+	}
+	return out
+}
+
 func sizeVarint(x uint64) (n int) {
 	for {
 		n++


### PR DESCRIPTION
- It seems like `farm.Fingerprint` is undeterministic causing different hashes for the same byte slice. This causes the txn conflict detection to fail, causing 2 concurrent txns to both succeed.
- Remove fingerprint and store keys as strings for conflict detection.
- Currently testing this change [WIP, OK for over 4h, longest run ever]

Note from observation:
```
Comparing @ts=437427 with @ts=437428
Index: 92881. Account [{Id:92881 Bal:120}] -> [{Id:92881 Bal:115}]
Index: 94432. Account [{Id:94432 Bal:115}] -> [{Id:94432 Bal:120}]

2018/09/26 09:49:12 Balance did NOT match up. Expected: 10000000. Received: 9999995
Index: 57525. Account [{Id:57525 Bal:115}] -> [{Id:57525 Bal:120}]
Index: 94432. Account [{Id:94432 Bal:120}] -> [{Id:94432 Bal:110}]

So, both read $115. @ts=437428, 94332 acct went from 115 -> 120.
@ts=437443, 94332 acct went from the read 115 -> 110 (but the actual was 120).
This should have been a txn conflict. It seems like farm.Fingerprint might have
generated a non-deterministic hash.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/593)
<!-- Reviewable:end -->
