### PR TITLE
Acquire lock before incrementing orc.nextTxnTs

### DIFF
--- a/db.go
+++ b/db.go
@@ -309,7 +309,7 @@ func Open(opt Options) (db *DB, err error) {
 	// In normal mode, we must update readMark so older versions of keys can be removed during
 	// compaction when run in offline mode via the flatten tool.
 	db.orc.readMark.Done(db.orc.nextTxnTs)
-	db.orc.incrementNextTxnTs()
+	db.orc.incrementNextTs()
 
 	db.writeCh = make(chan *request, kvWriteChCapacity)
 	db.closers.writes = y.NewCloser(1)

--- a/db.go
+++ b/db.go
@@ -309,7 +309,7 @@ func Open(opt Options) (db *DB, err error) {
 	// In normal mode, we must update readMark so older versions of keys can be removed during
 	// compaction when run in offline mode via the flatten tool.
 	db.orc.readMark.Done(db.orc.nextTxnTs)
-	db.orc.nextTxnTs++
+	db.orc.incrementNextTxnTs()
 
 	db.writeCh = make(chan *request, kvWriteChCapacity)
 	db.closers.writes = y.NewCloser(1)

--- a/txn.go
+++ b/txn.go
@@ -127,6 +127,12 @@ func (o *oracle) nextTs() uint64 {
 	return o.nextTxnTs
 }
 
+func (o *oracle) incrementNextTxnTs() {
+	o.Lock()
+	defer o.Unlock()
+	o.nextTxnTs++
+}
+
 // Any deleted or invalid versions at or below ts would be discarded during
 // compaction to reclaim disk space in LSM tree and thence value log.
 func (o *oracle) setDiscardTs(ts uint64) {

--- a/txn.go
+++ b/txn.go
@@ -127,7 +127,7 @@ func (o *oracle) nextTs() uint64 {
 	return o.nextTxnTs
 }
 
-func (o *oracle) incrementNextTxnTs() {
+func (o *oracle) incrementNextTs() {
 	o.Lock()
 	defer o.Unlock()
 	o.nextTxnTs++


### PR DESCRIPTION
Incrementing the value of db.orc.nextTxnTs without acquiring lock causes race condition.
See https://teamcity.dgraph.io/viewLog.html?buildId=11417&buildTypeId=Badger_UnitTests logs

```
[09:33:00] :	 [Step 2/2] === RUN   TestNoCrash
[09:33:00] :	 [Step 2/2] badger 2019/05/07 09:33:00 INFO: All 0 tables opened in 0s
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Storing value log head: {Fid:0 Len:0 Offset:0}
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Running for level: 0
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: LOG Compact. Added 102 keys. Skipped 0 keys. Iteration took: 1.751092ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Discard stats: map[]
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: LOG Compact 0->1, del 1 tables, add 1 tables, took 26.314199ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Compaction for level: 0 DONE
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Force compaction on level 0 done
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: All 1 tables opened in 1ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Value Log Discard stats: map[]
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Replaying file id: 0 at offset: 0
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Replay took: 164.446µs
...
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Replaying file id: 100 at offset: 0
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Replay took: 13.082µs
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Storing value log head: {Fid:0 Len:0 Offset:0}
[09:33:01] :	 [Step 2/2] ==================
[09:33:01] :	 [Step 2/2] WARNING: DATA RACE
[09:33:01] :	 [Step 2/2] Read at 0x00c02e5038d0 by goroutine 330:
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.(*oracle).nextTs()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/txn.go:127 +0x88
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.(*DB).handleFlushTask()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/db.go:830 +0x951
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.(*DB).flushMemtable()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/db.go:882 +0x209
[09:33:01] :	 [Step 2/2] 
[09:33:01] :	 [Step 2/2] Previous write at 0x00c02e5038d0 by goroutine 101:
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.Open()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/db.go:312 +0x10d7
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.TestNoCrash()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/db_test.go:1725 +0x56d
[09:33:01] :	 [Step 2/2]   testing.tRunner()
[09:33:01] :	 [Step 2/2]       /usr/local/go/src/testing/testing.go:827 +0x162
[09:33:01] :	 [Step 2/2] 
[09:33:01] :	 [Step 2/2] Goroutine 330 (running) created at:
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.Open()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/db.go:283 +0x158a
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.TestNoCrash()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/db_test.go:1725 +0x56d
[09:33:01] :	 [Step 2/2]   testing.tRunner()
[09:33:01] :	 [Step 2/2]       /usr/local/go/src/testing/testing.go:827 +0x162
[09:33:01] :	 [Step 2/2] 
[09:33:01] :	 [Step 2/2] Goroutine 101 (running) created at:
[09:33:01] :	 [Step 2/2]   testing.(*T).Run()
[09:33:01] :	 [Step 2/2]       /usr/local/go/src/testing/testing.go:878 +0x659
[09:33:01] :	 [Step 2/2]   testing.runTests.func1()
[09:33:01] :	 [Step 2/2]       /usr/local/go/src/testing/testing.go:1119 +0xa8
[09:33:01] :	 [Step 2/2]   testing.tRunner()
[09:33:01] :	 [Step 2/2]       /usr/local/go/src/testing/testing.go:827 +0x162
[09:33:01] :	 [Step 2/2]   testing.runTests()
[09:33:01] :	 [Step 2/2]       /usr/local/go/src/testing/testing.go:1117 +0x4ee
[09:33:01] :	 [Step 2/2]   testing.(*M).Run()
[09:33:01] :	 [Step 2/2]       /usr/local/go/src/testing/testing.go:1034 +0x2ee
[09:33:01] :	 [Step 2/2]   github.com/dgraph-io/badger.TestMain()
[09:33:01] :	 [Step 2/2]       /home/pawan0201/go/src/github.com/dgraph-io/badger/db_test.go:1737 +0x50
[09:33:01] :	 [Step 2/2]   main.main()
[09:33:01] :	 [Step 2/2]       _testmain.go:234 +0x221
[09:33:01] :	 [Step 2/2] ==================
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Storing value log head: {Fid:0 Len:0 Offset:0}
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Storing value log head: {Fid:0 Len:0 Offset:0}
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Storing value log head: {Fid:100 Len:0 Offset:0}
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Running for level: 0
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: LOG Compact. Added 31 keys. Skipped 0 keys. Iteration took: 2.140023ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: LOG Compact. Added 36 keys. Skipped 0 keys. Iteration took: 2.340898ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: LOG Compact. Added 35 keys. Skipped 0 keys. Iteration took: 2.317545ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: LOG Compact. Added 1 keys. Skipped 0 keys. Iteration took: 1.601465ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 DEBUG: Discard stats: map[]
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: LOG Compact 0->1, del 7 tables, add 4 tables, took 14.743849ms
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Compaction for level: 0 DONE
[09:33:01] :	 [Step 2/2] badger 2019/05/07 09:33:01 INFO: Force compaction on level 0 done
[09:33:01] :	 [Step 2/2] --- FAIL: TestNoCrash (0.65s)
[09:33:01] :	 [Step 2/2]     testing.go:771: race detected during execution of test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/806)
<!-- Reviewable:end -->
