### PR TITLE
Create a WriteBatch API to allow efficient serial writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,51 +614,24 @@ There are multiple workarounds during iteration:
 
 Are you creating a new transaction for every single key update, and waiting for
 it to `Commit` fully before creating a new one? This will lead to very low
-throughput. To get best write performance, batch up multiple writes inside a
-transaction using single `DB.Update()` call. You could also have multiple such
-`DB.Update()` calls being made concurrently from multiple goroutines.
+throughput.
 
-The way to achieve the highest write throughput via Badger, is to do serial
-writes and use callbacks in `txn.Commit`, like so:
+We have created `WriteBatch` API which provides a way to batch up
+many updates into a single transaction and `Commit` that transaction using
+callbacks to avoid blocking. This amortizes the cost of a transaction really
+well, and provides the most efficient way to do bulk writes.
+
+Note that `WriteBatch` API does not allow any reads. For read-modify-write
+workloads, you should be using the `Transaction` API.
 
 ```go
-che := make(chan error, 1)
-storeErr := func(err error) {
-  if err == nil {
-    return
-  }
-  select {
-    case che <- err:
-    default:
-  }
+wb := db.NewWriteBatch()
+for i := 0; i < N; i++ {
+  err := wb.Set(key(i), value(i), 0) // Will create txns as needed.
+  handle(err)
 }
-
-getErr := func() error {
-  select {
-    case err := <-che:
-      return err
-    default:
-      return nil
-  }
-}
-
-var wg sync.WaitGroup
-for _, kv := range kvs {
-  wg.Add(1)
-  txn := db.NewTransaction(true)
-  handle(txn.Set(kv.Key, kv.Value))
-  handle(txn.Commit(func(err error) {
-    storeErr(err)
-    wg.Done()
-  }))
-}
-wg.Wait()
-return getErr()
+handle(wb.Flush()) // Wait for all txns to finish.
 ```
-
-In this code, we passed a callback function to `txn.Commit`, which can pick up
-and return the first error encountered, if any. Callbacks can be made to do more
-things, like retrying commits etc.
 
 - **I don't see any disk write. Why?**
 

--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package badger
+
+import (
+	"fmt"
+	"sync"
+)
+
+type WriteBatch struct {
+	sync.Mutex
+	txn *Txn
+	db  *DB
+	wg  sync.WaitGroup
+	err error
+}
+
+// NewWriteBatch creates a new WriteBatch. This provides a way to conveniently do a lot of writes,
+// batching them up as tightly as possible in a single transaction and using callbacks to avoid
+// waiting for them to commit, thus achieving good performance. This API hides away the logic of
+// creating and committing transactions. Due to the nature of SSI guaratees provided by Badger,
+// blind writes can never encounter transaction conflicts (ErrConflict).
+func (db *DB) NewWriteBatch() *WriteBatch {
+	return &WriteBatch{db: db, txn: db.NewTransaction(true)}
+}
+
+func (wb *WriteBatch) callback(err error) {
+	// sync.WaitGroup is thread-safe, so it doesn't need to be run inside wb.Lock.
+	defer wb.wg.Done()
+	if err == nil {
+		return
+	}
+
+	wb.Lock()
+	defer wb.Unlock()
+	if wb.err != nil {
+		return
+	}
+	wb.err = err
+}
+
+// Set is equivalent of Txn.SetWithMeta.
+func (wb *WriteBatch) Set(k, v []byte, meta byte) error {
+	wb.Lock()
+	defer wb.Unlock()
+
+	err := wb.txn.SetWithMeta(k, v, meta)
+	if err == ErrTxnTooBig {
+		return wb.commit()
+	}
+	return err
+}
+
+// Delete is equivalent of Txn.Delete.
+func (wb *WriteBatch) Delete(k []byte) error {
+	wb.Lock()
+	defer wb.Unlock()
+
+	err := wb.txn.Delete(k)
+	if err == ErrTxnTooBig {
+		return wb.commit()
+	}
+	return err
+}
+
+// This must hold a lock.
+func (wb *WriteBatch) commit() error {
+	fmt.Println("Doing a commit")
+	if wb.err != nil {
+		fmt.Printf("Got error: %v\n", wb.err)
+		return wb.err
+	}
+	// Get a new txn before we commit this one. So, the new txn doesn't need
+	// to wait for this one to commit.
+	newTxn := wb.db.NewTransaction(true)
+	fmt.Println("newtxn")
+	wb.wg.Add(1)
+	wb.txn.CommitWith(wb.callback)
+	wb.txn = newTxn
+	return wb.err
+}
+
+// Flush must be called at the end to ensure that any pending writes get committed to Badger. Flush
+// returns any error stored by WriteBatch.
+func (wb *WriteBatch) Flush() error {
+	wb.Lock()
+	_ = wb.commit()
+	wb.txn.Discard()
+	wb.Unlock()
+
+	fmt.Println("waiting for wait")
+	wb.wg.Wait()
+	// Safe to access error without any synchronization here.
+	return wb.err
+}
+
+// Error returns any errors encountered so far. No commits would be run once an error is detected.
+func (wb *WriteBatch) Error() error {
+	wb.Lock()
+	defer wb.Unlock()
+	return wb.err
+}

--- a/batch.go
+++ b/batch.go
@@ -93,10 +93,9 @@ func (wb *WriteBatch) Delete(k []byte) error {
 	return nil
 }
 
-// This must hold a lock.
+// Caller to commit must hold a write lock.
 func (wb *WriteBatch) commit() error {
 	if wb.err != nil {
-		fmt.Printf("Got error: %v\n", wb.err)
 		return wb.err
 	}
 	// Get a new txn before we commit this one. So, the new txn doesn't need

--- a/batch.go
+++ b/batch.go
@@ -17,7 +17,6 @@
 package badger
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -48,7 +47,6 @@ func (wb *WriteBatch) callback(err error) {
 	wb.Lock()
 	defer wb.Unlock()
 	if wb.err != nil {
-		panic(fmt.Sprintf("Got error: %v\n", err))
 		return
 	}
 	wb.err = err

--- a/batch_test.go
+++ b/batch_test.go
@@ -26,7 +26,10 @@ import (
 
 func TestWriteBatch(t *testing.T) {
 	key := func(i int) []byte {
-		return []byte(fmt.Sprintf("%30d", i))
+		// b := make([]byte, 8)
+		// binary.BigEndian.PutUint64(b, uint64(i))
+		// return b
+		return []byte(fmt.Sprintf("%10d", i))
 	}
 	val := func(i int) []byte {
 		return []byte(fmt.Sprintf("%128d", i))
@@ -44,7 +47,7 @@ func TestWriteBatch(t *testing.T) {
 			require.NoError(t, wb.Delete(key(i)))
 		}
 		require.NoError(t, wb.Flush())
-		t.Logf("Time it took to do 51K writes: %s\n", time.Since(start))
+		t.Logf("Time taken for %d writes (w/ test options): %s\n", N+M, time.Since(start))
 
 		err := db.View(func(txn *Txn) error {
 			itr := txn.NewIterator(DefaultIteratorOptions)
@@ -53,7 +56,7 @@ func TestWriteBatch(t *testing.T) {
 			i := M
 			for itr.Rewind(); itr.Valid(); itr.Next() {
 				item := itr.Item()
-				require.Equal(t, key(i), item.Key())
+				require.Equal(t, string(key(i)), string(item.Key()))
 				valcopy, err := item.ValueCopy(nil)
 				require.NoError(t, err)
 				require.Equal(t, val(i), valcopy)

--- a/batch_test.go
+++ b/batch_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package badger
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteBatch(t *testing.T) {
+	key := func(i int) []byte {
+		return []byte(fmt.Sprintf("%30d", i))
+	}
+	val := func(i int) []byte {
+		return []byte(fmt.Sprintf("%128d", i))
+	}
+
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		wb := db.NewWriteBatch()
+		N, M := 50000, 1000
+		start := time.Now()
+
+		for i := 0; i < N; i++ {
+			require.NoError(t, wb.Set(key(i), val(i), 0))
+		}
+		for i := 0; i < M; i++ {
+			require.NoError(t, wb.Delete(key(i)))
+		}
+		require.NoError(t, wb.Flush())
+		t.Logf("Time it took to do 51K writes: %s\n", time.Since(start))
+
+		err := db.View(func(txn *Txn) error {
+			itr := txn.NewIterator(DefaultIteratorOptions)
+			defer itr.Close()
+
+			i := M
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				item := itr.Item()
+				require.Equal(t, key(i), item.Key())
+				valcopy, err := item.ValueCopy(nil)
+				require.NoError(t, err)
+				require.Equal(t, val(i), valcopy)
+				i++
+			}
+			require.Equal(t, N, i)
+			return nil
+		})
+		require.NoError(t, err)
+	})
+}

--- a/db.go
+++ b/db.go
@@ -47,11 +47,12 @@ var (
 )
 
 type closers struct {
-	updateSize *y.Closer
-	compactors *y.Closer
-	memtable   *y.Closer
-	writes     *y.Closer
-	valueGC    *y.Closer
+	updateSize  *y.Closer
+	compactors  *y.Closer
+	memtable    *y.Closer
+	writes      *y.Closer
+	valueGC     *y.Closer
+	txnCallback *y.Closer
 }
 
 // DB provides the various functions required to interact with Badger.
@@ -63,17 +64,18 @@ type DB struct {
 	// nil if Dir and ValueDir are the same
 	valueDirGuard *directoryLockGuard
 
-	closers   closers
-	elog      trace.EventLog
-	mt        *skl.Skiplist   // Our latest (actively written) in-memory table
-	imm       []*skl.Skiplist // Add here only AFTER pushing to flushChan.
-	opt       Options
-	manifest  *manifestFile
-	lc        *levelsController
-	vlog      valueLog
-	vptr      valuePointer // less than or equal to a pointer to the last vlog value put into mt
-	writeCh   chan *request
-	flushChan chan flushTask // For flushing memtables.
+	closers       closers
+	elog          trace.EventLog
+	mt            *skl.Skiplist   // Our latest (actively written) in-memory table
+	imm           []*skl.Skiplist // Add here only AFTER pushing to flushChan.
+	opt           Options
+	manifest      *manifestFile
+	lc            *levelsController
+	vlog          valueLog
+	vptr          valuePointer // less than or equal to a pointer to the last vlog value put into mt
+	writeCh       chan *request
+	flushChan     chan flushTask // For flushing memtables.
+	txnCallbackCh chan *txnCb    // For running txn callbacks.
 
 	blockWrites int32
 
@@ -246,6 +248,7 @@ func Open(opt Options) (db *DB, err error) {
 		imm:           make([]*skl.Skiplist, 0, opt.NumMemtables),
 		flushChan:     make(chan flushTask, opt.NumMemtables),
 		writeCh:       make(chan *request, kvWriteChCapacity),
+		txnCallbackCh: make(chan *txnCb, 100),
 		opt:           opt,
 		manifest:      manifestFile,
 		elog:          trace.NewEventLog("Badger", "DB"),

--- a/managed_db.go
+++ b/managed_db.go
@@ -45,7 +45,7 @@ func (db *DB) NewTransactionAt(readTs uint64, update bool) *Txn {
 	if !db.opt.managedTxns {
 		panic("Cannot use NewTransactionAt with managedDB=false. Use NewTransaction instead.")
 	}
-	txn := db.NewTransaction(update)
+	txn := db.newTransaction(update, true)
 	txn.readTs = readTs
 	return txn
 }

--- a/managed_db.go
+++ b/managed_db.go
@@ -60,7 +60,11 @@ func (txn *Txn) CommitAt(commitTs uint64, callback func(error)) error {
 		panic("Cannot use CommitAt with managedDB=false. Use Commit instead.")
 	}
 	txn.commitTs = commitTs
-	return txn.Commit(callback)
+	if callback == nil {
+		return txn.Commit()
+	}
+	txn.CommitWith(callback)
+	return nil
 }
 
 // SetDiscardTs sets a timestamp at or below which, any invalid or deleted

--- a/txn.go
+++ b/txn.go
@@ -577,8 +577,8 @@ func (txn *Txn) commitPrecheck() {
 // If error is nil, the transaction is successfully committed. In case of a non-nil error, the LSM
 // tree won't be updated, so there's no need for any rollback.
 func (txn *Txn) Commit() error {
-	defer txn.Discard()
 	txn.commitPrecheck()
+	defer txn.Discard()
 
 	if len(txn.writes) == 0 {
 		return nil // Nothing to do.

--- a/txn.go
+++ b/txn.go
@@ -577,7 +577,7 @@ func (txn *Txn) commitPrecheck() {
 // If error is nil, the transaction is successfully committed. In case of a non-nil error, the LSM
 // tree won't be updated, so there's no need for any rollback.
 func (txn *Txn) Commit() error {
-	txn.commitPrecheck()
+	txn.commitPrecheck() // Precheck before discarding txn.
 	defer txn.Discard()
 
 	if len(txn.writes) == 0 {
@@ -634,8 +634,9 @@ func (db *DB) runTxnCallbacks(closer *y.Closer) {
 // so it is safe to increment sync.WaitGroup before calling CommitWith, and
 // decrementing it in the callback; to block until all callbacks are run.
 func (txn *Txn) CommitWith(cb func(error)) {
+	txn.commitPrecheck() // Precheck before discarding txn.
 	defer txn.Discard()
-	txn.commitPrecheck()
+
 	if cb == nil {
 		panic("Nil callback provided to CommitWith")
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -163,11 +163,11 @@ func TestValueGC(t *testing.T) {
 		rand.Read(v[:rand.Intn(sz)])
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v))
 		if i%20 == 0 {
-			require.NoError(t, txn.Commit(nil))
+			require.NoError(t, txn.Commit())
 			txn = kv.NewTransaction(true)
 		}
 	}
-	require.NoError(t, txn.Commit(nil))
+	require.NoError(t, txn.Commit())
 
 	for i := 0; i < 45; i++ {
 		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
@@ -216,11 +216,11 @@ func TestValueGC2(t *testing.T) {
 		rand.Read(v[:rand.Intn(sz)])
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v))
 		if i%20 == 0 {
-			require.NoError(t, txn.Commit(nil))
+			require.NoError(t, txn.Commit())
 			txn = kv.NewTransaction(true)
 		}
 	}
-	require.NoError(t, txn.Commit(nil))
+	require.NoError(t, txn.Commit())
 
 	for i := 0; i < 5; i++ {
 		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
@@ -301,11 +301,11 @@ func TestValueGC3(t *testing.T) {
 		// Keys key000, key001, key002, such that sorted order matches insertion order
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%03d", i)), v))
 		if i%20 == 0 {
-			require.NoError(t, txn.Commit(nil))
+			require.NoError(t, txn.Commit())
 			txn = kv.NewTransaction(true)
 		}
 	}
-	require.NoError(t, txn.Commit(nil))
+	require.NoError(t, txn.Commit())
 
 	// Start an iterator to keys in the first value log file
 	itOpt := IteratorOptions{
@@ -367,11 +367,11 @@ func TestValueGC4(t *testing.T) {
 		rand.Read(v[:rand.Intn(sz)])
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v))
 		if i%3 == 0 {
-			require.NoError(t, txn.Commit(nil))
+			require.NoError(t, txn.Commit())
 			txn = kv.NewTransaction(true)
 		}
 	}
-	require.NoError(t, txn.Commit(nil))
+	require.NoError(t, txn.Commit())
 
 	for i := 0; i < 8; i++ {
 		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
@@ -625,11 +625,11 @@ func TestValueLogTrigger(t *testing.T) {
 		rand.Read(v[:rand.Intn(sz)])
 		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v))
 		if i%20 == 0 {
-			require.NoError(t, txn.Commit(nil))
+			require.NoError(t, txn.Commit())
 			txn = kv.NewTransaction(true)
 		}
 	}
-	require.NoError(t, txn.Commit(nil))
+	require.NoError(t, txn.Commit())
 
 	for i := 0; i < 45; i++ {
 		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
@@ -658,7 +658,7 @@ func createVlog(t *testing.T, entries []*Entry) []byte {
 	for _, entry := range entries {
 		require.NoError(t, txn.SetWithMeta(entry.Key, entry.Value, entry.meta))
 	}
-	require.NoError(t, txn.Commit(nil))
+	require.NoError(t, txn.Commit())
 	require.NoError(t, kv.Close())
 
 	filename := vlogFilePath(dir, 0)


### PR DESCRIPTION
**Breaking change**

- This change removes the ability to provide a callback in Commit. Instead, it creates another function called CommitWith, which takes a callback.
- Previously, a user specified callback might or might not get executed. This PR fixes that by guaranteeing that the commit callback is always executed.
- Create a WriteBatch API to batch up multiple updates into a single txn. The txn gets Committed via callback, so the user gets a simple efficient way to do a lot of writes.
- Run only a few goroutines to execute these user callbacks. Previously, we were shooting off one goroutine per Commit callback.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/608)
<!-- Reviewable:end -->
