### PR TITLE
Make getting key count optional in db.Tables()

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -223,7 +223,8 @@ func dur(src, dst time.Time) string {
 }
 
 func tableInfo(dir, valueDir string, db *badger.DB) {
-	tables := db.Tables()
+	// we want all tables with keys count here.
+	tables := db.Tables(true)
 	fmt.Println()
 	fmt.Println("SSTable [Li, Id, Total Keys including internal keys] [Left Key, Version -> Right Key, Version]")
 	for _, t := range tables {

--- a/db.go
+++ b/db.go
@@ -1129,16 +1129,18 @@ func (db *DB) GetSequence(key []byte, bandwidth uint64) (*Sequence, error) {
 	return seq, err
 }
 
-// Tables gets the TableInfo objects from the level controller.
-func (db *DB) Tables() []TableInfo {
-	return db.lc.getTableInfo()
+// Tables gets the TableInfo objects from the level controller. If withKeysCount
+// is true, TableInfo objects also contain counts of keys for the tables.
+func (db *DB) Tables(withKeysCount bool) []TableInfo {
+	return db.lc.getTableInfo(withKeysCount)
 }
 
 // KeySplits can be used to get rough key ranges to divide up iteration over
 // the DB.
 func (db *DB) KeySplits(prefix []byte) []string {
 	var splits []string
-	for _, ti := range db.Tables() {
+	// We just want table ranges here and not keys count.
+	for _, ti := range db.Tables(false) {
 		// We don't use ti.Left, because that has a tendency to store !badger
 		// keys.
 		if bytes.HasPrefix(ti.Right, prefix) {

--- a/levels.go
+++ b/levels.go
@@ -952,14 +952,17 @@ type TableInfo struct {
 	KeyCount uint64 // Number of keys in the table
 }
 
-func (s *levelsController) getTableInfo() (result []TableInfo) {
+func (s *levelsController) getTableInfo(withKeysCount bool) (result []TableInfo) {
 	for _, l := range s.levels {
 		for _, t := range l.tables {
-			it := t.NewIterator(false)
 			var count uint64
-			for it.Rewind(); it.Valid(); it.Next() {
-				count++
+			if withKeysCount {
+				it := t.NewIterator(false)
+				for it.Rewind(); it.Valid(); it.Next() {
+					count++
+				}
 			}
+
 			info := TableInfo{
 				ID:       t.ID(),
 				Level:    l.level,


### PR DESCRIPTION
Currently db.Tables() returns list of TableInfo objects. These objects
also contain keys count for the tables. Getting keys count for tables
can be expensive as it requires iterating all the tables, espcially in
large databases. db.KeySplits function(used for steaming) also uses the
same function, which does not require keys count for tables. Hence
in case of large databases, stream can take lot of time just for getting
key splits. This commit adds support for getting keys count optionally
in TableInfo objects.

I compared time for KeySplits() in with and without keys count case.
Environment:
* Ubuntu 18.10 system with 16 core, 32 GB RAM and SSD storage
* Created DB using fill command containing 500M records and 473 SSTs

I tried to create stream on DB created above (stream internally uses
db.KeySplits()). Time taken by db.KeySplits():
with keys count: ~49 sec
without keys count: ~500 microsec

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/796)
<!-- Reviewable:end -->
