### PR TITLE
Renaming the stream writer API

### DIFF
--- a/badger/cmd/fill.go
+++ b/badger/cmd/fill.go
@@ -100,7 +100,7 @@ func fillSorted(db *badger.DB, num uint64) error {
 			return err
 		}
 	}
-	return writer.Done()
+	return writer.Flush()
 }
 
 func fill(cmd *cobra.Command, args []string) error {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -144,9 +144,9 @@ func (sw *StreamWriter) Write(kvs *pb.KVList) error {
 	return nil
 }
 
-// Done is called once we are done writing all the entries. It syncs DB directories. It also
+// Flush is called once we are done writing all the entries. It syncs DB directories. It also
 // updates Oracle with maxVersion found in all entries (if DB is not managed).
-func (sw *StreamWriter) Done() error {
+func (sw *StreamWriter) Flush() error {
 	defer sw.done()
 	for _, writer := range sw.writers {
 		if err := writer.Done(); err != nil {

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -60,7 +60,7 @@ func TestStreamWriter1(t *testing.T) {
 			sw := db.NewStreamWriter()
 			require.NoError(t, sw.Prepare(), "sw.Prepare() failed")
 			require.NoError(t, sw.Write(list), "sw.Write() failed")
-			require.NoError(t, sw.Done(), "sw.Done() failed")
+			require.NoError(t, sw.Flush(), "sw.Flush() failed")
 
 			err := db.View(func(txn *Txn) error {
 				// read any random key from inserted keys
@@ -103,7 +103,7 @@ func TestStreamWriter2(t *testing.T) {
 			require.NoError(t, sw.Write(list), "sw.Write() failed")
 			// get max version of sw, will be used in transactions for managed mode
 			maxVs := sw.maxVersion
-			require.NoError(t, sw.Done(), "sw.Done() failed")
+			require.NoError(t, sw.Flush(), "sw.Flush() failed")
 
 			// delete all the inserted keys
 			val := make([]byte, valueSize)
@@ -171,7 +171,7 @@ func TestStreamWriter3(t *testing.T) {
 			require.NoError(t, sw.Write(list), "sw.Write() failed")
 			// get max version of sw, will be used in transactions for managed mode
 			maxVs := sw.maxVersion
-			require.NoError(t, sw.Done(), "sw.Done() failed")
+			require.NoError(t, sw.Flush(), "sw.Flush() failed")
 
 			// insert keys which are odd
 			val := make([]byte, valueSize)


### PR DESCRIPTION
so that the stream writer and the TxnWriter in dgraph confirm to the same interface
type badgerWriter interface {
	Write(kvs *bpb.KVList) error
	Flush() error
}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/814)
<!-- Reviewable:end -->
