### PR TITLE
Add show-keys and lookup flag to info command

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -17,6 +17,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -24,6 +26,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/badger/options"
@@ -35,7 +39,12 @@ import (
 
 type flagOptions struct {
 	showTables    bool
-	sizeHistogram bool
+	showHistogram bool
+	showKeys      bool
+	withPrefix    string
+	keyLookup     string
+	itemMeta      bool
+	keyHistory    bool
 }
 
 var (
@@ -46,8 +55,14 @@ func init() {
 	RootCmd.AddCommand(infoCmd)
 	infoCmd.Flags().BoolVarP(&opt.showTables, "show-tables", "s", false,
 		"If set to true, show tables as well.")
-	infoCmd.Flags().BoolVar(&opt.sizeHistogram, "histogram", false,
+	infoCmd.Flags().BoolVar(&opt.showHistogram, "histogram", false,
 		"Show a histogram of the key and value sizes.")
+	infoCmd.Flags().BoolVar(&opt.showKeys, "show-keys", false, "Show keys stored in Badger")
+	infoCmd.Flags().StringVar(&opt.withPrefix, "with-prefix", "",
+		"Consider only the keys with specified prefix")
+	infoCmd.Flags().StringVarP(&opt.keyLookup, "lookup", "l", "", "Hex of the key to lookup")
+	infoCmd.Flags().BoolVar(&opt.itemMeta, "show-meta", true, "Output item meta data as well")
+	infoCmd.Flags().BoolVar(&opt.keyHistory, "history", false, "Show all versions of a key")
 }
 
 var infoCmd = &cobra.Command{
@@ -59,39 +74,144 @@ info. It also prints info about missing/extra files, and general information abo
 files (which are not referenced by the manifest).  Use this tool to report any issues about Badger
 to the Dgraph team.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := printInfo(sstDir, vlogDir)
-		if err != nil {
-			fmt.Println("Error:", err.Error())
-			os.Exit(1)
-		}
-		if !opt.showTables {
-			return
-		}
-		// Open DB
-		opts := badger.DefaultOptions
-		opts.TableLoadingMode = options.MemoryMap
-		opts.Dir = sstDir
-		opts.ValueDir = vlogDir
-		opts.ReadOnly = true
+	RunE: handleInfo,
+}
 
-		db, err := badger.Open(opts)
-		if err != nil {
-			fmt.Println("Error:", err.Error())
-			os.Exit(1)
-		}
-		defer db.Close()
+func handleInfo(cmd *cobra.Command, args []string) error {
+	if err := printInfo(sstDir, vlogDir); err != nil {
+		return errors.Wrap(err, "failed to print information in MANIFEST file")
+	}
 
-		err = tableInfo(sstDir, vlogDir, db)
+	// Open DB
+	opts := badger.DefaultOptions
+	opts.TableLoadingMode = options.MemoryMap
+	opts.Dir = sstDir
+	opts.ValueDir = vlogDir
+	opts.ReadOnly = true
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		return errors.Wrap(err, "failed to open database")
+	}
+	defer db.Close()
+
+	if opt.showTables {
+		tableInfo(sstDir, vlogDir, db)
+	}
+
+	if opt.showHistogram {
+		db.PrintHistogram([]byte(opt.withPrefix))
+	}
+
+	if opt.showKeys {
+		if err := showKeys(db, opt.withPrefix); err != nil {
+			return err
+		}
+	}
+
+	if len(opt.keyLookup) > 0 {
+		if err := lookup(db); err != nil {
+			return errors.Wrapf(err, "failed to perform lookup for the key: %x", opt.keyLookup)
+		}
+	}
+	return nil
+}
+
+func showKeys(db *badger.DB, prefix string) error {
+	if len(prefix) > 0 {
+		fmt.Printf("Only choosing keys with prefix: \n%s", hex.Dump([]byte(prefix)))
+	}
+	txn := db.NewTransaction(false)
+	defer txn.Discard()
+
+	iopt := badger.DefaultIteratorOptions
+	iopt.Prefix = []byte(prefix)
+	iopt.PrefetchValues = false
+	iopt.AllVersions = opt.keyHistory
+	it := txn.NewIterator(iopt)
+	defer it.Close()
+
+	totalKeys := 0
+	for it.Rewind(); it.Valid(); it.Next() {
+		item := it.Item()
+		if err := printKey(item, false); err != nil {
+			return errors.Wrapf(err, "failed to print information about key: %x(%d)",
+				item.Key(), item.Version())
+		}
+		totalKeys++
+	}
+	fmt.Print("\n[Summary]\n")
+	fmt.Println("Total Number of keys:", totalKeys)
+	return nil
+
+}
+
+func lookup(db *badger.DB) error {
+	txn := db.NewTransaction(false)
+	defer txn.Discard()
+
+	key, err := hex.DecodeString(opt.keyLookup)
+	if err != nil {
+		return errors.Wrapf(err, "failed to decode key: %q", opt.keyLookup)
+	}
+
+	iopts := badger.DefaultIteratorOptions
+	iopts.AllVersions = opt.keyHistory
+	iopts.PrefetchValues = opt.keyHistory
+	itr := txn.NewKeyIterator(key, iopts)
+	defer itr.Close()
+
+	itr.Rewind()
+	if !itr.Valid() {
+		return errors.Errorf("Unable to rewind to key:\n%s", hex.Dump(key))
+	}
+	fmt.Println()
+	item := itr.Item()
+	if err := printKey(item, true); err != nil {
+		return errors.Wrapf(err, "failed to print information about key: %x(%d)",
+			item.Key(), item.Version())
+	}
+
+	if !opt.keyHistory {
+		return nil
+	}
+
+	itr.Next() // Move to the next key
+	for ; itr.Valid(); itr.Next() {
+		item := itr.Item()
+		if !bytes.Equal(key, item.Key()) {
+			break
+		}
+		if err := printKey(item, true); err != nil {
+			return errors.Wrapf(err, "failed to print information about key: %x(%d)",
+				item.Key(), item.Version())
+		}
+	}
+	return nil
+}
+
+func printKey(item *badger.Item, showValue bool) error {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Key: %x\tversion: %d", item.Key(), item.Version())
+	if opt.itemMeta {
+		fmt.Fprintf(&buf, "\tsize: %d\tmeta: b%04b", item.EstimatedSize(), item.UserMeta())
+	}
+	if item.IsDeletedOrExpired() {
+		buf.WriteString("\t{deleted}")
+	}
+	if item.DiscardEarlierVersions() {
+		buf.WriteString("\t{discard}")
+	}
+	if showValue {
+		val, err := item.ValueCopy(nil)
 		if err != nil {
-			fmt.Println("Error:", err.Error())
-			os.Exit(1)
+			return errors.Wrapf(err,
+				"failed to copy value of the key: %x(%d)", item.Key(), item.Version())
 		}
-		if opt.sizeHistogram {
-			// use prefix as nil since we want to list all keys
-			db.PrintHistogram(nil)
-		}
-	},
+		fmt.Fprintf(&buf, "\n\tvalue: %v", val)
+	}
+	fmt.Println(buf.String())
+	return nil
 }
 
 func hbytes(sz int64) string {
@@ -102,7 +222,7 @@ func dur(src, dst time.Time) string {
 	return humanize.RelTime(dst, src, "earlier", "later")
 }
 
-func tableInfo(dir, valueDir string, db *badger.DB) error {
+func tableInfo(dir, valueDir string, db *badger.DB) {
 	tables := db.Tables()
 	fmt.Println()
 	fmt.Println("SSTable [Li, Id, Total Keys including internal keys] [Left Key, Version -> Right Key, Version]")
@@ -114,7 +234,6 @@ func tableInfo(dir, valueDir string, db *badger.DB) error {
 			t.Level, t.ID, t.KeyCount, lk, lt, rk, rt)
 	}
 	fmt.Println()
-	return nil
 }
 
 func printInfo(dir, valueDir string) error {

--- a/iterator.go
+++ b/iterator.go
@@ -140,7 +140,7 @@ func (item *Item) IsDeletedOrExpired() bool {
 	return isDeletedOrExpired(item.meta, item.expiresAt)
 }
 
-// DiscardEarlierVersions returns whether the iterator was created with the
+// DiscardEarlierVersions returns whether the item was created with the
 // option to discard earlier versions of a key when multiple are available.
 func (item *Item) DiscardEarlierVersions() bool {
 	return item.meta&bitDiscardEarlierVersions > 0


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/508

This commit adds the following new flags
1. `--show-keys` which prints all the keys in badger to stdout
2. `--lookup` which allows user to lookup a specific key (in hex)
3. `--history` which would show all versions of the key

Sample output 
```
$ badger info --dir /tmp/badger --show-keys
Listening for /debug HTTP requests at port: 8080

[2019-04-26T14:43:38+05:30] MANIFEST       62 B MA
[                      now] 000001.sst   1.1 kB L0 9c1a594c352ea3cf057ffb58d7d85bc9ba7dd37b80081eaa5af7e648f8a72411
[                      now] 000000.vlog  1.2 kB VL

[Summary]
Level 0 size:       1.1 kB
Total index size:   1.1 kB
Value log size:     1.2 kB

Abnormalities: None.
0 extra files.
0 missing files.
0 empty files.
0 truncated manifests.
badger 2019/04/26 14:44:00 INFO: All 1 tables opened in 1ms
badger 2019/04/26 14:44:00 DEBUG: Value Log Discard stats: map[]
badger 2019/04/26 14:44:00 INFO: Replaying file id: 0 at offset: 1202
badger 2019/04/26 14:44:00 INFO: Replay took: 48.736µs
Key: 6b657930   version: 1      size: 8 meta: b0000
Key: 6b657931   version: 1      size: 8 meta: b0000
Key: 6b65793130 version: 1      size: 9 meta: b0000
Key: 6b65793131 version: 1      size: 9 meta: b0000
Key: 6b65793132 version: 1      size: 9 meta: b0000
Key: 6b65793133 version: 1      size: 9 meta: b0000
Key: 6b65793134 version: 1      size: 9 meta: b0000
Key: 6b65793135 version: 1      size: 9 meta: b0000
Key: 6b65793136 version: 1      size: 9 meta: b0000
Key: 6b65793137 version: 1      size: 9 meta: b0000
Key: 6b65793138 version: 1      size: 9 meta: b0000
Key: 6b65793139 version: 1      size: 9 meta: b0000
Key: 6b657932   version: 1      size: 8 meta: b0000
Key: 6b65793230 version: 1      size: 9 meta: b0000
Key: 6b65793231 version: 1      size: 9 meta: b0000
Key: 6b65793232 version: 1      size: 9 meta: b0000
Key: 6b65793233 version: 1      size: 9 meta: b0000
Key: 6b65793234 version: 1      size: 9 meta: b0000
Key: 6b65793235 version: 1      size: 9 meta: b0000
Key: 6b65793236 version: 1      size: 9 meta: b0000
Key: 6b65793237 version: 1      size: 9 meta: b0000
Key: 6b65793238 version: 1      size: 9 meta: b0000
Key: 6b65793239 version: 1      size: 9 meta: b0000
Key: 6b657933   version: 1      size: 8 meta: b0000
Key: 6b657934   version: 1      size: 8 meta: b0000
Key: 6b657935   version: 1      size: 8 meta: b0000
Key: 6b657936   version: 1      size: 8 meta: b0000
Key: 6b657937   version: 1      size: 8 meta: b0000
Key: 6b657938   version: 1      size: 8 meta: b0000
Key: 6b657939   version: 1      size: 8 meta: b0000

[Summary]
Total Number of keys: 30
$ badger info --dir /tmp/badger --lookup 6b657933
Listening for /debug HTTP requests at port: 8080

[2019-04-26T14:43:38+05:30] MANIFEST       62 B MA
[                      now] 000001.sst   1.1 kB L0 9c1a594c352ea3cf057ffb58d7d85bc9ba7dd37b80081eaa5af7e648f8a72411
[                      now] 000000.vlog  1.2 kB VL

[Summary]
Level 0 size:       1.1 kB
Total index size:   1.1 kB
Value log size:     1.2 kB

Abnormalities: None.
0 extra files.
0 missing files.
0 empty files.
0 truncated manifests.
badger 2019/04/26 14:44:26 INFO: All 1 tables opened in 1ms
badger 2019/04/26 14:44:26 DEBUG: Value Log Discard stats: map[]
badger 2019/04/26 14:44:26 INFO: Replaying file id: 0 at offset: 1202
badger 2019/04/26 14:44:26 INFO: Replay took: 25.801µs

Key: 6b657933   version: 1      size: 8 meta: b0000     value: [98 97 114 49]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/770)
<!-- Reviewable:end -->
