### PR TITLE
Bug Fix: Truncate of penultimate log files

### DIFF
--- a/db.go
+++ b/db.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"expvar"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -83,7 +84,7 @@ const (
 	kvWriteChCapacity = 1000
 )
 
-func replayFunction(out *DB) func(Entry, valuePointer) error {
+func (out *DB) replayFunction() func(Entry, valuePointer) error {
 	type txnEntry struct {
 		nk []byte
 		v  y.ValueStruct
@@ -135,6 +136,7 @@ func replayFunction(out *DB) func(Entry, valuePointer) error {
 			if err != nil {
 				return errors.Wrapf(err, "Unable to parse txn fin: %q", e.Value)
 			}
+			fmt.Printf("bitFinTxn. Ts=%d\n", txnTs)
 			y.AssertTrue(lastCommit == txnTs)
 			y.AssertTrue(len(txn) > 0)
 			// Got the end of txn. Now we can store them.
@@ -144,22 +146,28 @@ func replayFunction(out *DB) func(Entry, valuePointer) error {
 			txn = txn[:0]
 			lastCommit = 0
 
-		} else if e.meta&bitTxn == 0 {
+		} else if e.meta&bitTxn > 0 {
+			txnTs := y.ParseTs(nk)
+			fmt.Printf("bitTxn. Ts=%d\n", txnTs)
+			if lastCommit == 0 {
+				lastCommit = txnTs
+			}
+			if lastCommit != txnTs {
+				// We have found an incomplete txn. Let's discard it.
+				fmt.Printf("Discarding txn: %+v\n", txn)
+				txn = txn[:0]
+				lastCommit = txnTs
+			}
+			te := txnEntry{nk: nk, v: v}
+			txn = append(txn, te)
+
+		} else {
 			// This entry is from a rewrite.
 			toLSM(nk, v)
 
 			// We shouldn't get this entry in the middle of a transaction.
 			y.AssertTrue(lastCommit == 0)
 			y.AssertTrue(len(txn) == 0)
-
-		} else {
-			txnTs := y.ParseTs(nk)
-			if lastCommit == 0 {
-				lastCommit = txnTs
-			}
-			y.AssertTrue(lastCommit == txnTs)
-			te := txnEntry{nk: nk, v: v}
-			txn = append(txn, te)
 		}
 		return nil
 	}
@@ -273,10 +281,6 @@ func Open(opt Options) (db *DB, err error) {
 		go db.flushMemtable(db.closers.memtable) // Need levels controller to be up.
 	}
 
-	if err = db.vlog.Open(db, opt); err != nil {
-		return nil, err
-	}
-
 	headKey := y.KeyWithTs(head, math.MaxUint64)
 	// Need to pass with timestamp, lsm get removes the last 8 bytes and compares key
 	vs, err := db.get(headKey)
@@ -292,22 +296,15 @@ func Open(opt Options) (db *DB, err error) {
 	replayCloser := y.NewCloser(1)
 	go db.doWrites(replayCloser)
 
-	if err = db.vlog.Replay(vptr, replayFunction(db)); err != nil {
+	if err = db.vlog.open(db, vptr, db.replayFunction()); err != nil {
 		return db, err
 	}
-
 	replayCloser.SignalAndWait() // Wait for replay to be applied first.
 
 	// Let's advance nextTxnTs to one more than whatever we observed via
 	// replaying the logs.
 	db.orc.txnMark.Done(db.orc.nextTxnTs)
 	db.orc.nextTxnTs++
-
-	// Mmap writable log
-	lf := db.vlog.filesMap[db.vlog.maxFid]
-	if err = lf.mmap(2 * db.vlog.opt.ValueLogFileSize); err != nil {
-		return db, errors.Wrapf(err, "Unable to mmap RDWR log file")
-	}
 
 	// These goroutines run the user specified callbacks passed during txn.CommitWith.
 	db.closers.txnCallback = y.NewCloser(3)

--- a/db.go
+++ b/db.go
@@ -151,6 +151,7 @@ func (out *DB) replayFunction() func(Entry, valuePointer) error {
 			}
 			if lastCommit != txnTs {
 				// We have found an incomplete txn. Let's discard it.
+				Warningf("Found an incomplete txn at timestamp %d. Discarding it.\n", lastCommit)
 				txn = txn[:0]
 				lastCommit = txnTs
 			}

--- a/db.go
+++ b/db.go
@@ -150,7 +150,6 @@ func (out *DB) replayFunction() func(Entry, valuePointer) error {
 				lastCommit = txnTs
 			}
 			if lastCommit != txnTs {
-				// We have found an incomplete txn. Let's discard it.
 				Warningf("Found an incomplete txn at timestamp %d. Discarding it.\n", lastCommit)
 				txn = txn[:0]
 				lastCommit = txnTs

--- a/db.go
+++ b/db.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"expvar"
-	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -136,7 +135,6 @@ func (out *DB) replayFunction() func(Entry, valuePointer) error {
 			if err != nil {
 				return errors.Wrapf(err, "Unable to parse txn fin: %q", e.Value)
 			}
-			fmt.Printf("bitFinTxn. Ts=%d\n", txnTs)
 			y.AssertTrue(lastCommit == txnTs)
 			y.AssertTrue(len(txn) > 0)
 			// Got the end of txn. Now we can store them.
@@ -148,13 +146,11 @@ func (out *DB) replayFunction() func(Entry, valuePointer) error {
 
 		} else if e.meta&bitTxn > 0 {
 			txnTs := y.ParseTs(nk)
-			fmt.Printf("bitTxn. Ts=%d\n", txnTs)
 			if lastCommit == 0 {
 				lastCommit = txnTs
 			}
 			if lastCommit != txnTs {
 				// We have found an incomplete txn. Let's discard it.
-				fmt.Printf("Discarding txn: %+v\n", txn)
 				txn = txn[:0]
 				lastCommit = txnTs
 			}

--- a/txn.go
+++ b/txn.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -536,7 +535,6 @@ func (txn *Txn) commitAndSend() (func() error, error) {
 		meta:  bitFinTxn,
 	}
 	entries = append(entries, e)
-	fmt.Printf("Sending %d entries at ts=%d\n", len(entries), commitTs)
 
 	req, err := txn.db.sendToWriteCh(entries)
 	if err != nil {

--- a/txn.go
+++ b/txn.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -535,6 +536,7 @@ func (txn *Txn) commitAndSend() (func() error, error) {
 		meta:  bitFinTxn,
 	}
 	entries = append(entries, e)
+	fmt.Printf("Sending %d entries at ts=%d\n", len(entries), commitTs)
 
 	req, err := txn.db.sendToWriteCh(entries)
 	if err != nil {

--- a/value.go
+++ b/value.go
@@ -778,8 +778,7 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 		return errFile(err, last.path, "file.Seek to end")
 	}
 	vlog.writableLogOffset = uint32(lastOffset)
-	// Map the file if needed. When we create a file, it is automatically
-	// mapped.
+	// Map the file if needed. When we create a file, it is automatically mapped.
 	if err = last.mmap(2 * opt.ValueLogFileSize); err != nil {
 		return errFile(err, last.path, "Map log file")
 	}

--- a/value.go
+++ b/value.go
@@ -24,6 +24,7 @@ import (
 	"hash/crc32"
 	"io"
 	"io/ioutil"
+	"log"
 	"math"
 	"math/rand"
 	"os"
@@ -266,7 +267,7 @@ func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) (uint32, 
 
 	// We're not at the end of the file. Let's Seek to the offset and start reading.
 	if _, err := lf.fd.Seek(int64(offset), io.SeekStart); err != nil {
-		return 0, y.Wrap(err)
+		return 0, errFile(err, lf.path, "Unable to seek")
 	}
 
 	reader := bufio.NewReader(lf.fd)
@@ -328,7 +329,7 @@ func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) (uint32, 
 			if err == errStop {
 				break
 			}
-			return 0, y.Wrap(err)
+			return 0, errFile(err, lf.path, "Iteration function")
 		}
 	}
 	return validEndOffset, nil
@@ -342,7 +343,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 	wb := make([]*Entry, 0, 1000)
 	var size int64
 
-	y.AssertTrue(vlog.kv != nil)
+	y.AssertTrue(vlog.db != nil)
 	var count, moved int
 	fe := func(e Entry) error {
 		count++
@@ -350,7 +351,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 			tr.LazyPrintf("Processing entry %d", count)
 		}
 
-		vs, err := vlog.kv.get(e.Key)
+		vs, err := vlog.db.get(e.Key)
 		if err != nil {
 			return err
 		}
@@ -394,7 +395,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 			size += int64(e.estimateSize(vlog.opt.ValueThreshold))
 			if size >= 64*mi {
 				tr.LazyPrintf("request has %d entries, size %d", len(wb), size)
-				if err := vlog.kv.batchSet(wb); err != nil {
+				if err := vlog.db.batchSet(wb); err != nil {
 					return err
 				}
 				size = 0
@@ -426,7 +427,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 		if end > len(wb) {
 			end = len(wb)
 		}
-		if err := vlog.kv.batchSet(wb[i:end]); err != nil {
+		if err := vlog.db.batchSet(wb[i:end]); err != nil {
 			if err == ErrTxnTooBig {
 				// Decrease the batch size to half.
 				batchSize = batchSize / 2
@@ -466,7 +467,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 }
 
 func (vlog *valueLog) deleteMoveKeysFor(fid uint32, tr trace.Trace) error {
-	db := vlog.kv
+	db := vlog.db
 	var result []*Entry
 	var count, pointers uint64
 	tr.LazyPrintf("Iterating over move keys to find invalids for fid: %d", fid)
@@ -580,7 +581,7 @@ type valueLog struct {
 	// A refcount of iterators -- when this hits zero, we can delete the filesToBeDeleted.
 	numActiveIterators int32
 
-	kv                *DB
+	db                *DB
 	maxFid            uint32 // accessed via atomics.
 	writableLogOffset uint32 // read by read, written by write. Must access via atomics.
 	numEntriesWritten uint32
@@ -599,6 +600,8 @@ func (vlog *valueLog) fpath(fid uint32) string {
 }
 
 func (vlog *valueLog) populateFilesMap() error {
+	vlog.filesMap = make(map[uint32]*logFile)
+
 	files, err := ioutil.ReadDir(vlog.dirPath)
 	if err != nil {
 		return errors.Wrapf(err, "Error while opening value log")
@@ -612,10 +615,10 @@ func (vlog *valueLog) populateFilesMap() error {
 		fsz := len(file.Name())
 		fid, err := strconv.ParseUint(file.Name()[:fsz-5], 10, 32)
 		if err != nil {
-			return errors.Wrapf(err, "Error while parsing value log id for file: %q", file.Name())
+			return fmt.Errorf("Unable to parse value log id for file %q. Err=%v", file.Name(), err)
 		}
 		if _, ok := found[fid]; ok {
-			return errors.Errorf("Found the same value log file twice: %d", fid)
+			return fmt.Errorf("Found the same value log file twice: %d", fid)
 		}
 		found[fid] = struct{}{}
 
@@ -629,75 +632,79 @@ func (vlog *valueLog) populateFilesMap() error {
 	return nil
 }
 
-func (vlog *valueLog) openOrCreateFiles(readOnly bool) error {
-	files, err := ioutil.ReadDir(vlog.dirPath)
-	if err != nil {
-		return errors.Wrapf(err, "Error while opening value log")
-	}
+// func (vlog *valueLog) openOrCreateFiles(readOnly bool) error {
+// 	files, err := ioutil.ReadDir(vlog.dirPath)
+// 	if err != nil {
+// 		return errors.Wrapf(err, "Error while opening value log")
+// 	}
 
-	found := make(map[uint64]struct{})
-	var maxFid uint32 // Beware len(files) == 0 case, this starts at 0.
-	for _, file := range files {
-		if !strings.HasSuffix(file.Name(), ".vlog") {
-			continue
-		}
-		fsz := len(file.Name())
-		fid, err := strconv.ParseUint(file.Name()[:fsz-5], 10, 32)
-		if err != nil {
-			return errors.Wrapf(err, "Error while parsing value log id for file: %q", file.Name())
-		}
-		if _, ok := found[fid]; ok {
-			return errors.Errorf("Found the same value log file twice: %d", fid)
-		}
-		found[fid] = struct{}{}
+// 	found := make(map[uint64]struct{})
+// 	var maxFid uint32 // Beware len(files) == 0 case, this starts at 0.
+// 	for _, file := range files {
+// 		if !strings.HasSuffix(file.Name(), ".vlog") {
+// 			continue
+// 		}
+// 		fsz := len(file.Name())
+// 		fid, err := strconv.ParseUint(file.Name()[:fsz-5], 10, 32)
+// 		if err != nil {
+// 			return errors.Wrapf(err, "Error while parsing value log id for file: %q", file.Name())
+// 		}
+// 		if _, ok := found[fid]; ok {
+// 			return errors.Errorf("Found the same value log file twice: %d", fid)
+// 		}
+// 		found[fid] = struct{}{}
 
-		lf := &logFile{
-			fid:         uint32(fid),
-			path:        vlog.fpath(uint32(fid)),
-			loadingMode: vlog.opt.ValueLogLoadingMode,
-		}
-		vlog.filesMap[uint32(fid)] = lf
-		if uint32(fid) > maxFid {
-			maxFid = uint32(fid)
-		}
-	}
-	vlog.maxFid = uint32(maxFid)
+// 		lf := &logFile{
+// 			fid:         uint32(fid),
+// 			path:        vlog.fpath(uint32(fid)),
+// 			loadingMode: vlog.opt.ValueLogLoadingMode,
+// 		}
+// 		vlog.filesMap[uint32(fid)] = lf
+// 		if uint32(fid) > maxFid {
+// 			maxFid = uint32(fid)
+// 		}
+// 	}
+// 	vlog.maxFid = uint32(maxFid)
 
-	// Open all previous log files as read only. Open the last log file
-	// as read write (unless the DB is read only).
-	for fid, lf := range vlog.filesMap {
-		if fid == maxFid {
-			var flags uint32
-			if vlog.opt.SyncWrites {
-				flags |= y.Sync
-			}
-			if readOnly {
-				flags |= y.ReadOnly
-			}
-			if lf.fd, err = y.OpenExistingFile(vlog.fpath(fid), flags); err != nil {
-				return errors.Wrapf(err, "Unable to open value log file")
-			}
-		} else {
-			if err := lf.openReadOnly(); err != nil {
-				return err
-			}
-		}
-	}
+// 	// Open all previous log files as read only. Open the last log file
+// 	// as read write (unless the DB is read only).
+// 	for fid, lf := range vlog.filesMap {
+// 		if fid == maxFid {
+// 			var flags uint32
+// 			if vlog.opt.SyncWrites {
+// 				flags |= y.Sync
+// 			}
+// 			if readOnly {
+// 				flags |= y.ReadOnly
+// 			}
+// 			if lf.fd, err = y.OpenExistingFile(vlog.fpath(fid), flags); err != nil {
+// 				return errors.Wrapf(err, "Unable to open value log file")
+// 			}
+// 		} else {
+// 			if err := lf.openReadOnly(); err != nil {
+// 				return err
+// 			}
+// 		}
+// 	}
 
-	// If no files are found, then create a new file.
-	if len(vlog.filesMap) == 0 {
-		// We already set vlog.maxFid above
-		_, err := vlog.createVlogFile(0)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
+// 	// If no files are found, then create a new file.
+// 	if len(vlog.filesMap) == 0 {
+// 		// We already set vlog.maxFid above
+// 		_, err := vlog.createVlogFile(0)
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+// 	return nil
+// }
 
 func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 	path := vlog.fpath(fid)
-	lf := &logFile{fid: fid, path: path, loadingMode: vlog.opt.ValueLogLoadingMode}
+	lf := &logFile{
+		fid:         fid,
+		path:        path,
+		loadingMode: vlog.opt.ValueLogLoadingMode,
+	}
 	// writableLogOffset is only written by write func, by read by Read func.
 	// To avoid a race condition, all reads and updates to this variable must be
 	// done via atomics.
@@ -706,11 +713,13 @@ func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 
 	var err error
 	if lf.fd, err = y.CreateSyncedFile(path, vlog.opt.SyncWrites); err != nil {
-		return nil, errors.Wrapf(err, "Unable to create value log file")
+		return nil, errFile(err, lf.path, "Create value log file")
 	}
-
 	if err = syncDir(vlog.dirPath); err != nil {
-		return nil, errors.Wrapf(err, "Unable to sync value log file dir")
+		return nil, errFile(err, vlog.dirPath, "Sync value log dir")
+	}
+	if err = lf.mmap(2 * vlog.opt.ValueLogFileSize); err != nil {
+		return nil, errFile(err, lf.path, "Mmap value log file")
 	}
 
 	vlog.filesLock.Lock()
@@ -720,24 +729,28 @@ func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 	return lf, nil
 }
 
+func errFile(err error, path string, msg string) error {
+	return fmt.Errorf("%s. Path=%s. Error=%v", msg, path, err)
+}
+
 func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) error {
 	// We should open the file in RW mode, so it can be truncated.
 	var err error
 	lf.fd, err = os.OpenFile(lf.path, os.O_RDWR, 0)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to open file in RW mode: %q", lf.path)
+		return errFile(err, lf.path, "Open file in RW mode")
 	}
 	defer lf.fd.Close()
 
 	fi, err := lf.fd.Stat()
 	if err != nil {
-		return errors.Wrapf(err, "Unable to run file.Stat: %q", lf.path)
+		return errFile(err, lf.path, "Unable to run file.Stat")
 	}
 
 	// Alright, let's iterate now.
 	endOffset, err := vlog.iterate(lf, offset, replayFn)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to replay logfile: %q", lf.path)
+		return errFile(err, lf.path, "Unable to replay logfile")
 	}
 	if int64(endOffset) == fi.Size() {
 		return nil
@@ -750,17 +763,20 @@ func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) e
 		return ErrTruncateNeeded
 	}
 	if err := lf.fd.Truncate(int64(endOffset)); err != nil {
-		return errors.Wrapf(err, "Unable to truncate file: %q at offset: %d."+
-			" This can also be done manually to allow Badger to run.", lf.path, endOffset)
+		return errFile(err, lf.path, fmt.Sprintf(
+			"Truncation needed at offset %d. Can be done manually as well.", endOffset))
 	}
 	return nil
 }
 
-func (db *DB) openValueLog(ptr valuePointer, replayFn logEntry) error {
-	vlog, opt := db.vlog, db.opt
-	vlog.dirPath = opt.ValueDir
+func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
+	opt := db.opt
 	vlog.opt = opt
-	vlog.kv = db
+	vlog.dirPath = opt.ValueDir
+	vlog.db = db
+	vlog.elog = trace.NewEventLog("Badger", "Valuelog")
+	vlog.garbageCh = make(chan struct{}, 1) // Only allow one GC at a time.
+	vlog.lfDiscardStats = &lfDiscardStats{m: make(map[uint32]int64)}
 
 	if err := vlog.populateFilesMap(); err != nil {
 		return err
@@ -768,7 +784,9 @@ func (db *DB) openValueLog(ptr valuePointer, replayFn logEntry) error {
 
 	// If no files are found, then create a new file.
 	if len(vlog.filesMap) == 0 {
-		_, err := vlog.createVlogFile(0)
+		// TODO: Warn if the valuePointer is > 0.
+		lf, err := vlog.createVlogFile(0)
+		fmt.Printf("creating zero log file: %v. err=%v\n", lf, err)
 		return err
 	}
 
@@ -822,32 +840,21 @@ func (db *DB) openValueLog(ptr valuePointer, replayFn logEntry) error {
 	}
 
 	// Seek to the end to start writing.
-	last := vlog.filesMap[vlog.maxFid]
+	last, ok := vlog.filesMap[vlog.maxFid]
+	y.AssertTrue(ok)
 	lastOffset, err := last.fd.Seek(0, io.SeekEnd)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to seek to end of value log: %q", last.path)
+		return errFile(err, last.path, "file.Seek to end")
 	}
 	vlog.writableLogOffset = uint32(lastOffset)
-
-	vlog.elog = trace.NewEventLog("Badger", "Valuelog")
-	vlog.garbageCh = make(chan struct{}, 1) // Only allow one GC at a time.
-	vlog.lfDiscardStats = &lfDiscardStats{m: make(map[uint32]int64)}
+	if err = last.mmap(2 * opt.ValueLogFileSize); err != nil {
+		return errFile(err, last.path, "Map log file")
+	}
 	return nil
 }
 
-func (vlog *valueLog) Open(kv *DB, opt Options) error {
-	vlog.dirPath = opt.ValueDir
-	vlog.opt = opt
-	vlog.kv = kv
-	vlog.filesMap = make(map[uint32]*logFile)
-	if err := vlog.openOrCreateFiles(kv.opt.ReadOnly); err != nil {
-		return errors.Wrapf(err, "Unable to open value log")
-	}
-
-	vlog.elog = trace.NewEventLog("Badger", "Valuelog")
-	vlog.garbageCh = make(chan struct{}, 1) // Only allow one GC at a time.
-	vlog.lfDiscardStats = &lfDiscardStats{m: make(map[uint32]int64)}
-	return nil
+func (vlog *valueLog) Replay(vptr valuePointer, fn interface{}) {
+	log.Fatalf("replay")
 }
 
 func (vlog *valueLog) Close() error {
@@ -894,61 +901,6 @@ func (vlog *valueLog) sortedFids() []uint32 {
 		return ret[i] < ret[j]
 	})
 	return ret
-}
-
-// Replay replays the value log. The kv provided is only valid for the lifetime of function call.
-func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
-	fid := ptr.Fid
-	offset := ptr.Offset + ptr.Len
-	vlog.elog.Printf("Seeking at value pointer: %+v\n", ptr)
-
-	fids := vlog.sortedFids()
-
-	for _, id := range fids {
-		if id < fid {
-			continue
-		}
-		of := offset
-		if id > fid {
-			of = 0
-		}
-		lf := vlog.filesMap[id]
-		vlog.elog.Printf("Iterating file id: %d", id)
-		now := time.Now()
-		fi, err := lf.fd.Stat()
-		if err != nil {
-			return err
-		}
-		validEndOffset, err := vlog.iterate(lf, of, fn)
-		if err != nil {
-			return errors.Wrapf(err, "Unable to replay value log: %q", lf.path)
-		}
-		if int64(validEndOffset) != fi.Size() {
-			y.AssertTrue(int64(validEndOffset) <= fi.Size())
-			switch {
-			case !vlog.opt.Truncate:
-				return ErrTruncateNeeded
-			case len(lf.fmap) > 0:
-				// Only truncate if the file isn't mmaped. Otherwise, Windows would puke.
-				return ErrTruncateNeeded
-			default:
-				if err := lf.fd.Truncate(int64(validEndOffset)); err != nil {
-					return errors.Wrapf(err, "Unable to truncate file: %q", lf.path)
-				}
-			}
-		}
-		vlog.elog.Printf("Iteration took: %s\n", time.Since(now))
-		if err != nil {
-			return errors.Wrapf(err, "Unable to replay value log: %q", lf.path)
-		}
-	}
-
-	// Seek to the end to start writing.
-	var err error
-	last := vlog.filesMap[vlog.maxFid]
-	lastOffset, err := last.fd.Seek(0, io.SeekEnd)
-	atomic.AddUint32(&vlog.writableLogOffset, uint32(lastOffset))
-	return errors.Wrapf(err, "Unable to seek to end of value log: %q", last.path)
 }
 
 type request struct {
@@ -1005,6 +957,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 	maxFid := atomic.LoadUint32(&vlog.maxFid)
 	curlf := vlog.filesMap[maxFid]
 	vlog.filesLock.RUnlock()
+	fmt.Printf("maxfid=%d. curlf=%v\n", maxFid, curlf)
 
 	toDisk := func() error {
 		if vlog.buf.Len() == 0 {
@@ -1034,11 +987,6 @@ func (vlog *valueLog) write(reqs []*request) error {
 			if err != nil {
 				return err
 			}
-
-			if err = newlf.mmap(2 * vlog.opt.ValueLogFileSize); err != nil {
-				return err
-			}
-
 			curlf = newlf
 		}
 		return nil
@@ -1257,7 +1205,7 @@ func (vlog *valueLog) doRunGC(lf *logFile, discardRatio float64, tr trace.Trace)
 
 	var r reason
 	start := time.Now()
-	y.AssertTrue(vlog.kv != nil)
+	y.AssertTrue(vlog.db != nil)
 	s := new(y.Slice)
 	var numIterations int
 	_, err = vlog.iterate(lf, 0, func(e Entry, vp valuePointer) error {
@@ -1284,7 +1232,7 @@ func (vlog *valueLog) doRunGC(lf *logFile, discardRatio float64, tr trace.Trace)
 		r.total += esz
 		r.count++
 
-		vs, err := vlog.kv.get(e.Key)
+		vs, err := vlog.db.get(e.Key)
 		if err != nil {
 			return err
 		}

--- a/value.go
+++ b/value.go
@@ -785,8 +785,7 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 	// If no files are found, then create a new file.
 	if len(vlog.filesMap) == 0 {
 		// TODO: Warn if the valuePointer is > 0.
-		lf, err := vlog.createVlogFile(0)
-		fmt.Printf("creating zero log file: %v. err=%v\n", lf, err)
+		_, err := vlog.createVlogFile(0)
 		return err
 	}
 
@@ -957,7 +956,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 	maxFid := atomic.LoadUint32(&vlog.maxFid)
 	curlf := vlog.filesMap[maxFid]
 	vlog.filesLock.RUnlock()
-	fmt.Printf("maxfid=%d. curlf=%v\n", maxFid, curlf)
+	// fmt.Printf("maxfid=%d. curlf=%v\n", maxFid, curlf)
 
 	toDisk := func() error {
 		if vlog.buf.Len() == 0 {

--- a/value_test.go
+++ b/value_test.go
@@ -398,9 +398,6 @@ func TestValueGC4(t *testing.T) {
 	kv.vlog.rewrite(lf0, tr)
 	kv.vlog.rewrite(lf1, tr)
 
-	// This function is no longer available.
-	// Replay value log
-	// kv.vlog.Replay(valuePointer{Fid: 2}, kv.replayFunction())
 	err = kv.vlog.open(kv, valuePointer{Fid: 2}, kv.replayFunction())
 	require.NoError(t, err)
 
@@ -697,7 +694,6 @@ func TestPenultimateLogCorruption(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-	// require.NoError(t, db0.Close())
 	// Simulate a crash by not closing db0, but releasing the locks.
 	if db0.dirLockGuard != nil {
 		require.NoError(t, db0.dirLockGuard.release())
@@ -827,14 +823,14 @@ func BenchmarkReadWrite(b *testing.B) {
 	for _, vsz := range valueSize {
 		for _, rw := range rwRatio {
 			b.Run(fmt.Sprintf("%3.1f,%04d", rw, vsz), func(b *testing.B) {
-				var vl valueLog
-				dir, err := ioutil.TempDir("", "vlog")
+				dir, err := ioutil.TempDir("", "vlog-benchmark")
 				y.Check(err)
 				defer os.RemoveAll(dir)
-				// TODO: Fix this up.
-				// err = vl.Open(nil, getTestOptions(dir))
+
+				db, err := Open(getTestOptions(dir))
 				y.Check(err)
-				defer vl.Close()
+
+				vl := db.vlog
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {

--- a/value_test.go
+++ b/value_test.go
@@ -357,7 +357,8 @@ func TestValueGC4(t *testing.T) {
 	opt := getTestOptions(dir)
 	opt.ValueLogFileSize = 1 << 20
 
-	kv, _ := Open(opt)
+	kv, err := Open(opt)
+	require.NoError(t, err)
 	defer kv.Close()
 
 	sz := 128 << 10 // 5 entries per value log file.
@@ -397,8 +398,11 @@ func TestValueGC4(t *testing.T) {
 	kv.vlog.rewrite(lf0, tr)
 	kv.vlog.rewrite(lf1, tr)
 
+	// This function is no longer available.
 	// Replay value log
-	kv.vlog.Replay(valuePointer{Fid: 2}, kv.replayFunction())
+	// kv.vlog.Replay(valuePointer{Fid: 2}, kv.replayFunction())
+	err = kv.vlog.open(kv, valuePointer{Fid: 2}, kv.replayFunction())
+	require.NoError(t, err)
 
 	for i := 0; i < 8; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
@@ -564,7 +568,7 @@ func TestPartialAppendToValueLog(t *testing.T) {
 	checkKeys(t, kv, [][]byte{k3})
 
 	// Replay value log from beginning, badger head is past k2.
-	kv.vlog.Replay(valuePointer{Fid: 0}, kv.replayFunction())
+	kv.vlog.open(kv, valuePointer{Fid: 0}, kv.replayFunction())
 	require.NoError(t, kv.Close())
 }
 


### PR DESCRIPTION
Value log files minus the most recent log one, were being opened with read-only permissions. If the value head pointer was pointing to them, and one of them had a file system corruption issue, where they missed their bits, it would cause Badger to try to truncate them. Being read-only, this would cause an "invalid argument" to be returned by the Go file.truncate call. This error caused confusion before, but essentially, it was being returned because the files were read-only, and therefore couldn't be truncated (EINVAL).

This PR fixes that by refactoring how value log is opened. It iterates over the log files, and if they need to be replayed, it would open them in RW mode; allowing truncation to happen. Then, it would open them in the mode they can be consumed by Badger.

Fixes #613 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/616)
<!-- Reviewable:end -->
