### PR TITLE
Support for DB-specific loggers.

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -64,7 +64,7 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 				var err error
 				valCopy, err = item.ValueCopy(nil)
 				if err != nil {
-					Errorf("Key [%x, %d]. Error while fetching value [%v]\n",
+					SafeErrorf(db, "Key [%x, %d]. Error while fetching value [%v]\n",
 						item.Key(), item.Version(), err)
 					return nil, err
 				}

--- a/backup.go
+++ b/backup.go
@@ -64,7 +64,7 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 				var err error
 				valCopy, err = item.ValueCopy(nil)
 				if err != nil {
-					SafeErrorf(stream.db, "Key [%x, %d]. Error while fetching value [%v]\n",
+					stream.db.opt.Errorf("Key [%x, %d]. Error while fetching value [%v]\n",
 						item.Key(), item.Version(), err)
 					return nil, err
 				}

--- a/backup.go
+++ b/backup.go
@@ -64,7 +64,7 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 				var err error
 				valCopy, err = item.ValueCopy(nil)
 				if err != nil {
-					SafeErrorf(db, "Key [%x, %d]. Error while fetching value [%v]\n",
+					SafeErrorf(stream.db, "Key [%x, %d]. Error while fetching value [%v]\n",
 						item.Key(), item.Version(), err)
 					return nil, err
 				}

--- a/levels.go
+++ b/levels.go
@@ -241,7 +241,7 @@ func (s *levelsController) runWorker(lc *y.Closer) {
 				if err := s.doCompact(p); err == nil {
 					break
 				} else {
-					Errorf("Error while running doCompact: %v\n", err)
+					SafeErrorf(s.kv, "Error while running doCompact: %v\n", err)
 				}
 			}
 		case <-lc.HasBeenClosed():

--- a/levels.go
+++ b/levels.go
@@ -241,7 +241,7 @@ func (s *levelsController) runWorker(lc *y.Closer) {
 				if err := s.doCompact(p); err == nil {
 					break
 				} else {
-					SafeErrorf(s.kv, "Error while running doCompact: %v\n", err)
+					s.kv.opt.Errorf("Error while running doCompact: %v\n", err)
 				}
 			}
 		case <-lc.HasBeenClosed():

--- a/logger.go
+++ b/logger.go
@@ -33,23 +33,16 @@ var badgerLogger Logger
 // SetLogger sets the global logger.
 func SetLogger(l Logger) { badgerLogger = l }
 
-// SetLogger sets the DB-specific logger. If the DB-specific logger is valid,
-// it will be used instead of the global logger. Otherwise the global logger
-// will be used.
-func (db *DB) SetLogger(l Logger) {
-	db.logger = l
-}
-
 // Errorf logs an ERROR message to the global logger.
 func Errorf(format string, v ...interface{}) {
 	badgerLogger.Errorf(format, v...)
 }
 
-// SafeErrorf calls Errorf on the DB-specific logger if it is valid. Otherwise
-// it fallbacks on using Errorf (i.e using the global logger).
-func SafeErrorf(db *DB, format string, v ...interface{}) {
-	if db != nil && db.logger != nil {
-		db.logger.Errorf(format, v...)
+// Errorf logs an ERROR log message to the logger specified in opts or to the
+// global logger if no logger is specified in opts.
+func (opt *Options) Errorf(format string, v ...interface{}) {
+	if opt.Logger != nil {
+		opt.Logger.Errorf(format, v...)
 		return
 	}
 	Errorf(format, v...)
@@ -60,10 +53,10 @@ func Infof(format string, v ...interface{}) {
 	badgerLogger.Infof(format, v...)
 }
 
-// SafeInfof is like SafeErrorf but for INFO messages.
-func SafeInfof(db *DB, format string, v ...interface{}) {
-	if db != nil && db.logger != nil {
-		db.logger.Infof(format, v...)
+// Infof is like Errorf but for INFO messages.
+func (opt *Options) Infof(format string, v ...interface{}) {
+	if opt.Logger != nil {
+		opt.Logger.Infof(format, v...)
 		return
 	}
 	Infof(format, v...)
@@ -74,10 +67,10 @@ func Warningf(format string, v ...interface{}) {
 	badgerLogger.Warningf(format, v...)
 }
 
-// SafeWarningf is like SafeErrorf but for WARNING messages.
-func SafeWarningf(db *DB, format string, v ...interface{}) {
-	if db != nil && db.logger != nil {
-		db.logger.Warningf(format, v...)
+// Warningf is like Errorf but for WARNING messages.
+func (opt *Options) Warningf(format string, v ...interface{}) {
+	if opt.Logger != nil {
+		opt.Logger.Warningf(format, v...)
 		return
 	}
 	Warningf(format, v...)

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package badger
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockLogger struct {
+	output string
+}
+
+func (l *mockLogger) Errorf(f string, v ...interface{}) {
+	l.output = fmt.Sprintf("ERROR: "+f, v...)
+}
+
+func (l *mockLogger) Infof(f string, v ...interface{}) {
+	l.output = fmt.Sprintf("INFO: "+f, v...)
+}
+
+func (l *mockLogger) Warningf(f string, v ...interface{}) {
+	l.output = fmt.Sprintf("WARNING: "+f, v...)
+}
+
+// Test that the DB-specific log is used instead of the global log.
+func TestDbLog(t *testing.T) {
+	db := DB{}
+	l := &mockLogger{}
+	db.SetLogger(l)
+
+	SafeErrorf(&db, "test")
+	require.Equal(t, "ERROR: test", l.output)
+	SafeInfof(&db, "test")
+	require.Equal(t, "INFO: test", l.output)
+	SafeWarningf(&db, "test")
+	require.Equal(t, "WARNING: test", l.output)
+}
+
+// Test there are no errors when the db is nil or does not have a logger.
+func TestNoDbLog(t *testing.T) {
+	l := &mockLogger{}
+	SetLogger(l)
+
+	SafeErrorf(nil, "test")
+	require.Equal(t, "ERROR: test", l.output)
+	SafeInfof(nil, "test")
+	require.Equal(t, "INFO: test", l.output)
+	SafeWarningf(nil, "test")
+	require.Equal(t, "WARNING: test", l.output)
+
+	db := DB{}
+	SafeErrorf(&db, "test")
+	require.Equal(t, "ERROR: test", l.output)
+	SafeInfof(&db, "test")
+	require.Equal(t, "INFO: test", l.output)
+	SafeWarningf(&db, "test")
+	require.Equal(t, "WARNING: test", l.output)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -41,35 +41,27 @@ func (l *mockLogger) Warningf(f string, v ...interface{}) {
 
 // Test that the DB-specific log is used instead of the global log.
 func TestDbLog(t *testing.T) {
-	db := DB{}
 	l := &mockLogger{}
-	db.SetLogger(l)
+	opt := Options{Logger: l}
 
-	SafeErrorf(&db, "test")
+	opt.Errorf("test")
 	require.Equal(t, "ERROR: test", l.output)
-	SafeInfof(&db, "test")
+	opt.Infof("test")
 	require.Equal(t, "INFO: test", l.output)
-	SafeWarningf(&db, "test")
+	opt.Warningf("test")
 	require.Equal(t, "WARNING: test", l.output)
 }
 
-// Test there are no errors when the db is nil or does not have a logger.
+// Test that the global logger is used when no logger is specified in Options.
 func TestNoDbLog(t *testing.T) {
 	l := &mockLogger{}
 	SetLogger(l)
+	opt := Options{}
 
-	SafeErrorf(nil, "test")
+	opt.Errorf("test")
 	require.Equal(t, "ERROR: test", l.output)
-	SafeInfof(nil, "test")
+	opt.Infof("test")
 	require.Equal(t, "INFO: test", l.output)
-	SafeWarningf(nil, "test")
-	require.Equal(t, "WARNING: test", l.output)
-
-	db := DB{}
-	SafeErrorf(&db, "test")
-	require.Equal(t, "ERROR: test", l.output)
-	SafeInfof(&db, "test")
-	require.Equal(t, "INFO: test", l.output)
-	SafeWarningf(&db, "test")
+	opt.Warningf("test")
 	require.Equal(t, "WARNING: test", l.output)
 }

--- a/merge.go
+++ b/merge.go
@@ -134,7 +134,7 @@ func (op *MergeOperator) runCompactions(dur time.Duration) {
 		case <-ticker.C: // wait for tick
 		}
 		if err := op.compact(); err != nil {
-			SafeErrorf(op.db, "failure while running merge operation: %s", err)
+			op.db.opt.Errorf("failure while running merge operation: %s", err)
 		}
 		if stop {
 			ticker.Stop()

--- a/merge.go
+++ b/merge.go
@@ -134,7 +134,7 @@ func (op *MergeOperator) runCompactions(dur time.Duration) {
 		case <-ticker.C: // wait for tick
 		}
 		if err := op.compact(); err != nil {
-			Errorf("failure while running merge operation: %s", err)
+			SafeErrorf(op.db, "failure while running merge operation: %s", err)
 		}
 		if stop {
 			ticker.Stop()

--- a/options.go
+++ b/options.go
@@ -106,6 +106,9 @@ type Options struct {
 
 	// Truncate value log to delete corrupt data, if any. Would not truncate if ReadOnly is set.
 	Truncate bool
+
+	// DB-specific logger which will override the global logger.
+	Logger Logger
 }
 
 // DefaultOptions sets a list of recommended options for good performance.
@@ -135,6 +138,7 @@ var DefaultOptions = Options{
 	ValueLogMaxEntries: 1000000,
 	ValueThreshold:     32,
 	Truncate:           false,
+	Logger:             defaultLogger,
 }
 
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold

--- a/stream.go
+++ b/stream.go
@@ -229,7 +229,7 @@ func (st *Stream) streamKVs(ctx context.Context) error {
 		if err := st.Send(batch); err != nil {
 			return err
 		}
-		SafeInfof(st.db, "%s Created batch of size: %s in %s.\n",
+		st.db.opt.Infof("%s Created batch of size: %s in %s.\n",
 			st.LogPrefix, humanize.Bytes(sz), time.Since(t))
 		return nil
 	}
@@ -248,7 +248,7 @@ outer:
 				continue
 			}
 			speed := bytesSent / durSec
-			SafeInfof(st.db, "%s Time elapsed: %s, bytes sent: %s, speed: %s/sec\n", st.LogPrefix,
+			st.db.opt.Infof("%s Time elapsed: %s, bytes sent: %s, speed: %s/sec\n", st.LogPrefix,
 				y.FixedDuration(dur), humanize.Bytes(bytesSent), humanize.Bytes(speed))
 
 		case kvs, ok := <-st.kvChan:
@@ -263,7 +263,7 @@ outer:
 		}
 	}
 
-	SafeInfof(st.db, "%s Sent %d keys\n", st.LogPrefix, count)
+	st.db.opt.Infof("%s Sent %d keys\n", st.LogPrefix, count)
 	return nil
 }
 

--- a/stream.go
+++ b/stream.go
@@ -229,7 +229,7 @@ func (st *Stream) streamKVs(ctx context.Context) error {
 		if err := st.Send(batch); err != nil {
 			return err
 		}
-		Infof("%s Created batch of size: %s in %s.\n",
+		SafeInfof(st.db, "%s Created batch of size: %s in %s.\n",
 			st.LogPrefix, humanize.Bytes(sz), time.Since(t))
 		return nil
 	}
@@ -248,7 +248,7 @@ outer:
 				continue
 			}
 			speed := bytesSent / durSec
-			Infof("%s Time elapsed: %s, bytes sent: %s, speed: %s/sec\n", st.LogPrefix,
+			SafeInfof(st.db, "%s Time elapsed: %s, bytes sent: %s, speed: %s/sec\n", st.LogPrefix,
 				y.FixedDuration(dur), humanize.Bytes(bytesSent), humanize.Bytes(speed))
 
 		case kvs, ok := <-st.kvChan:
@@ -263,7 +263,7 @@ outer:
 		}
 	}
 
-	Infof("%s Sent %d keys\n", st.LogPrefix, count)
+	SafeInfof(st.db, "%s Sent %d keys\n", st.LogPrefix, count)
 	return nil
 }
 

--- a/value.go
+++ b/value.go
@@ -402,7 +402,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 				wb = wb[:0]
 			}
 		} else {
-			SafeWarningf(vlog.db, "This entry should have been caught. %+v\n", e)
+			vlog.db.opt.Warningf("This entry should have been caught. %+v\n", e)
 		}
 		return nil
 	}
@@ -420,7 +420,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 	for i := 0; i < len(wb); {
 		loops++
 		if batchSize == 0 {
-			SafeWarningf(vlog.db, "We shouldn't reach batch size of zero.")
+			vlog.db.opt.Warningf("We shouldn't reach batch size of zero.")
 			return ErrNoRewrite
 		}
 		end := i + batchSize
@@ -575,13 +575,13 @@ func (vlog *valueLog) dropAll() (int, error) {
 		loops++
 		if vlog.iteratorCount() == 0 {
 			if loops%10 == 0 {
-				SafeInfof(vlog.db, "Waiting for iterators to get done. Currently active: %d",
+				vlog.db.opt.Infof("Waiting for iterators to get done. Currently active: %d",
 					vlog.iteratorCount())
 			}
 			break
 		}
 	}
-	SafeInfof(vlog.db, "No active value log iterators. Deleting value logs...")
+	vlog.db.opt.Infof("No active value log iterators. Deleting value logs...")
 
 	var count int
 	deleteAll := func() error {
@@ -599,7 +599,7 @@ func (vlog *valueLog) dropAll() (int, error) {
 		return count, err
 	}
 
-	SafeInfof(vlog.db, "Value logs deleted. Creating value log file: 0")
+	vlog.db.opt.Infof("Value logs deleted. Creating value log file: 0")
 	if _, err := vlog.createVlogFile(0); err != nil {
 		return count, err
 	}
@@ -786,14 +786,14 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 		if fid == ptr.Fid {
 			offset = ptr.Offset + ptr.Len
 		}
-		SafeInfof(vlog.db, "Replaying file id: %d at offset: %d\n", fid, offset)
+		vlog.db.opt.Infof("Replaying file id: %d at offset: %d\n", fid, offset)
 		now := time.Now()
 		// Replay and possible truncation done. Now we can open the file as per
 		// user specified options.
 		if err := vlog.replayLog(lf, offset, replayFn); err != nil {
 			return err
 		}
-		SafeInfof(vlog.db, "Replay took: %s\n", time.Since(now))
+		vlog.db.opt.Infof("Replay took: %s\n", time.Since(now))
 
 		if fid < vlog.maxFid {
 			if err := lf.openReadOnly(); err != nil {

--- a/value.go
+++ b/value.go
@@ -402,7 +402,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 				wb = wb[:0]
 			}
 		} else {
-			Warningf("This entry should have been caught. %+v\n", e)
+			SafeWarningf(vlog.db, "This entry should have been caught. %+v\n", e)
 		}
 		return nil
 	}
@@ -420,7 +420,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 	for i := 0; i < len(wb); {
 		loops++
 		if batchSize == 0 {
-			Warningf("We shouldn't reach batch size of zero.")
+			SafeWarningf(vlog.db, "We shouldn't reach batch size of zero.")
 			return ErrNoRewrite
 		}
 		end := i + batchSize
@@ -575,13 +575,13 @@ func (vlog *valueLog) dropAll() (int, error) {
 		loops++
 		if vlog.iteratorCount() == 0 {
 			if loops%10 == 0 {
-				Infof("Waiting for iterators to get done. Currently active: %d",
+				SafeInfof(vlog.db, "Waiting for iterators to get done. Currently active: %d",
 					vlog.iteratorCount())
 			}
 			break
 		}
 	}
-	Infof("No active value log iterators. Deleting value logs...")
+	SafeInfof(vlog.db, "No active value log iterators. Deleting value logs...")
 
 	var count int
 	deleteAll := func() error {
@@ -599,7 +599,7 @@ func (vlog *valueLog) dropAll() (int, error) {
 		return count, err
 	}
 
-	Infof("Value logs deleted. Creating value log file: 0")
+	SafeInfof(vlog.db, "Value logs deleted. Creating value log file: 0")
 	if _, err := vlog.createVlogFile(0); err != nil {
 		return count, err
 	}
@@ -786,14 +786,14 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 		if fid == ptr.Fid {
 			offset = ptr.Offset + ptr.Len
 		}
-		Infof("Replaying file id: %d at offset: %d\n", fid, offset)
+		SafeInfof(vlog.db, "Replaying file id: %d at offset: %d\n", fid, offset)
 		now := time.Now()
 		// Replay and possible truncation done. Now we can open the file as per
 		// user specified options.
 		if err := vlog.replayLog(lf, offset, replayFn); err != nil {
 			return err
 		}
-		Infof("Replay took: %s\n", time.Since(now))
+		SafeInfof(vlog.db, "Replay took: %s\n", time.Since(now))
 
 		if fid < vlog.maxFid {
 			if err := lf.openReadOnly(); err != nil {


### PR DESCRIPTION
This commit adds support for overriding the global logger in specific DBs. If no DB-specific logger is given, the global logger will be used instead.

Addresses #657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/659)
<!-- Reviewable:end -->
