### PR TITLE
New tools, new option

### DIFF
--- a/badger/cmd/fill.go
+++ b/badger/cmd/fill.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cmd
 
 import (

--- a/badger/cmd/fill.go
+++ b/badger/cmd/fill.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"time"
+
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/badger/y"
+	"github.com/spf13/cobra"
+)
+
+var fillCmd = &cobra.Command{
+	Use:   "fill",
+	Short: "Fill Badger with random data.",
+	Long: `
+This command would fill Badger with random data. Useful for testing and performance analysis.
+`,
+	RunE: fill,
+}
+
+var keySz, valSz int
+var numKeys float64
+
+const mil float64 = 1e6
+
+func init() {
+	RootCmd.AddCommand(fillCmd)
+	fillCmd.Flags().IntVarP(&keySz, "key-size", "k", 32, "Size of key")
+	fillCmd.Flags().IntVarP(&valSz, "val-size", "v", 128, "Size of value")
+	fillCmd.Flags().Float64VarP(&numKeys, "keys-mil", "m", 10.0,
+		"Number of keys to add in millions")
+}
+
+func fill(cmd *cobra.Command, args []string) error {
+	opts := badger.DefaultOptions
+	opts.Dir = sstDir
+	opts.ValueDir = vlogDir
+	opts.Truncate = truncate
+	opts.SyncWrites = false
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	start := time.Now()
+	batch := db.NewWriteBatch()
+	num := int64(numKeys * mil)
+	for i := int64(1); i <= num; i++ {
+		k := make([]byte, keySz)
+		v := make([]byte, valSz)
+		y.Check2(rand.Read(k))
+		y.Check2(rand.Read(v))
+		if err := batch.Set(k, v, 0); err != nil {
+			return err
+		}
+		if i%1e5 == 0 {
+			badger.Infof("Written keys: %d\n", i)
+		}
+	}
+	if err := batch.Flush(); err != nil {
+		return err
+	}
+	badger.Infof("%d keys written. Time taken: %s\n", num, time.Since(start))
+	return nil
+}

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -14,8 +14,13 @@ This command would compact all the LSM tables into one level.
 	RunE: flatten,
 }
 
+var numWorkers int
+
 func init() {
 	RootCmd.AddCommand(flattenCmd)
+	flattenCmd.Flags().IntVarP(&numWorkers, "num-workers", "w", 1,
+		"Number of concurrent compactors to run. More compactors would use more"+
+			" server resources to potentially achieve faster compactions.")
 }
 
 func flatten(cmd *cobra.Command, args []string) error {
@@ -31,5 +36,5 @@ func flatten(cmd *cobra.Command, args []string) error {
 	}
 	defer db.Close()
 
-	return db.Flatten()
+	return db.Flatten(numWorkers)
 }

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cmd
 
 import (

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/dgraph-io/badger"
+	"github.com/spf13/cobra"
+)
+
+var flattenCmd = &cobra.Command{
+	Use:   "flatten",
+	Short: "Flatten the LSM tree.",
+	Long: `
+This command would compact all the LSM tables into one level.
+`,
+	RunE: flatten,
+}
+
+func init() {
+	RootCmd.AddCommand(flattenCmd)
+}
+
+func flatten(cmd *cobra.Command, args []string) error {
+	opts := badger.DefaultOptions
+	opts.Dir = sstDir
+	opts.ValueDir = vlogDir
+	opts.Truncate = truncate
+	opts.NumCompactors = 0
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	return db.Flatten()
+}

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -47,6 +47,9 @@ to the Dgraph team.
 			fmt.Println("Error:", err.Error())
 			os.Exit(1)
 		}
+		if !showTables {
+			return
+		}
 		err = tableInfo(sstDir, vlogDir)
 		if err != nil {
 			fmt.Println("Error:", err.Error())
@@ -55,8 +58,12 @@ to the Dgraph team.
 	},
 }
 
+var showTables bool
+
 func init() {
 	RootCmd.AddCommand(infoCmd)
+	infoCmd.Flags().BoolVarP(&showTables, "show-tables", "s", false,
+		"If set to true, show tables as well.")
 }
 
 func hbytes(sz int64) string {

--- a/compaction.go
+++ b/compaction.go
@@ -172,19 +172,12 @@ func (cs *compactStatus) compareAndAdd(_ thisAndNextLevelRLocked, cd compactDef)
 	}
 	// Check whether this level really needs compaction or not. Otherwise, we'll end up
 	// running parallel compactions for the same level.
-	// NOTE: We can directly call thisLevel.totalSize, because we already have acquire a read lock
-	// over this and the next level.
-
-	// We should not be checking size here. Compaction priority already did the size checks. Here we
-	// should just be executing the wish of others.
-	// if cd.thisLevel.totalSize-thisLevel.delSize < cd.thisLevel.maxTotalSize {
-	// 	return false
-	// }
+	// Update: We should not be checking size here. Compaction priority already did the size checks.
+	// Here we should just be executing the wish of others.
 
 	thisLevel.ranges = append(thisLevel.ranges, cd.thisRange)
 	nextLevel.ranges = append(nextLevel.ranges, cd.nextRange)
 	thisLevel.delSize += cd.thisSize
-
 	return true
 }
 

--- a/compaction.go
+++ b/compaction.go
@@ -174,9 +174,12 @@ func (cs *compactStatus) compareAndAdd(_ thisAndNextLevelRLocked, cd compactDef)
 	// running parallel compactions for the same level.
 	// NOTE: We can directly call thisLevel.totalSize, because we already have acquire a read lock
 	// over this and the next level.
-	if cd.thisLevel.totalSize-thisLevel.delSize < cd.thisLevel.maxTotalSize {
-		return false
-	}
+
+	// We should not be checking size here. Compaction priority already did the size checks. Here we
+	// should just be executing the wish of others.
+	// if cd.thisLevel.totalSize-thisLevel.delSize < cd.thisLevel.maxTotalSize {
+	// 	return false
+	// }
 
 	thisLevel.ranges = append(thisLevel.ranges, cd.thisRange)
 	nextLevel.ranges = append(nextLevel.ranges, cd.nextRange)

--- a/levels.go
+++ b/levels.go
@@ -605,7 +605,6 @@ func (s *levelsController) fillTables(cd *compactDef) bool {
 			cd.bot = []*table.Table{}
 			cd.nextRange = cd.thisRange
 			if !s.cstatus.compareAndAdd(thisAndNextLevelRLocked{}, *cd) {
-				Infof("CompareAndAdd failed here.")
 				continue
 			}
 			return true

--- a/levels.go
+++ b/levels.go
@@ -236,9 +236,6 @@ func (s *levelsController) startCompact(lc *y.Closer) {
 
 func (s *levelsController) runWorker(lc *y.Closer) {
 	defer lc.Done()
-	if s.kv.opt.DoNotCompact {
-		return
-	}
 
 	time.Sleep(time.Duration(rand.Int31n(1000)) * time.Millisecond)
 	ticker := time.NewTicker(time.Second)
@@ -250,10 +247,10 @@ func (s *levelsController) runWorker(lc *y.Closer) {
 		case <-ticker.C:
 			prios := s.pickCompactLevels()
 			for _, p := range prios {
-				// TODO: Handle error.
-				didCompact, _ := s.doCompact(p)
-				if didCompact {
+				if err := s.doCompact(p); err == nil {
 					break
+				} else {
+					Errorf("Error while running doCompact: %v\n", err)
 				}
 			}
 		case <-lc.HasBeenClosed():
@@ -608,6 +605,7 @@ func (s *levelsController) fillTables(cd *compactDef) bool {
 			cd.bot = []*table.Table{}
 			cd.nextRange = cd.thisRange
 			if !s.cstatus.compareAndAdd(thisAndNextLevelRLocked{}, *cd) {
+				Infof("CompareAndAdd failed here.")
 				continue
 			}
 			return true
@@ -617,7 +615,6 @@ func (s *levelsController) fillTables(cd *compactDef) bool {
 		if s.cstatus.overlapsWith(cd.nextLevel.level, cd.nextRange) {
 			continue
 		}
-
 		if !s.cstatus.compareAndAdd(thisAndNextLevelRLocked{}, *cd) {
 			continue
 		}
@@ -670,7 +667,7 @@ func (s *levelsController) runCompactDef(l int, cd compactDef) (err error) {
 }
 
 // doCompact picks some table on level l and compacts it away to the next level.
-func (s *levelsController) doCompact(p compactionPriority) (bool, error) {
+func (s *levelsController) doCompact(p compactionPriority) error {
 	l := p.level
 	y.AssertTrue(l+1 < s.kv.opt.MaxLevels) // Sanity check.
 
@@ -689,13 +686,13 @@ func (s *levelsController) doCompact(p compactionPriority) (bool, error) {
 	if l == 0 {
 		if !s.fillTablesL0(&cd) {
 			cd.elog.LazyPrintf("fillTables failed for level: %d\n", l)
-			return false, nil
+			return fmt.Errorf("Unable to fill tables for level: %d\n", l)
 		}
 
 	} else {
 		if !s.fillTables(&cd) {
 			cd.elog.LazyPrintf("fillTables failed for level: %d\n", l)
-			return false, nil
+			return fmt.Errorf("Unable to fill tables for level: %d\n", l)
 		}
 	}
 	defer s.cstatus.delete(cd) // Remove the ranges from compaction status.
@@ -705,12 +702,12 @@ func (s *levelsController) doCompact(p compactionPriority) (bool, error) {
 	if err := s.runCompactDef(l, cd); err != nil {
 		// This compaction couldn't be done successfully.
 		cd.elog.LazyPrintf("\tLOG Compact FAILED with error: %+v: %+v", err, cd)
-		return false, err
+		return err
 	}
 
 	s.cstatus.toLog(cd.elog)
 	cd.elog.LazyPrintf("Compaction for level: %d DONE", cd.thisLevel.level)
-	return true, nil
+	return nil
 }
 
 func (s *levelsController) addLevel0Table(t *table.Table) error {

--- a/options.go
+++ b/options.go
@@ -80,7 +80,8 @@ type Options struct {
 	// determined by the smaller of its file size and max entries.
 	ValueLogMaxEntries uint32
 
-	// Number of compaction workers to run concurrently.
+	// Number of compaction workers to run concurrently. Setting this to zero would stop LSM tree
+	// from compactions.
 	NumCompactors int
 
 	// Transaction start and commit timestamps are managed by end-user.
@@ -90,8 +91,6 @@ type Options struct {
 
 	// 4. Flags for testing purposes
 	// ------------------------------
-	DoNotCompact bool // Stops LSM tree from compactions.
-
 	maxBatchCount int64 // max entries in batch
 	maxBatchSize  int64 // max batch size in bytes
 
@@ -108,7 +107,6 @@ type Options struct {
 // DefaultOptions sets a list of recommended options for good performance.
 // Feel free to modify these to suit your needs.
 var DefaultOptions = Options{
-	DoNotCompact:        false,
 	LevelOneSize:        256 << 20,
 	LevelSizeMultiplier: 10,
 	TableLoadingMode:    options.LoadToRAM,

--- a/options.go
+++ b/options.go
@@ -119,7 +119,7 @@ var DefaultOptions = Options{
 	// table.Nothing to not preload the tables.
 	MaxLevels:               7,
 	MaxTableSize:            64 << 20,
-	NumCompactors:           3,
+	NumCompactors:           2, // Compactions can be expensive. Only run 2.
 	NumLevelZeroTables:      5,
 	NumLevelZeroTablesStall: 10,
 	NumMemtables:            5,

--- a/options.go
+++ b/options.go
@@ -84,6 +84,10 @@ type Options struct {
 	// from compactions.
 	NumCompactors int
 
+	// When closing the DB, force compact Level 0. This ensures that both reads and writes are
+	// efficient when the DB is opened later.
+	CompactL0OnClose bool
+
 	// Transaction start and commit timestamps are managed by end-user.
 	// This is only useful for databases built on top of Badger (like Dgraph).
 	// Not recommended for most users.
@@ -121,6 +125,7 @@ var DefaultOptions = Options{
 	NumMemtables:            5,
 	SyncWrites:              true,
 	NumVersionsToKeep:       1,
+	CompactL0OnClose:        true,
 	// Nothing to read/write value log using standard File I/O
 	// MemoryMap to mmap() the value log files
 	// (2^30 - 1)*2 when mmapping < 2^31 - 1, max int32.

--- a/options.go
+++ b/options.go
@@ -80,8 +80,8 @@ type Options struct {
 	// determined by the smaller of its file size and max entries.
 	ValueLogMaxEntries uint32
 
-	// Number of compaction workers to run concurrently. Setting this to zero would stop LSM tree
-	// from compactions.
+	// Number of compaction workers to run concurrently. Setting this to zero would stop compactions
+	// to happen within LSM tree. If set to zero, writes could block forever.
 	NumCompactors int
 
 	// When closing the DB, force compact Level 0. This ensures that both reads and writes are


### PR DESCRIPTION
- Add a new flatten command, which would flatten out all the LSM tree levels into a single level. It ensures that that level does not exceed its max size limits, as specified in the options.
- Add a new fill command, which would random key-values to Badger. Useful for testing.
- Add a new option to skip force compaction of Level 0 on DB.Close.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/645)
<!-- Reviewable:end -->
