### PR TITLE
Introduce DropPrefix API in Badger

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -65,7 +65,9 @@ func (r keyRange) overlapsWith(dst keyRange) bool {
 }
 
 func getKeyRange(tables []*table.Table) keyRange {
-	y.AssertTrue(len(tables) > 0)
+	if len(tables) == 0 {
+		return keyRange{}
+	}
 	smallest := tables[0].Smallest()
 	biggest := tables[0].Biggest()
 	for i := 1; i < len(tables); i++ {

--- a/db.go
+++ b/db.go
@@ -373,6 +373,8 @@ func (db *DB) Close() (err error) {
 		err := db.lc.doCompact(compactionPriority{level: 0, score: 1.73})
 		switch err {
 		case errFillTables:
+			// This error only means that there might be enough tables to do a compaction. So, we
+			// should not report it to the end user to avoid confusing them.
 		case nil:
 			db.opt.Infof("Force compaction on level 0 done")
 		default:
@@ -778,8 +780,7 @@ func arenaSize(opt Options) int64 {
 
 // WriteLevel0Table flushes memtable.
 func writeLevel0Table(ft flushTask, f *os.File) error {
-	s := ft.mt
-	iter := s.NewIterator()
+	iter := ft.mt.NewIterator()
 	defer iter.Close()
 	b := table.NewTableBuilder()
 	defer b.Close()

--- a/level_handler.go
+++ b/level_handler.go
@@ -102,48 +102,69 @@ func (s *levelHandler) deleteTables(toDel []*table.Table) error {
 
 // replaceTables will replace tables[left:right] with newTables. Note this EXCLUDES tables[right].
 // You must call decr() to delete the old tables _after_ writing the update to the manifest.
-func (s *levelHandler) replaceTables(newTables []*table.Table) error {
+func (s *levelHandler) replaceTables(toDel, toAdd []*table.Table) error {
 	// Need to re-search the range of tables in this level to be replaced as other goroutines might
 	// be changing it as well.  (They can't touch our tables, but if they add/remove other tables,
 	// the indices get shifted around.)
-	if len(newTables) == 0 {
-		return nil
-	}
-
 	s.Lock() // We s.Unlock() below.
 
+	// TODO: This needs to be rewritten so we delete cd.bot tables and add newTables. We can just do
+	// a sort afterwards. Not sure why this logic is so complex.
+
+	toDelMap := make(map[uint64]struct{})
+	for _, t := range toDel {
+		toDelMap[t.ID()] = struct{}{}
+	}
+	var newTables []*table.Table
+	for _, t := range s.tables {
+		_, found := toDelMap[t.ID()]
+		if !found {
+			newTables = append(newTables, t)
+			continue
+		}
+		t.DecrRef()
+		s.totalSize -= t.Size()
+	}
+
 	// Increase totalSize first.
-	for _, tbl := range newTables {
-		s.totalSize += tbl.Size()
-		tbl.IncrRef()
+	for _, t := range toAdd {
+		s.totalSize += t.Size()
+		t.IncrRef()
+		newTables = append(newTables, t)
 	}
 
-	kr := keyRange{
-		left:  newTables[0].Smallest(),
-		right: newTables[len(newTables)-1].Biggest(),
-	}
-	left, right := s.overlappingTables(levelHandlerRLocked{}, kr)
-
-	toDecr := make([]*table.Table, right-left)
-	// Update totalSize and reference counts.
-	for i := left; i < right; i++ {
-		tbl := s.tables[i]
-		s.totalSize -= tbl.Size()
-		toDecr[i-left] = tbl
-	}
-
-	// To be safe, just make a copy. TODO: Be more careful and avoid copying.
-	numDeleted := right - left
-	numAdded := len(newTables)
-	tables := make([]*table.Table, len(s.tables)-numDeleted+numAdded)
-	y.AssertTrue(left == copy(tables, s.tables[:left]))
-	t := tables[left:]
-	y.AssertTrue(numAdded == copy(t, newTables))
-	t = t[numAdded:]
-	y.AssertTrue(len(s.tables[right:]) == copy(t, s.tables[right:]))
-	s.tables = tables
+	// Assign tables.
+	s.tables = newTables
+	sort.Slice(s.tables, func(i, j int) bool {
+		return y.CompareKeys(s.tables[i].Smallest(), s.tables[j].Smallest()) < 0
+	})
 	s.Unlock() // s.Unlock before we DecrRef tables -- that can be slow.
-	return decrRefs(toDecr)
+	return decrRefs(toDel)
+
+	// kr := keyRange{
+	// 	left:  newTables[0].Smallest(),
+	// 	right: newTables[len(newTables)-1].Biggest(),
+	// }
+	// left, right := s.overlappingTables(levelHandlerRLocked{}, kr)
+
+	// toDecr := make([]*table.Table, right-left)
+	// // Update totalSize and reference counts.
+	// for i := left; i < right; i++ {
+	// 	tbl := s.tables[i]
+	// 	s.totalSize -= tbl.Size()
+	// 	toDecr[i-left] = tbl
+	// }
+
+	// // To be safe, just make a copy. TODO: Be more careful and avoid copying.
+	// numDeleted := right - left
+	// numAdded := len(newTables)
+	// tables := make([]*table.Table, len(s.tables)-numDeleted+numAdded)
+	// y.AssertTrue(left == copy(tables, s.tables[:left]))
+	// t := tables[left:]
+	// y.AssertTrue(numAdded == copy(t, newTables))
+	// t = t[numAdded:]
+	// y.AssertTrue(len(s.tables[right:]) == copy(t, s.tables[right:]))
+	// s.tables = tables
 }
 
 func decrRefs(tables []*table.Table) error {
@@ -294,6 +315,9 @@ type levelHandlerRLocked struct{}
 // This function should already have acquired a read lock, and this is so important the caller must
 // pass an empty parameter declaring such.
 func (s *levelHandler) overlappingTables(_ levelHandlerRLocked, kr keyRange) (int, int) {
+	if len(kr.left) == 0 || len(kr.right) == 0 {
+		return 0, 0
+	}
 	left := sort.Search(len(s.tables), func(i int) bool {
 		return y.CompareKeys(kr.left, s.tables[i].Biggest()) <= 0
 	})

--- a/levels.go
+++ b/levels.go
@@ -267,13 +267,15 @@ func (s *levelsController) dropPrefix(prefix []byte) error {
 	for _, l := range s.levels {
 		l.RLock()
 		if l.level == 0 {
-			sz := len(l.tables)
+			size := len(l.tables)
 			l.RUnlock()
 
-			if sz > 0 {
+			if size > 0 {
 				cp := compactionPriority{
-					level:      0,
-					score:      1.74,
+					level: 0,
+					score: 1.74,
+					// A unique number greater than 1.0 does two things. Helps identify this
+					// function in logs, and forces a compaction.
 					dropPrefix: prefix,
 				}
 				if err := s.doCompact(cp); err != nil {
@@ -463,7 +465,8 @@ func (s *levelsController) compactBuildTables(
 		if len(cd.dropPrefix) > 0 &&
 			bytes.HasPrefix(table.Smallest(), cd.dropPrefix) &&
 			bytes.HasPrefix(table.Biggest(), cd.dropPrefix) {
-			// This table does not need to be in the iterator.
+			// All the keys in this table have the dropPrefix. So, this table does not need to be
+			// in the iterator and can be dropped immediately.
 			continue
 		}
 		valid = append(valid, table)

--- a/levels.go
+++ b/levels.go
@@ -17,6 +17,7 @@
 package badger
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"math/rand"
@@ -255,6 +256,63 @@ func (s *levelsController) deleteLSMTree() (int, error) {
 	return len(all), nil
 }
 
+func (s *levelsController) dropPrefix(prefix []byte) error {
+	opt := s.kv.opt
+	for _, l := range s.levels {
+		l.RLock()
+		if l.level == 0 {
+			sz := len(l.tables)
+			l.RUnlock()
+
+			if sz > 0 {
+				cp := compactionPriority{
+					level:      0,
+					score:      1.74,
+					dropPrefix: prefix,
+				}
+				if err := s.doCompact(cp); err != nil {
+					opt.Warningf("While compacting level 0: %v", err)
+					return nil
+				}
+			}
+			continue
+		}
+
+		var tables []*table.Table
+		for _, table := range l.tables {
+			var absent bool
+			switch {
+			case bytes.HasPrefix(table.Smallest(), prefix):
+			case bytes.HasPrefix(table.Biggest(), prefix):
+			case bytes.Compare(prefix, table.Smallest()) > 0 &&
+				bytes.Compare(prefix, table.Biggest()) < 0:
+			default:
+				absent = true
+			}
+			if !absent {
+				tables = append(tables, table)
+			}
+		}
+		cd := compactDef{
+			elog:       trace.New(fmt.Sprintf("Badger.L%d", l.level), "Compact"),
+			thisLevel:  l,
+			nextLevel:  l,
+			top:        []*table.Table{},
+			bot:        tables,
+			dropPrefix: prefix,
+		}
+		l.RUnlock()
+
+		opt.Infof("Running compact def for: %+v", cd)
+		if err := s.runCompactDef(l.level, cd); err != nil {
+			opt.Warningf("While running compact def: %+v. Error: %v", cd, err)
+			return err
+		}
+	}
+	opt.Infof("Done dropping prefix")
+	return nil
+}
+
 func (s *levelsController) startCompact(lc *y.Closer) {
 	n := s.kv.opt.NumCompactors
 	lc.AddRunning(n - 1)
@@ -311,8 +369,9 @@ func (l *levelHandler) isCompactable(delSize int64) bool {
 }
 
 type compactionPriority struct {
-	level int
-	score float64
+	level      int
+	score      float64
+	dropPrefix []byte
 }
 
 // pickCompactLevel determines which level to compact.
@@ -350,7 +409,7 @@ func (s *levelsController) pickCompactLevels() (prios []compactionPriority) {
 
 // compactBuildTables merge topTables and botTables to form a list of new tables.
 func (s *levelsController) compactBuildTables(
-	l int, cd compactDef) ([]*table.Table, func() error, error) {
+	lev int, cd compactDef) ([]*table.Table, func() error, error) {
 	topTables := cd.top
 	botTables := cd.bot
 
@@ -358,7 +417,7 @@ func (s *levelsController) compactBuildTables(
 	{
 		kr := getKeyRange(cd.top)
 		for i, lh := range s.levels {
-			if i <= l { // Skip upper levels.
+			if i <= lev { // Skip upper levels.
 				continue
 			}
 			lh.RLock()
@@ -385,15 +444,25 @@ func (s *levelsController) compactBuildTables(
 
 	// Create iterators across all the tables involved first.
 	var iters []y.Iterator
-	if l == 0 {
+	if lev == 0 {
 		iters = appendIteratorsReversed(iters, topTables, false)
-	} else {
+	} else if len(topTables) > 0 {
 		y.AssertTrue(len(topTables) == 1)
 		iters = []y.Iterator{topTables[0].NewIterator(false)}
 	}
 
 	// Next level has level>=1 and we can use ConcatIterator as key ranges do not overlap.
-	iters = append(iters, table.NewConcatIterator(botTables, false))
+	var valid []*table.Table
+	for _, table := range botTables {
+		if len(cd.dropPrefix) > 0 &&
+			bytes.HasPrefix(table.Smallest(), cd.dropPrefix) &&
+			bytes.HasPrefix(table.Biggest(), cd.dropPrefix) {
+			// This table does not need to be in the iterator.
+			continue
+		}
+		valid = append(valid, table)
+	}
+	iters = append(iters, table.NewConcatIterator(valid, false))
 	it := y.NewMergeIterator(iters, false)
 	defer it.Close() // Important to close the iterator to do ref counting.
 
@@ -417,6 +486,13 @@ func (s *levelsController) compactBuildTables(
 		builder := table.NewTableBuilder()
 		var numKeys, numSkips uint64
 		for ; it.Valid(); it.Next() {
+			// See if we need to skip the prefix.
+			if len(cd.dropPrefix) > 0 && bytes.HasPrefix(it.Key(), cd.dropPrefix) {
+				numSkips++
+				updateStats(it.Value())
+				continue
+			}
+
 			// See if we need to skip this key.
 			if len(skipKey) > 0 {
 				if y.SameKey(it.Key(), skipKey) {
@@ -474,8 +550,8 @@ func (s *levelsController) compactBuildTables(
 		}
 		// It was true that it.Valid() at least once in the loop above, which means we
 		// called Add() at least once, and builder is not Empty().
-		cd.elog.LazyPrintf("Added %d keys. Skipped %d keys.", numKeys, numSkips)
-		cd.elog.LazyPrintf("LOG Compact. Iteration took: %v\n", time.Since(timeStart))
+		s.kv.opt.Infof("Added %d keys. Skipped %d keys.", numKeys, numSkips)
+		s.kv.opt.Infof("LOG Compact. Iteration took: %v\n", time.Since(timeStart))
 		if !builder.Empty() {
 			numBuilds++
 			fileID := s.reserveFileID()
@@ -534,7 +610,7 @@ func (s *levelsController) compactBuildTables(
 		return y.CompareKeys(newTables[i].Biggest(), newTables[j].Biggest()) < 0
 	})
 	s.kv.vlog.updateGCStats(discardStats)
-	cd.elog.LazyPrintf("Discard stats: %v", discardStats)
+	s.kv.opt.Infof("Discard stats: %v", discardStats)
 	return newTables, func() error { return decrRefs(newTables) }, nil
 }
 
@@ -566,6 +642,8 @@ type compactDef struct {
 	nextRange keyRange
 
 	thisSize int64
+
+	dropPrefix []byte
 }
 
 func (cd *compactDef) lockLevels() {
@@ -689,7 +767,7 @@ func (s *levelsController) runCompactDef(l int, cd compactDef) (err error) {
 
 	// See comment earlier in this function about the ordering of these ops, and the order in which
 	// we access levels when reading.
-	if err := nextLevel.replaceTables(newTables); err != nil {
+	if err := nextLevel.replaceTables(cd.bot, newTables); err != nil {
 		return err
 	}
 	if err := thisLevel.deleteTables(cd.top); err != nil {
@@ -699,7 +777,7 @@ func (s *levelsController) runCompactDef(l int, cd compactDef) (err error) {
 	// Note: For level 0, while doCompact is running, it is possible that new tables are added.
 	// However, the tables are added only to the end, so it is ok to just delete the first table.
 
-	cd.elog.LazyPrintf("LOG Compact %d->%d, del %d tables, add %d tables, took %v\n",
+	s.kv.opt.Infof("LOG Compact %d->%d, del %d tables, add %d tables, took %v\n",
 		l, l+1, len(cd.top)+len(cd.bot), len(newTables), time.Since(timeStart))
 	return nil
 }
@@ -712,41 +790,42 @@ func (s *levelsController) doCompact(p compactionPriority) error {
 	y.AssertTrue(l+1 < s.kv.opt.MaxLevels) // Sanity check.
 
 	cd := compactDef{
-		elog:      trace.New(fmt.Sprintf("Badger.L%d", l), "Compact"),
-		thisLevel: s.levels[l],
-		nextLevel: s.levels[l+1],
+		elog:       trace.New(fmt.Sprintf("Badger.L%d", l), "Compact"),
+		thisLevel:  s.levels[l],
+		nextLevel:  s.levels[l+1],
+		dropPrefix: p.dropPrefix,
 	}
 	cd.elog.SetMaxEvents(100)
 	defer cd.elog.Finish()
 
-	cd.elog.LazyPrintf("Got compaction priority: %+v", p)
+	s.kv.opt.Infof("Got compaction priority: %+v", p)
 
 	// While picking tables to be compacted, both levels' tables are expected to
 	// remain unchanged.
 	if l == 0 {
 		if !s.fillTablesL0(&cd) {
-			cd.elog.LazyPrintf("fillTables failed for level: %d\n", l)
+			s.kv.opt.Infof("fillTables failed for level: %d\n", l)
 			return errFillTables
 		}
 
 	} else {
 		if !s.fillTables(&cd) {
-			cd.elog.LazyPrintf("fillTables failed for level: %d\n", l)
+			s.kv.opt.Infof("fillTables failed for level: %d\n", l)
 			return errFillTables
 		}
 	}
 	defer s.cstatus.delete(cd) // Remove the ranges from compaction status.
 
-	cd.elog.LazyPrintf("Running for level: %d\n", cd.thisLevel.level)
+	s.kv.opt.Infof("Running for level: %d\n", cd.thisLevel.level)
 	s.cstatus.toLog(cd.elog)
 	if err := s.runCompactDef(l, cd); err != nil {
 		// This compaction couldn't be done successfully.
-		cd.elog.LazyPrintf("\tLOG Compact FAILED with error: %+v: %+v", err, cd)
+		s.kv.opt.Warningf("\tLOG Compact FAILED with error: %+v: %+v", err, cd)
 		return err
 	}
 
 	s.cstatus.toLog(cd.elog)
-	cd.elog.LazyPrintf("Compaction for level: %d DONE", cd.thisLevel.level)
+	s.kv.opt.Infof("Compaction for level: %d DONE", cd.thisLevel.level)
 	return nil
 }
 

--- a/levels.go
+++ b/levels.go
@@ -256,6 +256,12 @@ func (s *levelsController) dropTree() (int, error) {
 	return len(all), nil
 }
 
+// dropPrefix runs a L0->L1 compaction, and then runs same level compaction on the rest of the
+// levels. For L0->L1 compaction, it runs compactions normally, but skips over all the keys with the
+// provided prefix. For Li->Li compactions, it picks up the tables which would have the prefix. The
+// tables who only have keys with this prefix are quickly dropped. The ones which have other keys
+// are run through MergeIterator and compacted to create new tables. All the mechanisms of
+// compactions apply, i.e. level sizes and MANIFEST are updated as in the normal flow.
 func (s *levelsController) dropPrefix(prefix []byte) error {
 	opt := s.kv.opt
 	for _, l := range s.levels {

--- a/logger.go
+++ b/logger.go
@@ -24,8 +24,9 @@ import (
 // Logger is implemented by any logging system that is used for standard logs.
 type Logger interface {
 	Errorf(string, ...interface{})
-	Infof(string, ...interface{})
 	Warningf(string, ...interface{})
+	Infof(string, ...interface{})
+	Debugf(string, ...interface{})
 }
 
 // Errorf logs an ERROR log message to the logger specified in opts or to the
@@ -53,6 +54,14 @@ func (opt *Options) Warningf(format string, v ...interface{}) {
 	opt.Logger.Warningf(format, v...)
 }
 
+// Warningf logs a WARNING message to the logger specified in opts.
+func (opt *Options) Debugf(format string, v ...interface{}) {
+	if opt.Logger == nil {
+		return
+	}
+	opt.Logger.Debugf(format, v...)
+}
+
 type defaultLog struct {
 	*log.Logger
 }
@@ -63,10 +72,14 @@ func (l *defaultLog) Errorf(f string, v ...interface{}) {
 	l.Printf("ERROR: "+f, v...)
 }
 
+func (l *defaultLog) Warningf(f string, v ...interface{}) {
+	l.Printf("WARNING: "+f, v...)
+}
+
 func (l *defaultLog) Infof(f string, v ...interface{}) {
 	l.Printf("INFO: "+f, v...)
 }
 
-func (l *defaultLog) Warningf(f string, v ...interface{}) {
-	l.Printf("WARNING: "+f, v...)
+func (l *defaultLog) Debugf(f string, v ...interface{}) {
+	l.Printf("DEBUG: "+f, v...)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -39,6 +39,10 @@ func (l *mockLogger) Warningf(f string, v ...interface{}) {
 	l.output = fmt.Sprintf("WARNING: "+f, v...)
 }
 
+func (l *mockLogger) Debugf(f string, v ...interface{}) {
+	l.output = fmt.Sprintf("DEBUG: "+f, v...)
+}
+
 // Test that the DB-specific log is used instead of the global log.
 func TestDbLog(t *testing.T) {
 	l := &mockLogger{}

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -372,34 +372,34 @@ func TestDropPrefix(t *testing.T) {
 	}
 
 	populate(db)
-	// require.NoError(t, db.Flatten(1))
 	require.Equal(t, int(N), numKeys(db))
 
 	require.NoError(t, db.DropPrefix([]byte("key000")))
-	t.Logf("numkeys: %d", numKeys(db))
+	require.Equal(t, int(N)-10, numKeys(db))
 
 	require.NoError(t, db.DropPrefix([]byte("key00")))
-	t.Logf("numkeys: %d", numKeys(db))
+	require.Equal(t, int(N)-100, numKeys(db))
 
+	expected := int(N)
 	for i := 0; i < 10; i++ {
 		require.NoError(t, db.DropPrefix([]byte(fmt.Sprintf("key%d", i))))
-		t.Logf("numkeys: %d", numKeys(db))
+		expected -= 1000
+		require.Equal(t, expected, numKeys(db))
 	}
 	require.NoError(t, db.DropPrefix([]byte("key1")))
-	t.Logf("numkeys: %d", numKeys(db))
+	require.Equal(t, 0, numKeys(db))
 	require.NoError(t, db.DropPrefix([]byte("key")))
-	t.Logf("numkeys: %d", numKeys(db))
-
-	db.Close()
+	require.Equal(t, 0, numKeys(db))
 
 	// Check that we can still write to mdb, and using lower timestamps.
-	// populate(db)
-	// require.Equal(t, int(N), numKeys(db))
-	// db.Close()
+	populate(db)
+	require.Equal(t, int(N), numKeys(db))
+	require.NoError(t, db.DropPrefix([]byte("key")))
+	db.Close()
 
-	// // Ensure that value log is correctly replayed.
-	// db2, err := Open(opts)
-	// require.NoError(t, err)
-	// require.Equal(t, int(N), numKeys(db2))
-	// db2.Close()
+	// Ensure that value log is correctly replayed.
+	db2, err := Open(opts)
+	require.NoError(t, err)
+	require.Equal(t, 0, numKeys(db2))
+	db2.Close()
 }

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -561,7 +561,7 @@ func TestDropPrefixRace(t *testing.T) {
 
 	require.NoError(t, db.DropPrefix([]byte("key00")))
 	require.NoError(t, db.DropPrefix([]byte("key1")))
-	require.NoError(t, db.DropAll())
+	require.NoError(t, db.DropPrefix([]byte("key")))
 	closer.SignalAndWait()
 
 	after := numKeysManaged(db, math.MaxUint64)

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ go test -v --manual=true -run='TestTruncateVlogNoClose$' .
 truncate --size=4096 p/000000.vlog
 go test -v --manual=true -run='TestTruncateVlogNoClose2$' .
 go test -v --manual=true -run='TestTruncateVlogNoClose3$' .
-rm -R p
+rm -R p || true
 
 # Then the normal tests.
 go test -v --vlog_mmap=true -race ./...


### PR DESCRIPTION
This API would allow Badger to completely get rid of the given prefix, P. It does this by:

1. Flushing memtables to disk (skipping over the keys with P).
2. Doing normal compaction from L0 -> L1 (skipping keys with P).
3. Doing same level compaction on all the rest of the levels, picking tables which might have the prefix and rewriting them to new tables (again, skipping keys with P).

Before starting, all the writes are paused, the usual bits which apply to `DropAll` apply here as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/715)
<!-- Reviewable:end -->
