### PR TITLE
Populate TTL field in value struct while replay

### DIFF
--- a/db.go
+++ b/db.go
@@ -127,9 +127,10 @@ func (db *DB) replayFunction() func(Entry, valuePointer) error {
 		}
 
 		v := y.ValueStruct{
-			Value:    nv,
-			Meta:     meta,
-			UserMeta: e.UserMeta,
+			Value:     nv,
+			Meta:      meta,
+			UserMeta:  e.UserMeta,
+			ExpiresAt: e.ExpiresAt,
 		}
 
 		if e.meta&bitFinTxn > 0 {

--- a/db_test.go
+++ b/db_test.go
@@ -1044,6 +1044,46 @@ func TestExpiry(t *testing.T) {
 	})
 }
 
+func TestExpiryImproperDBClose(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	opt := getTestOptions(dir)
+	opt.ValueLogLoadingMode = options.FileIO
+
+	db0, err := Open(opt)
+	require.NoError(t, err)
+
+	dur := 1 * time.Hour
+	expiryTime := uint64(time.Now().Add(dur).Unix())
+	err = db0.Update(func(txn *Txn) error {
+		err = txn.SetWithTTL([]byte("test_key"), []byte("test_value"), dur)
+		require.NoError(t, err)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Simulate a crash by not closing db0, but releasing the locks.
+	if db0.dirLockGuard != nil {
+		require.NoError(t, db0.dirLockGuard.release())
+	}
+	if db0.valueDirGuard != nil {
+		require.NoError(t, db0.valueDirGuard.release())
+	}
+
+	db1, err := Open(opt)
+	require.NoError(t, err)
+	err = db1.View(func(txn *Txn) error {
+		itm, err := txn.Get([]byte("test_key"))
+		require.NoError(t, err)
+		require.True(t, expiryTime <= itm.ExpiresAt() && itm.ExpiresAt() <= uint64(time.Now().Add(dur).Unix()),
+			"expiry time of entry is invalid")
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, db1.Close())
+}
+
 func randBytes(n int) []byte {
 	recv := make([]byte, n)
 	in, err := rand.Read(recv)


### PR DESCRIPTION
Fixes #708

Currently if DB is not closed properly, after restart, TTL value is not
correct for some keys. Issue is with replayFunction present in db.go file.
If DB is not closed properly, latest value of value log head is not persisted
to disk. After restart, badger replays all entries from the last persisted
value log head. While contructing value struct for each key, ExpiresAt
field was not getting populated. This commit fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/755)
<!-- Reviewable:end -->
