### PR TITLE
Fix remaining lint warnings.

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -21,6 +21,7 @@ import (
 	"time"
 )
 
+// WriteBatch holds the necessary info to perform batched writes.
 type WriteBatch struct {
 	sync.Mutex
 	txn *Txn

--- a/db.go
+++ b/db.go
@@ -1103,6 +1103,7 @@ func (db *DB) GetSequence(key []byte, bandwidth uint64) (*Sequence, error) {
 	return seq, err
 }
 
+// Tables gets the TableInfo objects from the level controller.
 func (db *DB) Tables() []TableInfo {
 	return db.lc.getTableInfo()
 }

--- a/iterator.go
+++ b/iterator.go
@@ -140,6 +140,8 @@ func (item *Item) IsDeletedOrExpired() bool {
 	return isDeletedOrExpired(item.meta, item.expiresAt)
 }
 
+// DiscardEarlierVersions returns whether the iterator was created with the
+// option to discard earlier versions of a key when multiple are available.
 func (item *Item) DiscardEarlierVersions() bool {
 	return item.meta&bitDiscardEarlierVersions > 0
 }
@@ -329,7 +331,7 @@ type IteratorOptions struct {
 	internalAccess bool // Used to allow internal access to badger keys.
 }
 
-func (opt *IteratorOptions) PickTable(t table.TableInterface) bool {
+func (opt *IteratorOptions) pickTable(t table.TableInterface) bool {
 	if len(opt.Prefix) == 0 {
 		return true
 	}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -45,12 +45,12 @@ func TestPickTables(t *testing.T) {
 	within := func(prefix, left, right string) {
 		opt.Prefix = []byte(prefix)
 		tm := &tableMock{left: []byte(left), right: []byte(right)}
-		require.True(t, opt.PickTable(tm))
+		require.True(t, opt.pickTable(tm))
 	}
 	outside := func(prefix, left, right string) {
 		opt.Prefix = []byte(prefix)
 		tm := &tableMock{left: []byte(left), right: []byte(right)}
-		require.False(t, opt.PickTable(tm))
+		require.False(t, opt.pickTable(tm))
 	}
 	within("abc", "ab", "ad")
 	within("abc", "abc", "ad")

--- a/level_handler.go
+++ b/level_handler.go
@@ -272,7 +272,7 @@ func (s *levelHandler) appendIterators(iters []y.Iterator, opt *IteratorOptions)
 
 	tables := make([]*table.Table, 0, len(s.tables))
 	for _, t := range s.tables {
-		if opt.PickTable(t) {
+		if opt.pickTable(t) {
 			tables = append(tables, t)
 		}
 	}

--- a/levels.go
+++ b/levels.go
@@ -806,6 +806,7 @@ func (s *levelsController) appendIterators(
 	return iters
 }
 
+// TableInfo represents the information about a table.
 type TableInfo struct {
 	ID    uint64
 	Level int

--- a/y/y.go
+++ b/y/y.go
@@ -163,6 +163,8 @@ func (s *Slice) Resize(sz int) []byte {
 	return s.buf[0:sz]
 }
 
+// FixedDuration returns a string representation of the given duration with the
+// hours, minutes, and seconds.
 func FixedDuration(d time.Duration) string {
 	str := fmt.Sprintf("%02ds", int(d.Seconds())%60)
 	if d >= time.Minute {


### PR DESCRIPTION
- Add comments to public methods.
- Remove commented code from integration test.
- Unexport some methods that were only being used internally (e.g
  the pickTable method is only being used by the method controller).
- Rename short variables in integration test to avoid confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/674)
<!-- Reviewable:end -->
