### PR TITLE
fix the log prefix

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -48,7 +48,7 @@ type defaultLog struct {
 	*log.Logger
 }
 
-var defaultLogger = &defaultLog{Logger: log.New(os.Stderr, "badger", log.LstdFlags)}
+var defaultLogger = &defaultLog{Logger: log.New(os.Stderr, "badger ", log.LstdFlags)}
 
 func UseDefaultLogger() { SetLogger(defaultLogger) }
 


### PR DESCRIPTION
The log prefix is wrong, it produces ugly output like this by default:

    badger2018/12/28 19:28:54 INFO: Replaying file id: 0 at offset: 0
    badger2018/12/28 19:28:54 INFO: Replay took: 40.007µs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/652)
<!-- Reviewable:end -->
