### PR TITLE
Fix vlog.sync()

### DIFF
--- a/db.go
+++ b/db.go
@@ -433,7 +433,7 @@ const (
 // Sync syncs database content to disk. This function provides
 // more control to user to sync data whenever required.
 func (db *DB) Sync() error {
-	return db.vlog.sync()
+	return db.vlog.sync(math.MaxUint32)
 }
 
 // When you create or delete a file, you have to ensure the directory entry for the file is synced
@@ -770,7 +770,7 @@ func (db *DB) ensureRoomForWrite() error {
 	case db.flushChan <- flushTask{mt: db.mt, vptr: db.vhead}:
 		db.elog.Printf("Flushing value log to disk if async mode.")
 		// Ensure value log is synced to disk so this memtable's contents wouldn't be lost.
-		err = db.vlog.sync()
+		err = db.vlog.sync(db.vhead.Fid)
 		if err != nil {
 			return err
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -1790,6 +1790,39 @@ func TestSyncForRace(t *testing.T) {
 	<-doneChan
 }
 
+// Earlier, if head is not pointing to latest Vlog file, then at replay badger used to crash with
+// index out of range panic. After fix in this commit it should not.
+func TestNoCrash(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err, "cannot create badger dir")
+	defer os.RemoveAll(dir)
+
+	ops := getTestOptions(dir)
+	ops.ValueLogMaxEntries = 1
+	db, err := Open(ops)
+	require.NoError(t, err, "unable to open db")
+
+	// entering 100 entries will generate 100 vlog files
+	for i := 0; i < 100; i++ {
+		err := db.Update(func(txn *Txn) error {
+			return txn.Set([]byte(fmt.Sprintf("key-%d", i)), []byte(fmt.Sprintf("val-%d", i)))
+		})
+		require.NoError(t, err, "update to db failed")
+	}
+
+	db.Lock()
+	// make head to point to first file
+	db.vhead = valuePointer{0, 0, 0}
+	db.Unlock()
+	db.Close()
+
+	// reduce size of SSTable to flush early
+	ops.MaxTableSize = 1 << 10
+	db, err = Open(ops)
+	require.Nil(t, err, "error while opening db")
+	require.NoError(t, db.Close())
+}
+
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags
 	go func() {


### PR DESCRIPTION
vlog.sync() syncs only latest value log file(vlog.maxFid). There can
be case when vlog.maxFid is not opened and vlog.sync() is called(during
replay when head is not pointing to vlog.maxFid). Hence it will return
error. This causes assertion y.AssertTrue(ft.mt == db.imm[0]) in db.go
to fail, resulting in crash of badger. This commit fixes it by accepting
an argument fid in vlog.sync method. If fid < vlog.maxFid, it returns
without doing anything.

Fixes #783 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/787)
<!-- Reviewable:end -->
