### PR TITLE
badger/cmd: fix error

### DIFF
--- a/badger/cmd/root.go
+++ b/badger/cmd/root.go
@@ -56,7 +56,7 @@ func validateRootCmdArgs(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if sstDir == "" {
-		return errors.New("--sst-dir not specified")
+		return errors.New("--dir not specified")
 	}
 	if vlogDir == "" {
 		vlogDir = sstDir


### PR DESCRIPTION
There's a typo in the error of `badger info` when called without a directory:

```
$ badger info .
Listening for /debug HTTP requests at port: 8080
Error: --sst-dir not specified
Usage:
  badger info [flags]

Flags:
  -h, --help          help for info
  -s, --show-tables   If set to true, show tables as well.

Global Flags:
      --dir string        Directory where the LSM tree files are located. (required)
      --vlog-dir string   Directory where the value log files are located, if different from --dir

--sst-dir not specified
```

But `--sst-dir` doesn't exist:

```
$ badger info --sst-dir .
Listening for /debug HTTP requests at port: 8080
Error: unknown flag: --sst-dir
Usage:
  badger info [flags]

Flags:
  -h, --help          help for info
  -s, --show-tables   If set to true, show tables as well.

Global Flags:
      --dir string        Directory where the LSM tree files are located. (required)
      --vlog-dir string   Directory where the value log files are located, if different from --dir

unknown flag: --sst-dir
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/650)
<!-- Reviewable:end -->
