### PR TITLE
Fix goroutine leak caused by y.WaterMark

### DIFF
--- a/db.go
+++ b/db.go
@@ -381,6 +381,7 @@ func (db *DB) Close() (err error) {
 	}
 	db.elog.Printf("Waiting for closer")
 	db.closers.updateSize.SignalAndWait()
+	db.orc.Stop()
 
 	db.elog.Finish()
 

--- a/txn.go
+++ b/txn.go
@@ -54,6 +54,9 @@ type oracle struct {
 	// commits stores a key fingerprint and latest commit counter for it.
 	// refCount is used to clear out commits map to avoid a memory blowup.
 	commits map[uint64]uint64
+
+	// closer is used to stop watermarks.
+	closer *y.Closer
 }
 
 func newOracle(opt Options) *oracle {
@@ -66,10 +69,15 @@ func newOracle(opt Options) *oracle {
 		// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
 		readMark: &y.WaterMark{Name: "badger.PendingReads"},
 		txnMark:  &y.WaterMark{Name: "badger.TxnTimestamp"},
+		closer:   y.NewCloser(2),
 	}
-	orc.readMark.Init()
-	orc.txnMark.Init()
+	orc.readMark.Init(orc.closer)
+	orc.txnMark.Init(orc.closer)
 	return orc
+}
+
+func (o *oracle) Stop() {
+	o.closer.SignalAndWait()
 }
 
 func (o *oracle) addRef() {

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -65,7 +65,6 @@ type WaterMark struct {
 	Name      string
 	markCh    chan mark
 	elog      trace.EventLog
-	closer    *Closer
 }
 
 // Init initializes a WaterMark struct. MUST be called before using it.

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -65,13 +65,14 @@ type WaterMark struct {
 	Name      string
 	markCh    chan mark
 	elog      trace.EventLog
+	closer    *Closer
 }
 
 // Init initializes a WaterMark struct. MUST be called before using it.
-func (w *WaterMark) Init() {
+func (w *WaterMark) Init(closer *Closer) {
 	w.markCh = make(chan mark, 100)
 	w.elog = trace.NewEventLog("Watermark", w.Name)
-	go w.process()
+	go w.process(closer)
 }
 
 // Begin sets the last index to the given value.
@@ -137,7 +138,9 @@ func (w *WaterMark) WaitForMark(ctx context.Context, index uint64) error {
 // if no watermark is emitted at index 101 then waiter would get stuck indefinitely as it
 // can't decide whether the task at 101 has decided not to emit watermark or it didn't get
 // scheduled yet.
-func (w *WaterMark) process() {
+func (w *WaterMark) process(closer *Closer) {
+	defer closer.Done()
+
 	var indices uint64Heap
 	// pending maps raft proposal index to the number of pending mutations for this proposal.
 	pending := make(map[uint64]int)
@@ -201,25 +204,30 @@ func (w *WaterMark) process() {
 		}
 	}
 
-	for mark := range w.markCh {
-		if mark.waiter != nil {
-			doneUntil := atomic.LoadUint64(&w.doneUntil)
-			if doneUntil >= mark.index {
-				close(mark.waiter)
-			} else {
-				ws, ok := waiters[mark.index]
-				if !ok {
-					waiters[mark.index] = []chan struct{}{mark.waiter}
+	for {
+		select {
+		case <-closer.HasBeenClosed():
+			return
+		case mark := <-w.markCh:
+			if mark.waiter != nil {
+				doneUntil := atomic.LoadUint64(&w.doneUntil)
+				if doneUntil >= mark.index {
+					close(mark.waiter)
 				} else {
-					waiters[mark.index] = append(ws, mark.waiter)
+					ws, ok := waiters[mark.index]
+					if !ok {
+						waiters[mark.index] = []chan struct{}{mark.waiter}
+					} else {
+						waiters[mark.index] = append(ws, mark.waiter)
+					}
 				}
-			}
-		} else {
-			if mark.index > 0 {
-				processOne(mark.index, mark.done)
-			}
-			for _, index := range mark.indices {
-				processOne(index, mark.done)
+			} else {
+				if mark.index > 0 {
+					processOne(mark.index, mark.done)
+				}
+				for _, index := range mark.indices {
+					processOne(index, mark.done)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Allow the goroutines started by y.WaterMark to be stopped, and use it in Badger to ensure that repeated opening and closing won't cause leaks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/688)
<!-- Reviewable:end -->
