### PR TITLE
Fix DB crash during stream

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -954,6 +954,7 @@ type TableInfo struct {
 
 func (s *levelsController) getTableInfo(withKeysCount bool) (result []TableInfo) {
 	for _, l := range s.levels {
+		l.RLock()
 		for _, t := range l.tables {
 			var count uint64
 			if withKeysCount {
@@ -972,6 +973,7 @@ func (s *levelsController) getTableInfo(withKeysCount bool) (result []TableInfo)
 			}
 			result = append(result, info)
 		}
+		l.RUnlock()
 	}
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].Level != result[j].Level {


### PR DESCRIPTION
getTableInfo method of levelsController is not locking levels while
iterating their tables. This can throw races if we modify tables slice
during compaction or adding new tables in a level. Sometimes DB can
also panic as we iterate on tables and some table is deleted during
compaction. This commits adds changes to acquire read lock before
iterating tables of a level.

Fixes #795

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/798)
<!-- Reviewable:end -->
