### PR TITLE
Expose Sync method in DB

### DIFF
--- a/db.go
+++ b/db.go
@@ -426,6 +426,12 @@ const (
 	lockFile = "LOCK"
 )
 
+// Sync syncs database content to disk. This function provides
+// more control to user to sync data whenever required.
+func (db *DB) Sync() error {
+	return db.vlog.sync()
+}
+
 // When you create or delete a file, you have to ensure the directory entry for the file is synced
 // in order to guarantee the file is visible (if the system crashes).  (See the man page for fsync,
 // or see https://github.com/coreos/etcd/issues/6368 for an example.)


### PR DESCRIPTION
Currently syncing of DB data to disk is controlled by
syncWrites flag present in options. If syncWrites is true
value log file will be synced to disk for every write. If
this flag is false, value log file will be synced only at
file rotation. Sync method provides ability to sync data
whenever required.

Fixes #749

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/750)
<!-- Reviewable:end -->
