### PR TITLE
Remove loadToRAM method to improve startup performance

### DIFF
--- a/options.go
+++ b/options.go
@@ -118,6 +118,8 @@ type Options struct {
 	maxBatchCount int64 // max entries in batch
 	maxBatchSize  int64 // max batch size in bytes
 
+	// Validate checksum for each SST on startup
+	VerifyChecksumOnStartup bool
 }
 
 // DefaultOptions sets a list of recommended options for good performance.
@@ -144,11 +146,12 @@ var DefaultOptions = Options{
 	// -1 so 2*ValueLogFileSize won't overflow on 32-bit systems.
 	ValueLogFileSize: 1<<30 - 1,
 
-	ValueLogMaxEntries: 1000000,
-	ValueThreshold:     32,
-	Truncate:           false,
-	Logger:             defaultLogger,
-	LogRotatesToFlush:  2,
+	ValueLogMaxEntries:      1000000,
+	ValueThreshold:          32,
+	Truncate:                false,
+	Logger:                  defaultLogger,
+	LogRotatesToFlush:       2,
+	VerifyChecksumOnStartup: false,
 }
 
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold


### PR DESCRIPTION
**Update** - The benchmarks were invalid because I did not consider filesystem cache. Once filesystem cache was disabled, it turned out that the removal degraded the performance. Closing this PR.

This PR removes the call to `LoadToRAM` method while starting up the DB.
This change leads to significant performance improvement (roughly 2x startup speed)
## Benchmarks
1. With 100-million key-values
 - With Load to RAM (**7.110s**)
```
=== RUN   TestDBStartup
badger 2019/05/14 17:03:20 INFO: 40 tables out of 95 opened in 3.08s
badger 2019/05/14 17:03:23 INFO: 83 tables out of 95 opened in 6.137s
badger 2019/05/14 17:03:24 INFO: All 95 tables opened in 7.037s
badger 2019/05/14 17:03:24 DEBUG: Value Log Discard stats: map[]
badger 2019/05/14 17:03:24 INFO: Replaying file id: 95 at offset: 73672676
badger 2019/05/14 17:03:24 INFO: Replay took: 10.83µs
badger 2019/05/14 17:03:24 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
--- PASS: TestDBStartup (7.06s)
PASS
ok  	github.com/dgraph-io/badger	7.110s
```
 - Without Load to RAM (**1.177s**)
```
=== RUN   TestDBStartup
badger 2019/05/14 17:00:48 INFO: All 95 tables opened in 1.114s
badger 2019/05/14 17:00:48 DEBUG: Value Log Discard stats: map[]
badger 2019/05/14 17:00:48 INFO: Replaying file id: 95 at offset: 73672676
badger 2019/05/14 17:00:48 INFO: Replay took: 10.11µs
badger 2019/05/14 17:00:48 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
--- PASS: TestDBStartup (1.15s)
PASS
ok  	github.com/dgraph-io/badger	1.177s
```
2. With 300-million key-values
 - With Load to RAM (**21.781s**)
```
=== RUN   TestDBStartup
badger 2019/05/14 17:04:15 INFO: 36 tables out of 278 opened in 3.129s
badger 2019/05/14 17:04:18 INFO: 74 tables out of 278 opened in 6.028s
badger 2019/05/14 17:04:21 INFO: 115 tables out of 278 opened in 9.084s
badger 2019/05/14 17:04:24 INFO: 155 tables out of 278 opened in 12.028s
badger 2019/05/14 17:04:27 INFO: 195 tables out of 278 opened in 15.034s
badger 2019/05/14 17:04:30 INFO: 235 tables out of 278 opened in 18.057s
badger 2019/05/14 17:04:33 INFO: 271 tables out of 278 opened in 21.102s
badger 2019/05/14 17:04:34 INFO: All 278 tables opened in 21.673s
badger 2019/05/14 17:04:34 DEBUG: Value Log Discard stats: map[]
badger 2019/05/14 17:04:34 INFO: Replaying file id: 279 at offset: 19922495
badger 2019/05/14 17:04:34 INFO: Replay took: 10.46µs
badger 2019/05/14 17:04:34 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
--- PASS: TestDBStartup (21.71s)
PASS
ok  	github.com/dgraph-io/badger	21.781s

```
 - Without Load to RAM (**3.239s**)
```
=== RUN   TestDBStartup
badger 2019/05/14 17:00:58 INFO: 265 tables out of 278 opened in 3.02s
badger 2019/05/14 17:00:58 INFO: All 278 tables opened in 3.157s
badger 2019/05/14 17:00:58 DEBUG: Value Log Discard stats: map[]
badger 2019/05/14 17:00:58 INFO: Replaying file id: 279 at offset: 19922495
badger 2019/05/14 17:00:58 INFO: Replay took: 9.96µs
badger 2019/05/14 17:00:58 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
--- PASS: TestDBStartup (3.19s)
PASS
ok  	github.com/dgraph-io/badger	3.239s

```
This PR also adds a `VerifyChecksum()` API which the user can use to verify the checksum.
The user can specify if the checksum should be calculated at runtime by setting `options.VerifyChecksumOnStartup` to `true`. (default `false`) 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/808)
<!-- Reviewable:end -->
