### PR TITLE
Uint32 overflow causes read to fail

### DIFF
--- a/value.go
+++ b/value.go
@@ -126,9 +126,11 @@ func (lf *logFile) read(p valuePointer, s *y.Slice) (buf []byte, err error) {
 		n, err = lf.fd.ReadAt(buf, int64(offset))
 		nbr = int64(n)
 	} else {
-		size := uint32(len(lf.fmap))
+		ln := len(lf.fmap)
+		size := uint32(ln)
 		valsz := p.Len
 		if offset >= size || offset+valsz > size {
+			fmt.Printf("offset=%d. size=%d. valsz=%d len(fp.fmap)=%d\n", offset, size, valsz, len(lf.fmap))
 			err = y.ErrEOF
 		} else {
 			buf = lf.fmap[offset : offset+valsz]


### PR DESCRIPTION
If ValueLogFileSize is set to 2GB, during a size check of value log file, the 4GB mmapped region causes a  uint32 size variable to overflow. The size becomes zero, causing the read to fail with ErrEOF.

Fixes #585 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/600)
<!-- Reviewable:end -->
