### PR TITLE
Fix race condition in DropAll

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -37,6 +37,7 @@ import (
 // This can be used to backup the data in a database at a given point in time.
 func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 	stream := db.NewStream()
+	stream.LogPrefix = "DB.Backup"
 	stream.KeyToList = func(key []byte, itr *Iterator) (*pb.KVList, error) {
 		list := &pb.KVList{}
 		for ; itr.Valid(); itr.Next() {
@@ -105,7 +106,7 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 		return nil
 	}
 
-	if err := stream.Orchestrate(context.Background(), 8, "DB.Backup"); err != nil {
+	if err := stream.Orchestrate(context.Background()); err != nil {
 		return 0, err
 	}
 	return maxVersion, nil

--- a/db.go
+++ b/db.go
@@ -573,11 +573,6 @@ func (db *DB) writeRequests(reqs []*request) error {
 			r.Wg.Done()
 		}
 	}
-	if atomic.LoadInt32(&db.blockWrites) > 0 {
-		done(ErrBlockedWrites)
-		return ErrBlockedWrites
-	}
-
 	db.elog.Printf("writeRequests called. Writing to value log")
 
 	err := db.vlog.write(reqs)
@@ -1243,23 +1238,30 @@ func (db *DB) Flatten(workers int) error {
 // any reads while DropAll is going on, otherwise they may result in panics. Ideally, both reads and
 // writes are paused before running DropAll, and resumed after it is finished.
 func (db *DB) DropAll() error {
+	if db.opt.ReadOnly {
+		panic("Attempting to drop data in read-only mode.")
+	}
 	Infof("DropAll called. Blocking writes...")
 	// Stop accepting new writes.
 	atomic.StoreInt32(&db.blockWrites, 1)
 
-	// Wait for writeCh to reach size of zero. This is not ideal, but a very
-	// simple way to allow writeCh to flush out, before we proceed.
-	tick := time.NewTicker(100 * time.Millisecond)
-	for range tick.C {
-		if len(db.writeCh) == 0 {
-			break
-		}
-	}
-	tick.Stop()
-	Infof("All previous writes done. Stopping compactions...")
+	// Make all pending writes finish. The following will also close writeCh.
+	db.closers.writes.SignalAndWait()
+	Infof("Writes flushed. Stopping compactions now...")
 
+	// Stop all compactions.
 	db.stopCompactions()
-	defer db.startCompactions()
+	defer func() {
+		Infof("Resuming writes")
+		db.startCompactions()
+
+		db.writeCh = make(chan *request, kvWriteChCapacity)
+		db.closers.writes = y.NewCloser(1)
+		go db.doWrites(db.closers.writes)
+
+		// Resume writes.
+		atomic.StoreInt32(&db.blockWrites, 0)
+	}()
 	Infof("Compactions stopped. Dropping all SSTables...")
 
 	// Remove inmemory tables. Calling DecrRef for safety. Not sure if they're absolutely needed.
@@ -1281,11 +1283,6 @@ func (db *DB) DropAll() error {
 		return err
 	}
 	db.vhead = valuePointer{} // Zero it out.
-	Infof("Deleted %d value log files. Resuming operations...\n", num)
-
-	// Resume writes.
-	atomic.StoreInt32(&db.blockWrites, 0)
-
-	Infof("DropAll done")
+	Infof("Deleted %d value log files. DropAll done.\n", num)
 	return nil
 }

--- a/db.go
+++ b/db.go
@@ -319,6 +319,8 @@ func Open(opt Options) (db *DB, err error) {
 // cause panic.
 func (db *DB) Close() (err error) {
 	db.elog.Printf("Closing database")
+	atomic.StoreInt32(&db.blockWrites, 1)
+
 	// Stop value GC first.
 	db.closers.valueGC.SignalAndWait()
 

--- a/errors.go
+++ b/errors.go
@@ -97,9 +97,9 @@ var (
 
 	// ErrTruncateNeeded is returned when the value log gets corrupt, and requires truncation of
 	// corrupt data to allow Badger to run properly.
-	ErrTruncateNeeded = errors.New("Value log truncate required to run DB. This might result in data loss.")
+	ErrTruncateNeeded = errors.New("Value log truncate required to run DB. This might result in data loss")
 
 	// ErrBlockedWrites is returned if the user called DropAll. During the process of dropping all
 	// data from Badger, we stop accepting new writes, by returning this error.
-	ErrBlockedWrites = errors.New("Writes are blocked possibly due to DropAll")
+	ErrBlockedWrites = errors.New("Writes are blocked, possibly due to DropAll or Close")
 )

--- a/stream.go
+++ b/stream.go
@@ -248,8 +248,8 @@ outer:
 				continue
 			}
 			speed := bytesSent / durSec
-			Infof("%s Time elapsed: %s, bytes sent: %s, speed: %s/sec\n",
-				st.LogPrefix, y.FixedDuration(dur), humanize.Bytes(bytesSent), humanize.Bytes(speed))
+			Infof("%s Time elapsed: %s, bytes sent: %s, speed: %s/sec\n", st.LogPrefix,
+				y.FixedDuration(dur), humanize.Bytes(bytesSent), humanize.Bytes(speed))
 
 		case kvs, ok := <-st.kvChan:
 			if !ok {

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,158 @@
+package badger
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/dgraph-io/badger/y"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+func openManaged(dir string) (*DB, error) {
+	opt := DefaultOptions
+	opt.Dir = dir
+	opt.ValueDir = dir
+
+	return OpenManaged(opt)
+}
+
+func key(k int) []byte {
+	return []byte(strconv.Itoa(k))
+}
+
+func keyToInt(k []byte) int {
+	key, err := strconv.Atoi(string(k))
+	y.Check(err)
+	return key
+}
+
+func value(k int) []byte {
+	return []byte(fmt.Sprintf("%08d", k))
+}
+
+type collector struct {
+	kv []*bpb.KV
+}
+
+func (c *collector) Send(list *pb.KVList) error {
+	c.kv = append(c.kv, list.Kv...)
+	return nil
+}
+
+func TestOrchestrate(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := openManaged(dir)
+	require.NoError(t, err)
+
+	var count int
+	for _, pred := range []string{"p0", "p1", "p2"} {
+		txn := db.NewTransactionAt(math.MaxUint64, true)
+		for i := 1; i <= 100; i++ {
+			require.NoError(t, txn.Set(key(i), value(i)))
+			count++
+		}
+		require.NoError(t, txn.CommitAt(5, nil))
+	}
+
+	stream := db.NewStreamAt(math.MaxUint64)
+	stream.LogPrefix = "Testing"
+	// stream.KeyToList = func(key []byte, itr *Iterator) (*bpb.KVList, error) {
+	// 	item := itr.Item()
+	// 	val, err := item.ValueCopy(nil)
+	// 	require.NoError(t, err)
+	// 	kv := &bpb.KV{Key: item.KeyCopy(nil), Value: val, Version: item.Version()}
+	// 	itr.Next() // Just for fun.
+	// 	return kv, nil
+	// }
+
+	stream.Send = func(list *pb.KVList) error {
+		return c.Send(list)
+	}
+
+	// Test case 1. Retrieve everything.
+	err = sl.Orchestrate(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 300, len(c.kv), "Expected 300. Got: %d", len(c.kv))
+
+	m := make(map[string]int)
+	for _, kv := range c.kv {
+		ki := keyToInt(kv.Key)
+		expected := value(ki)
+		require.Equal(t, expected, kv.Value)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 3, len(m))
+	for pred, count := range m {
+		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
+	}
+
+	// Test case 2. Retrieve only 1 predicate.
+	sl.Predicate = "p1"
+	c.kv = c.kv[:0]
+	err = sl.Orchestrate(context.Background(), "Testing", math.MaxUint64)
+	require.NoError(t, err)
+	require.Equal(t, 100, len(c.kv), "Expected 100. Got: %d", len(c.kv))
+
+	m = make(map[string]int)
+	for _, kv := range c.kv {
+		pk := x.Parse(kv.Key)
+		expected := value(int(pk.Uid))
+		require.Equal(t, expected, kv.Value)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 1, len(m))
+	for pred, count := range m {
+		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
+	}
+
+	// Test case 3. Retrieve select keys within the predicate.
+	c.kv = c.kv[:0]
+	sl.ChooseKeyFunc = func(item *Item) bool {
+		pk := x.Parse(item.Key())
+		return pk.Uid%2 == 0
+	}
+	err = sl.Orchestrate(context.Background(), "Testing", math.MaxUint64)
+	require.NoError(t, err)
+	require.Equal(t, 50, len(c.kv), "Expected 50. Got: %d", len(c.kv))
+
+	m = make(map[string]int)
+	for _, kv := range c.kv {
+		pk := x.Parse(kv.Key)
+		expected := value(int(pk.Uid))
+		require.Equal(t, expected, kv.Value)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 1, len(m))
+	for pred, count := range m {
+		require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
+	}
+
+	// Test case 4. Retrieve select keys from all predicates.
+	c.kv = c.kv[:0]
+	sl.Predicate = ""
+	err = sl.Orchestrate(context.Background(), "Testing", math.MaxUint64)
+	require.NoError(t, err)
+	require.Equal(t, 150, len(c.kv), "Expected 150. Got: %d", len(c.kv))
+
+	m = make(map[string]int)
+	for _, kv := range c.kv {
+		pk := x.Parse(kv.Key)
+		expected := value(int(pk.Uid))
+		require.Equal(t, expected, kv.Value)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 3, len(m))
+	for pred, count := range m {
+		require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
+	}
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package badger
 
 import (


### PR DESCRIPTION
- Fix a race condition in DropAll, caused if concurrent writes are going on.
- Use `blockWrites` during DB.Close as well, so users don't see channel panics when doing writes after DB.Close.
- Port tests over for Stream framework from Dgraph.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/656)
<!-- Reviewable:end -->
