### PR TITLE
Make MemoryMap the default loading option for TableLoadingMode

### DIFF
--- a/options.go
+++ b/options.go
@@ -117,7 +117,7 @@ type Options struct {
 var DefaultOptions = Options{
 	LevelOneSize:        256 << 20,
 	LevelSizeMultiplier: 10,
-	TableLoadingMode:    options.LoadToRAM,
+	TableLoadingMode:    options.MemoryMap,
 	ValueLogLoadingMode: options.MemoryMap,
 	// table.MemoryMap to mmap() the tables.
 	// table.Nothing to not preload the tables.


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/732

Signed-off-by: Ibrahim Jarif <jarifibrahim@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/733)
<!-- Reviewable:end -->
