### PR TITLE
Refactor loading code and fix bug in batch

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -138,10 +138,10 @@ func (wb *WriteBatch) commit() error {
 	if wb.err != nil {
 		return wb.err
 	}
-	wb.txn.CommitWith(wb.callback)
 	if err := wb.throttle.Do(); err != nil {
 		return err
 	}
+	wb.txn.CommitWith(wb.callback)
 	wb.txn = wb.db.newTransaction(true, true)
 	wb.txn.readTs = 0 // We're not reading anything.
 	return wb.err


### PR DESCRIPTION
- Create a new Loader struct which can encapsulate the logic of writing data in bulk to Badger.
- Fix a bug in batch writer, where throttle.Done was getting called before throttle.Do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/800)
<!-- Reviewable:end -->
