### PR TITLE
Fix ineffassign warning.

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -468,7 +468,7 @@ func TestBackupLoadIncremental(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
-		since, err = db1.Backup(&bb, since)
+		_, err = db1.Backup(&bb, since)
 		require.NoError(t, err)
 		require.NoError(t, db1.Close())
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -329,8 +329,9 @@ func TestForceCompactL0(t *testing.T) {
 
 	opts.managedTxns = true
 	db, err = Open(opts)
-	defer db.Close()
+	require.NoError(t, err)
 	require.Equal(t, len(db.lc.levels[0].tables), 0)
+	require.NoError(t, db.Close())
 }
 
 // Put a lot of data to move some data to disk.


### PR DESCRIPTION
Also fixing a lint warning caused by ignoring the result of db.Close()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/665)
<!-- Reviewable:end -->
