### PR TITLE
Align watermarks to 64-bit for atomic package

### DIFF
--- a/y/watermark.go
+++ b/y/watermark.go
@@ -55,11 +55,14 @@ type mark struct {
 //
 // An index may also become "done" by calling SetDoneUntil at a time such that it is not
 // inter-mingled with Begin/Done calls.
+//
+// Since doneUntil and lastIndex addresses are passed to sync/atomic packages, we ensure that they
+// are 64-bit aligned by putting them at the beginning of the structure.
 type WaterMark struct {
-	Name      string
-	markCh    chan mark
 	doneUntil uint64
 	lastIndex uint64
+	Name      string
+	markCh    chan mark
 	elog      trace.EventLog
 }
 


### PR DESCRIPTION
On 32-bit systems, the WaterMark structure's uint64 are not 64-bit aligned.
This causes the `atomic/sync` package to crash on arm devices, as underlined in https://golang.org/src/runtime/internal/atomic/atomic_arm.go#L123

Additionally, as explained in https://golang.org/pkg/sync/atomic/#pkg-note-BUG, WaterMark structures must be allocated differently to be 64-bit aligned on arm/32-bit architectures.

> On both ARM and x86-32, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned. 

It should fix #610

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/611)
<!-- Reviewable:end -->
