### PR TITLE
Remove an uninterruptible sleep

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -240,7 +240,14 @@ func (s *levelsController) runWorker(lc *y.Closer) {
 		return
 	}
 
-	time.Sleep(time.Duration(rand.Int31n(1000)) * time.Millisecond)
+	randomDelay := time.NewTimer(time.Duration(rand.Int31n(1000)) * time.Millisecond)
+	select {
+	case <-randomDelay.C:
+	case <-lc.HasBeenClosed():
+		randomDelay.Stop()
+		return
+	}
+
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 


### PR DESCRIPTION
This sleep blocks closing the database.

Related to #641 (but, unfortunately, this fix isn't sufficient).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/642)
<!-- Reviewable:end -->
