### PR TITLE
reduce allocations by avoiding AssertTruef

### DIFF
--- a/y/y.go
+++ b/y/y.go
@@ -134,7 +134,7 @@ func ParseKey(key []byte) []byte {
 		return nil
 	}
 
-	AssertTruef(len(key) > 8, "key=%q", key)
+	AssertTrue(len(key) > 8)
 	return key[:len(key)-8]
 }
 


### PR DESCRIPTION
ParseKey is called *a lot*. Unfortunately, AssertTruef converts implicitly the arguments to interfaces which implicitly allocates. This was showing up as the primary source of allocations in go-ipfs by a wide margin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/597)
<!-- Reviewable:end -->
