### PR TITLE
Force flush memtable on log file rotate

### DIFF
--- a/db.go
+++ b/db.go
@@ -65,17 +65,18 @@ type DB struct {
 	// nil if Dir and ValueDir are the same
 	valueDirGuard *directoryLockGuard
 
-	closers   closers
-	elog      trace.EventLog
-	mt        *skl.Skiplist   // Our latest (actively written) in-memory table
-	imm       []*skl.Skiplist // Add here only AFTER pushing to flushChan.
-	opt       Options
-	manifest  *manifestFile
-	lc        *levelsController
-	vlog      valueLog
-	vhead     valuePointer // less than or equal to a pointer to the last vlog value put into mt
-	writeCh   chan *request
-	flushChan chan flushTask // For flushing memtables.
+	closers    closers
+	elog       trace.EventLog
+	mt         *skl.Skiplist   // Our latest (actively written) in-memory table
+	imm        []*skl.Skiplist // Add here only AFTER pushing to flushChan.
+	opt        Options
+	manifest   *manifestFile
+	lc         *levelsController
+	vlog       valueLog
+	vhead      valuePointer // less than or equal to a pointer to the last vlog value put into mt
+	writeCh    chan *request
+	flushChan  chan flushTask // For flushing memtables.
+	logRotates int32          // Number of log rotates since the last memtable flush
 
 	blockWrites int32
 
@@ -761,21 +762,31 @@ func (db *DB) ensureRoomForWrite() error {
 	var err error
 	db.Lock()
 	defer db.Unlock()
-	if db.mt.MemSize() < db.opt.MaxTableSize {
+
+	// Here we determine if we need to force flush memtable. Given we rotated log file, it would
+	// make sense to force flush a memtable, so the updated value head would have a chance to be
+	// pushed to L0. Otherwise, it would not go to L0, until the memtable has been fully filled,
+	// which can take a lot longer if the write load has fewer keys and larger values. This force
+	// flush, thus avoids the need to read through a lot of log files on a crash and restart.
+	forceFlush := atomic.LoadInt32(&db.logRotates) >= db.opt.LogRotatesToFlush
+
+	if !forceFlush && db.mt.MemSize() < db.opt.MaxTableSize {
 		return nil
 	}
 
 	y.AssertTrue(db.mt != nil) // A nil mt indicates that DB is being closed.
 	select {
 	case db.flushChan <- flushTask{mt: db.mt, vptr: db.vhead}:
-		db.elog.Printf("Flushing value log to disk if async mode.")
+		// After every memtable flush, let's reset the counter.
+		atomic.StoreInt32(&db.logRotates, 0)
+
 		// Ensure value log is synced to disk so this memtable's contents wouldn't be lost.
 		err = db.vlog.sync(db.vhead.Fid)
 		if err != nil {
 			return err
 		}
 
-		db.elog.Printf("Flushing memtable, mt.size=%d size of flushChan: %d\n",
+		db.opt.Debugf("Flushing memtable, mt.size=%d size of flushChan: %d\n",
 			db.mt.MemSize(), len(db.flushChan))
 		// We manage to push this task. Let's modify imm.
 		db.imm = append(db.imm, db.mt)
@@ -818,22 +829,26 @@ type flushTask struct {
 
 // handleFlushTask must be run serially.
 func (db *DB) handleFlushTask(ft flushTask) error {
-	if !ft.mt.Empty() {
-		// Store badger head even if vptr is zero, need it for readTs
-		db.opt.Debugf("Storing value log head: %+v\n", ft.vptr)
-		db.elog.Printf("Storing offset: %+v\n", ft.vptr)
-		offset := make([]byte, vptrSize)
-		ft.vptr.Encode(offset)
-
-		// Pick the max commit ts, so in case of crash, our read ts would be higher than all the
-		// commits.
-		headTs := y.KeyWithTs(head, db.orc.nextTs())
-		ft.mt.Put(headTs, y.ValueStruct{Value: offset})
-
-		// Also store lfDiscardStats before flushing memtables
-		discardStatsKey := y.KeyWithTs(lfDiscardStatsKey, 1)
-		ft.mt.Put(discardStatsKey, y.ValueStruct{Value: db.vlog.encodedDiscardStats()})
+	// There can be a scnerio, when empty memtable is flushed. For example, memtable is empty and
+	// after writing request to value log, rotation count exceeds db.LogRotatesToFlush.
+	if ft.mt.Empty() {
+		return nil
 	}
+
+	// Store badger head even if vptr is zero, need it for readTs
+	db.opt.Debugf("Storing value log head: %+v\n", ft.vptr)
+	db.elog.Printf("Storing offset: %+v\n", ft.vptr)
+	offset := make([]byte, vptrSize)
+	ft.vptr.Encode(offset)
+
+	// Pick the max commit ts, so in case of crash, our read ts would be higher than all the
+	// commits.
+	headTs := y.KeyWithTs(head, db.orc.nextTs())
+	ft.mt.Put(headTs, y.ValueStruct{Value: offset})
+
+	// Also store lfDiscardStats before flushing memtables
+	discardStatsKey := y.KeyWithTs(lfDiscardStatsKey, 1)
+	ft.mt.Put(discardStatsKey, y.ValueStruct{Value: db.vlog.encodedDiscardStats()})
 
 	fileID := db.lc.reserveFileID()
 	fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), true)

--- a/db_test.go
+++ b/db_test.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/options"
+	"github.com/dgraph-io/badger/skl"
 
 	"github.com/dgraph-io/badger/y"
 	"github.com/stretchr/testify/require"
@@ -1725,6 +1726,48 @@ func TestNoCrash(t *testing.T) {
 	db, err = Open(ops)
 	require.Nil(t, err, "error while opening db")
 	require.NoError(t, db.Close())
+}
+
+func TestForceFlushMemtable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err, "temp dir for badger count not be created")
+
+	ops := getTestOptions(dir)
+	ops.ValueLogMaxEntries = 1
+	ops.LogRotatesToFlush = 1
+
+	db, err := Open(ops)
+	require.NoError(t, err, "error while openning db")
+	defer db.Close()
+
+	for i := 0; i < 3; i++ {
+		err = db.Update(func(txn *Txn) error {
+			return txn.Set([]byte(fmt.Sprintf("key-%d", i)), []byte(fmt.Sprintf("value-%d", i)))
+		})
+		require.NoError(t, err, "unable to set key and value")
+	}
+	time.Sleep(1 * time.Second)
+
+	// We want to make sure that memtable is flushed on disk. While flushing memtable to disk, latest
+	// head is also stored in it. Hence we will try to read head from disk. To make sure this. we will
+	// truncate all memtables.
+	db.Lock()
+	db.mt.DecrRef()
+	for _, mt := range db.imm {
+		mt.DecrRef()
+	}
+	db.imm = db.imm[:0]
+	db.mt = skl.NewSkiplist(arenaSize(db.opt)) // Set it up for future writes.
+	db.Unlock()
+
+	// get latest value of value log head
+	headKey := y.KeyWithTs(head, math.MaxUint64)
+	vs, err := db.get(headKey)
+	var vptr valuePointer
+	vptr.Decode(vs.Value)
+	// Since we are inserting 3 entries and ValueLogMaxEntries is 1, there will be 3 rotation. For 1st
+	// and 2nd time head flushed with memtable will have fid as 0 and last time it will be 1.
+	require.True(t, vptr.Fid == 1, fmt.Sprintf("expected fid: %d, actual fid: %d", 1, vptr.Fid))
 }
 
 func TestMain(m *testing.M) {

--- a/db_test.go
+++ b/db_test.go
@@ -1748,9 +1748,9 @@ func TestForceFlushMemtable(t *testing.T) {
 	}
 	time.Sleep(1 * time.Second)
 
-	// We want to make sure that memtable is flushed on disk. While flushing memtable to disk, latest
-	// head is also stored in it. Hence we will try to read head from disk. To make sure this. we will
-	// truncate all memtables.
+	// We want to make sure that memtable is flushed on disk. While flushing memtable to disk,
+	// latest head is also stored in it. Hence we will try to read head from disk. To make sure
+	// this. we will truncate all memtables.
 	db.Lock()
 	db.mt.DecrRef()
 	for _, mt := range db.imm {
@@ -1765,8 +1765,8 @@ func TestForceFlushMemtable(t *testing.T) {
 	vs, err := db.get(headKey)
 	var vptr valuePointer
 	vptr.Decode(vs.Value)
-	// Since we are inserting 3 entries and ValueLogMaxEntries is 1, there will be 3 rotation. For 1st
-	// and 2nd time head flushed with memtable will have fid as 0 and last time it will be 1.
+	// Since we are inserting 3 entries and ValueLogMaxEntries is 1, there will be 3 rotation. For
+	// 1st and 2nd time head flushed with memtable will have fid as 0 and last time it will be 1.
 	require.True(t, vptr.Fid == 1, fmt.Sprintf("expected fid: %d, actual fid: %d", 1, vptr.Fid))
 }
 

--- a/value.go
+++ b/value.go
@@ -970,6 +970,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 				return err
 			}
 			curlf = newlf
+			atomic.AddInt32(&vlog.db.logRotates, 1)
 		}
 		return nil
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -478,8 +478,8 @@ func TestPersistLFDiscardStats(t *testing.T) {
 	db, err = Open(opt)
 	require.NoError(t, err)
 	defer db.Close()
-	require.True(t, reflect.DeepEqual(persistedMap, db.vlog.lfDiscardStats.m), "Discard maps are "+
-		"not equal")
+	require.True(t, reflect.DeepEqual(persistedMap, db.vlog.lfDiscardStats.m),
+		"Discard maps are not equal")
 }
 
 func TestChecksums(t *testing.T) {


### PR DESCRIPTION
Add a new option which allows a memtable to be force flushed after N log files have been rotated. This is useful in write loads where there are fewer keys and larger values. In those cases, memtables can take a long time to get filled up. But, the value log files fill up quickly and rotate. This causes the value log header in the LSM tree to not get persisted. When a crash happens, a lot of log files need to be replayed to get back to current state, causing slowdown in Open.

This PR avoids that scenario by allowing user to specify how many log files can be rotated before a memtable must be force flushed. Note that the counter gets reset every time a flush happens.

Fixes #549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/766)
<!-- Reviewable:end -->
