### PR TITLE
Disable SST checksum validation at DB Startup

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -140,23 +140,26 @@ func OpenTable(fd *os.File, mode options.FileLoadingMode, cksum []byte) (*Table,
 
 	t.tableSize = int(fileInfo.Size())
 
-	// The following code block is intentionally commented out. Removing the loadToRAM()
-	// call lead to significant performance improvement (see
-	// https://github.com/dgraph-io/badger/pull/808). We will be adding block level checksum
-	// (currently we have a table level checksum) along with a block level cache in near future.
-	//
-	// // We first load to RAM, so we can read the index and do checksum.
-	// if err := t.loadToRAM(); err != nil {
-	// 	return nil, err
-	// }
-	// // Enforce checksum before we read index. Otherwise, if the file was
-	// // truncated, we'd end up with panics in readIndex.
-	// if len(cksum) > 0 && !bytes.Equal(t.Checksum, cksum) {
-	// 	return nil, fmt.Errorf(
-	// 		"CHECKSUM_MISMATCH: Table checksum does not match checksum in MANIFEST."+
-	// 			" NOT including table %s. This would lead to missing data."+
-	// 			"\n  sha256 %x Expected\n  sha256 %x Found\n", filename, cksum, t.Checksum)
-	// }
+	/*
+		// The following code block is intentionally commented out. Removing the loadToRAM()
+		// call lead to significant performance improvement (see
+		// https://github.com/dgraph-io/badger/pull/808). We will be adding block level checksum
+		// (currently we have a table level checksum) along with a block level cache in near future.
+
+		// We first load to RAM, so we can read the index and do checksum.
+		if err := t.loadToRAM(); err != nil {
+			return nil, err
+		}
+		// Enforce checksum before we read index. Otherwise, if the file was
+		// truncated, we'd end up with panics in readIndex.
+		if len(cksum) > 0 && !bytes.Equal(t.Checksum, cksum) {
+			return nil, fmt.Errorf(
+				"CHECKSUM_MISMATCH: Table checksum does not match checksum in MANIFEST."+
+					" NOT including table %s. This would lead to missing data."+
+					"\n  sha256 %x Expected\n  sha256 %x Found\n", filename, cksum, t.Checksum)
+		}
+	*/
+
 	if err := t.readIndex(); err != nil {
 		return nil, y.Wrap(err)
 	}
@@ -177,7 +180,9 @@ func OpenTable(fd *os.File, mode options.FileLoadingMode, cksum []byte) (*Table,
 
 	switch mode {
 	case options.LoadToRAM:
-		// No need to do anything. t.mmap is already filled.
+		if err := t.loadToRAM(); err != nil {
+			return nil, err
+		}
 	case options.MemoryMap:
 		t.mmap, err = y.Mmap(fd, false, fileInfo.Size())
 		if err != nil {


### PR DESCRIPTION
This commit disables SST checksum validation by disabling the loadToRAM() function call at DB startup. Disabling loadToRAM() call lead to significant reduction in DB startup time. See https://github.com/dgraph-io/badger/pull/808#issue-277776266 for benchmarks.

In future, the table level checksum will be replaced with block level checksum along with block level caching.

Related to https://github.com/dgraph-io/badger/issues/790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/811)
<!-- Reviewable:end -->
