### PR TITLE
Allow custom key comparator

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -30,12 +30,15 @@ import (
 )
 
 type keyRange struct {
-	left  []byte
-	right []byte
-	inf   bool
+	left          []byte
+	right         []byte
+	inf           bool
+	keyComparator y.KeyComparator
 }
 
-var infRange = keyRange{inf: true}
+func infRange(comp y.KeyComparator) keyRange {
+	return keyRange{inf: true, keyComparator: comp}
+}
 
 func (r keyRange) String() string {
 	return fmt.Sprintf("[left=%x, right=%x, inf=%v]", r.left, r.right, r.inf)
@@ -53,20 +56,20 @@ func (r keyRange) overlapsWith(dst keyRange) bool {
 	}
 
 	// If my left is greater than dst right, we have no overlap.
-	if y.CompareKeys(r.left, dst.right) > 0 {
+	if r.keyComparator.CompareKeys(r.left, dst.right) > 0 {
 		return false
 	}
 	// If my right is less than dst left, we have no overlap.
-	if y.CompareKeys(r.right, dst.left) < 0 {
+	if r.keyComparator.CompareKeys(r.right, dst.left) < 0 {
 		return false
 	}
 	// We have overlap.
 	return true
 }
 
-func getKeyRange(tables []*table.Table) keyRange {
+func getKeyRange(tables []*table.Table, comp y.KeyComparator) keyRange {
 	if len(tables) == 0 {
-		return keyRange{}
+		return keyRange{keyComparator: comp}
 	}
 	smallest := tables[0].Smallest()
 	biggest := tables[0].Biggest()
@@ -79,8 +82,9 @@ func getKeyRange(tables []*table.Table) keyRange {
 		}
 	}
 	return keyRange{
-		left:  y.KeyWithTs(y.ParseKey(smallest), math.MaxUint64),
-		right: y.KeyWithTs(y.ParseKey(biggest), 0),
+		left:          y.KeyWithTs(y.ParseKey(smallest), math.MaxUint64),
+		right:         y.KeyWithTs(y.ParseKey(biggest), 0),
+		keyComparator: comp,
 	}
 }
 

--- a/compaction.go
+++ b/compaction.go
@@ -74,10 +74,10 @@ func getKeyRange(tables []*table.Table, comp y.KeyComparator) keyRange {
 	smallest := tables[0].Smallest()
 	biggest := tables[0].Biggest()
 	for i := 1; i < len(tables); i++ {
-		if y.CompareKeys(tables[i].Smallest(), smallest) < 0 {
+		if comp.CompareKeys(tables[i].Smallest(), smallest) < 0 {
 			smallest = tables[i].Smallest()
 		}
-		if y.CompareKeys(tables[i].Biggest(), biggest) > 0 {
+		if comp.CompareKeys(tables[i].Biggest(), biggest) > 0 {
 			biggest = tables[i].Biggest()
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -799,7 +799,7 @@ func (db *DB) ensureRoomForWrite() error {
 			db.mt.MemSize(), len(db.flushChan))
 		// We manage to push this task. Let's modify imm.
 		db.imm = append(db.imm, db.mt)
-		db.mt = skl.NewSkiplist(arenaSize(db.opt), opt.KeyComparator)
+		db.mt = skl.NewSkiplist(arenaSize(db.opt), db.opt.KeyComparator)
 		// New memtable is empty. We certainly have room.
 		return nil
 	default:
@@ -881,7 +881,7 @@ func (db *DB) handleFlushTask(ft flushTask) error {
 		db.elog.Errorf("ERROR while syncing level directory: %v", dirSyncErr)
 	}
 
-	tbl, err := table.OpenTable(fd, db.opt.TableLoadingMode, nil)
+	tbl, err := table.OpenTable(fd, db.opt.TableLoadingMode, db.opt.KeyComparator, nil)
 	if err != nil {
 		db.elog.Printf("ERROR while opening table: %v", err)
 		return err
@@ -1344,7 +1344,7 @@ func (db *DB) dropAll() (func(), error) {
 		mt.DecrRef()
 	}
 	db.imm = db.imm[:0]
-	db.mt = skl.NewSkiplist(arenaSize(db.opt), opt.KeyComparator) // Set it up for future writes.
+	db.mt = skl.NewSkiplist(arenaSize(db.opt), db.opt.KeyComparator) // Set it up for future writes.
 
 	num, err := db.lc.dropTree()
 	if err != nil {
@@ -1400,7 +1400,7 @@ func (db *DB) DropPrefix(prefix []byte) error {
 		memtable.DecrRef()
 	}
 	db.imm = db.imm[:0]
-	db.mt = skl.NewSkiplist(arenaSize(db.opt), opt.KeyComparator)
+	db.mt = skl.NewSkiplist(arenaSize(db.opt), db.opt.KeyComparator)
 
 	// Drop prefixes from the levels.
 	if err := db.lc.dropPrefix(prefix); err != nil {

--- a/db.go
+++ b/db.go
@@ -273,7 +273,7 @@ func Open(opt Options) (db *DB, err error) {
 	db.calculateSize()
 	db.closers.updateSize = y.NewCloser(1)
 	go db.updateSize(db.closers.updateSize)
-	db.mt = skl.NewSkiplist(arenaSize(opt))
+	db.mt = skl.NewSkiplist(arenaSize(opt), opt.KeyComparator)
 
 	// newLevelsController potentially loads files in directory.
 	if db.lc, err = newLevelsController(db, &manifest); err != nil {
@@ -799,7 +799,7 @@ func (db *DB) ensureRoomForWrite() error {
 			db.mt.MemSize(), len(db.flushChan))
 		// We manage to push this task. Let's modify imm.
 		db.imm = append(db.imm, db.mt)
-		db.mt = skl.NewSkiplist(arenaSize(db.opt))
+		db.mt = skl.NewSkiplist(arenaSize(db.opt), opt.KeyComparator)
 		// New memtable is empty. We certainly have room.
 		return nil
 	default:
@@ -1344,7 +1344,7 @@ func (db *DB) dropAll() (func(), error) {
 		mt.DecrRef()
 	}
 	db.imm = db.imm[:0]
-	db.mt = skl.NewSkiplist(arenaSize(db.opt)) // Set it up for future writes.
+	db.mt = skl.NewSkiplist(arenaSize(db.opt), opt.KeyComparator) // Set it up for future writes.
 
 	num, err := db.lc.dropTree()
 	if err != nil {
@@ -1400,7 +1400,7 @@ func (db *DB) DropPrefix(prefix []byte) error {
 		memtable.DecrRef()
 	}
 	db.imm = db.imm[:0]
-	db.mt = skl.NewSkiplist(arenaSize(db.opt))
+	db.mt = skl.NewSkiplist(arenaSize(db.opt), opt.KeyComparator)
 
 	// Drop prefixes from the levels.
 	if err := db.lc.dropPrefix(prefix); err != nil {

--- a/db.go
+++ b/db.go
@@ -195,6 +195,10 @@ func Open(opt Options) (db *DB, err error) {
 		opt.CompactL0OnClose = false
 	}
 
+	if opt.KeyComparator == nil {
+		opt.KeyComparator = new(y.DefaultKeyComparator)
+	}
+
 	for _, path := range []string{opt.Dir, opt.ValueDir} {
 		dirExists, err := exists(path)
 		if err != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -1757,7 +1757,7 @@ func TestForceFlushMemtable(t *testing.T) {
 		mt.DecrRef()
 	}
 	db.imm = db.imm[:0]
-	db.mt = skl.NewSkiplist(arenaSize(db.opt)) // Set it up for future writes.
+	db.mt = skl.NewSkiplist(arenaSize(db.opt), db.opt.KeyComparator) // Set it up for future writes.
 	db.Unlock()
 
 	// get latest value of value log head

--- a/db_test.go
+++ b/db_test.go
@@ -53,6 +53,7 @@ func getTestOptions(dir string) Options {
 	if !*mmap {
 		opt.ValueLogLoadingMode = options.FileIO
 	}
+	opt.KeyComparator = new(y.DefaultKeyComparator)
 	return opt
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -327,9 +327,6 @@ type IteratorOptions struct {
 	PrefetchSize int
 	Reverse      bool // Direction of iteration. False is forward, true is backward.
 	AllVersions  bool // Fetch all valid versions of the same key.
-	// The KeyComparator is used to sort keys.
-	// Defaults to y.CompareKeysDefault.
-	KeyComparator y.KeyComparator
 
 	// The following option is used to narrow down the SSTables that iterator picks up. If
 	// Prefix is specified, only tables which could have this prefix are picked based on their range
@@ -420,7 +417,7 @@ func (txn *Txn) NewIterator(opt IteratorOptions) *Iterator {
 	iters = txn.db.lc.appendIterators(iters, &opt) // This will increment references.
 	res := &Iterator{
 		txn:    txn,
-		iitr:   y.NewMergeIterator(iters, opt.KeyComparator, opt.Reverse),
+		iitr:   y.NewMergeIterator(iters, txn.db.opt.KeyComparator, opt.Reverse),
 		opt:    opt,
 		readTs: txn.readTs,
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -327,6 +327,9 @@ type IteratorOptions struct {
 	PrefetchSize int
 	Reverse      bool // Direction of iteration. False is forward, true is backward.
 	AllVersions  bool // Fetch all valid versions of the same key.
+	// The KeyComparator is used to sort keys.
+	// Defaults to y.CompareKeysDefault.
+	KeyComparator y.KeyComparator
 
 	// The following option is used to narrow down the SSTables that iterator picks up. If
 	// Prefix is specified, only tables which could have this prefix are picked based on their range
@@ -417,7 +420,7 @@ func (txn *Txn) NewIterator(opt IteratorOptions) *Iterator {
 	iters = txn.db.lc.appendIterators(iters, &opt) // This will increment references.
 	res := &Iterator{
 		txn:    txn,
-		iitr:   y.NewMergeIterator(iters, opt.Reverse),
+		iitr:   y.NewMergeIterator(iters, opt.KeyComparator, opt.Reverse),
 		opt:    opt,
 		readTs: txn.readTs,
 	}

--- a/level_handler.go
+++ b/level_handler.go
@@ -69,7 +69,7 @@ func (s *levelHandler) initTables(tables []*table.Table) {
 	} else {
 		// Sort tables by keys.
 		sort.Slice(s.tables, func(i, j int) bool {
-			return y.CompareKeys(s.tables[i].Smallest(), s.tables[j].Smallest()) < 0
+			return s.db.opt.KeyComparator.CompareKeys(s.tables[i].Smallest(), s.tables[j].Smallest()) < 0
 		})
 	}
 }
@@ -132,7 +132,7 @@ func (s *levelHandler) replaceTables(toDel, toAdd []*table.Table) error {
 	// Assign tables.
 	s.tables = newTables
 	sort.Slice(s.tables, func(i, j int) bool {
-		return y.CompareKeys(s.tables[i].Smallest(), s.tables[j].Smallest()) < 0
+		return s.db.opt.KeyComparator.CompareKeys(s.tables[i].Smallest(), s.tables[j].Smallest()) < 0
 	})
 	s.Unlock() // s.Unlock before we DecrRef tables -- that can be slow.
 	return decrRefs(toDel)
@@ -215,7 +215,7 @@ func (s *levelHandler) getTableForKey(key []byte) ([]*table.Table, func() error)
 	}
 	// For level >= 1, we can do a binary search as key range does not overlap.
 	idx := sort.Search(len(s.tables), func(i int) bool {
-		return y.CompareKeys(s.tables[i].Biggest(), key) >= 0
+		return s.db.opt.KeyComparator.CompareKeys(s.tables[i].Biggest(), key) >= 0
 	})
 	if idx >= len(s.tables) {
 		// Given key is strictly > than every element we have.
@@ -290,10 +290,10 @@ func (s *levelHandler) overlappingTables(_ levelHandlerRLocked, kr keyRange) (in
 		return 0, 0
 	}
 	left := sort.Search(len(s.tables), func(i int) bool {
-		return y.CompareKeys(kr.left, s.tables[i].Biggest()) <= 0
+		return s.db.opt.KeyComparator.CompareKeys(kr.left, s.tables[i].Biggest()) <= 0
 	})
 	right := sort.Search(len(s.tables), func(i int) bool {
-		return y.CompareKeys(kr.right, s.tables[i].Smallest()) < 0
+		return s.db.opt.KeyComparator.CompareKeys(kr.right, s.tables[i].Smallest()) < 0
 	})
 	return left, right
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -169,7 +169,7 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 	lh0 := newLevelHandler(kv, 0)
 	lh1 := newLevelHandler(kv, 1)
 	f := buildTestTable(t, "k", 2)
-	t1, err := table.OpenTable(f, options.MemoryMap, nil)
+	t1, err := table.OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer t1.DecrRef()
 
@@ -190,7 +190,7 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 	lc.runCompactDef(0, cd)
 
 	f = buildTestTable(t, "l", 2)
-	t2, err := table.OpenTable(f, options.MemoryMap, nil)
+	t2, err := table.OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer t2.DecrRef()
 	done = lh0.tryAddLevel0Table(t2)

--- a/options.go
+++ b/options.go
@@ -18,6 +18,7 @@ package badger
 
 import (
 	"github.com/dgraph-io/badger/options"
+	"github.com/dgraph-io/badger/y"
 )
 
 // NOTE: Keep the comments in the following to 75 chars width, so they
@@ -108,6 +109,10 @@ type Options struct {
 	// which can slow things on start.
 	LogRotatesToFlush int32
 
+	// The KeyComparator is used to sort keys.
+	// Defaults to y.CompareKeysDefault.
+	KeyComparator y.KeyComparator
+
 	// Transaction start and commit timestamps are managed by end-user.
 	// This is only useful for databases built on top of Badger (like Dgraph).
 	// Not recommended for most users.
@@ -149,6 +154,7 @@ var DefaultOptions = Options{
 	Truncate:           false,
 	Logger:             defaultLogger,
 	LogRotatesToFlush:  2,
+	KeyComparator:      new(y.DefaultKeyComparator),
 }
 
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold

--- a/options.go
+++ b/options.go
@@ -109,8 +109,8 @@ type Options struct {
 	// which can slow things on start.
 	LogRotatesToFlush int32
 
-	// The KeyComparator is used to sort keys.
-	// Defaults to y.CompareKeysDefault.
+	// The KeyComparator is used by all Badger's components to compare keys in order to sort them.
+	// Defaults to y.DefaultKeyComparator.
 	KeyComparator y.KeyComparator
 
 	// Transaction start and commit timestamps are managed by end-user.

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -50,7 +50,7 @@ func length(s *Skiplist) int {
 
 func TestEmpty(t *testing.T) {
 	key := []byte("aaa")
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 
 	v := l.Get(key)
 	require.True(t, v.Value == nil) // Cannot use require.Nil for unsafe.Pointer nil.
@@ -84,7 +84,7 @@ func TestEmpty(t *testing.T) {
 
 // TestBasic tests single-threaded inserts and updates and gets.
 func TestBasic(t *testing.T) {
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 	val1 := newValue(42)
 	val2 := newValue(52)
 	val3 := newValue(62)
@@ -122,7 +122,7 @@ func TestBasic(t *testing.T) {
 // TestConcurrentBasic tests concurrent writes followed by concurrent reads.
 func TestConcurrentBasic(t *testing.T) {
 	const n = 1000
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 	var wg sync.WaitGroup
 	key := func(i int) []byte {
 		return y.KeyWithTs([]byte(fmt.Sprintf("%05d", i)), 0)
@@ -154,7 +154,7 @@ func TestConcurrentBasic(t *testing.T) {
 func TestOneKey(t *testing.T) {
 	const n = 100
 	key := y.KeyWithTs([]byte("thekey"), 0)
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 	defer l.DecrRef()
 
 	var wg sync.WaitGroup
@@ -187,7 +187,7 @@ func TestOneKey(t *testing.T) {
 }
 
 func TestFindNear(t *testing.T) {
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 	defer l.DecrRef()
 	for i := 0; i < 1000; i++ {
 		key := fmt.Sprintf("%05d", i*10+5)
@@ -294,7 +294,7 @@ func TestFindNear(t *testing.T) {
 // TestIteratorNext tests a basic iteration over all nodes from the beginning.
 func TestIteratorNext(t *testing.T) {
 	const n = 100
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 	defer l.DecrRef()
 	it := l.NewIterator()
 	defer it.Close()
@@ -318,7 +318,7 @@ func TestIteratorNext(t *testing.T) {
 // TestIteratorPrev tests a basic iteration over all nodes from the end.
 func TestIteratorPrev(t *testing.T) {
 	const n = 100
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 	defer l.DecrRef()
 	it := l.NewIterator()
 	defer it.Close()
@@ -342,7 +342,7 @@ func TestIteratorPrev(t *testing.T) {
 // TestIteratorSeek tests Seek and SeekForPrev.
 func TestIteratorSeek(t *testing.T) {
 	const n = 100
-	l := NewSkiplist(arenaSize)
+	l := NewSkiplist(arenaSize, new(y.DefaultKeyComparator))
 	defer l.DecrRef()
 
 	it := l.NewIterator()
@@ -421,7 +421,7 @@ func BenchmarkReadWrite(b *testing.B) {
 	for i := 0; i <= 10; i++ {
 		readFrac := float32(i) / 10.0
 		b.Run(fmt.Sprintf("frac_%d", i), func(b *testing.B) {
-			l := NewSkiplist(int64((b.N + 1) * MaxNodeSize))
+			l := NewSkiplist(int64((b.N + 1) * MaxNodeSize), new(y.DefaultKeyComparator))
 			defer l.DecrRef()
 			b.ResetTimer()
 			var count int

--- a/stream.go
+++ b/stream.go
@@ -135,12 +135,12 @@ func (st *Stream) produceRanges(ctx context.Context) {
 
 	start := y.SafeCopy(nil, st.Prefix)
 	for _, key := range splits {
-		st.rangeCh <- keyRange{left: start, right: y.SafeCopy(nil, []byte(key))}
+		st.rangeCh <- keyRange{left: start, right: y.SafeCopy(nil, []byte(key)), keyComparator: st.db.opt.KeyComparator}
 		start = y.SafeCopy(nil, []byte(key))
 	}
 	// Edge case: prefix is empty and no splits exist. In that case, we should have at least one
 	// keyRange output.
-	st.rangeCh <- keyRange{left: start}
+	st.rangeCh <- keyRange{left: start, keyComparator: st.db.opt.KeyComparator}
 	close(st.rangeCh)
 }
 

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -262,7 +262,7 @@ func (w *sortedWriter) createTable(data []byte) error {
 	if _, err := fd.Write(data); err != nil {
 		return err
 	}
-	tbl, err := table.OpenTable(fd, w.db.opt.TableLoadingMode, nil)
+	tbl, err := table.OpenTable(fd, w.db.opt.TableLoadingMode, w.db.opt.KeyComparator, nil)
 	if err != nil {
 		return err
 	}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -480,7 +480,7 @@ func TestMergingIterator(t *testing.T) {
 	defer tbl2.DecrRef()
 	it1 := tbl1.NewIterator(false)
 	it2 := NewConcatIterator([]*Table{tbl2}, false)
-	it := y.NewMergeIterator([]y.Iterator{it1, it2}, false)
+	it := y.NewMergeIterator([]y.Iterator{it1, it2}, new(y.DefaultKeyComparator), false)
 	defer it.Close()
 
 	it.Rewind()
@@ -520,7 +520,7 @@ func TestMergingIteratorReversed(t *testing.T) {
 	defer tbl2.DecrRef()
 	it1 := tbl1.NewIterator(true)
 	it2 := NewConcatIterator([]*Table{tbl2}, true)
-	it := y.NewMergeIterator([]y.Iterator{it1, it2}, true)
+	it := y.NewMergeIterator([]y.Iterator{it1, it2}, new(y.DefaultKeyComparator), true)
 	defer it.Close()
 
 	it.Rewind()
@@ -560,7 +560,7 @@ func TestMergingIteratorTakeOne(t *testing.T) {
 
 	it1 := NewConcatIterator([]*Table{t1}, false)
 	it2 := NewConcatIterator([]*Table{t2}, false)
-	it := y.NewMergeIterator([]y.Iterator{it1, it2}, false)
+	it := y.NewMergeIterator([]y.Iterator{it1, it2}, new(y.DefaultKeyComparator), false)
 	defer it.Close()
 
 	it.Rewind()
@@ -600,7 +600,7 @@ func TestMergingIteratorTakeTwo(t *testing.T) {
 
 	it1 := NewConcatIterator([]*Table{t1}, false)
 	it2 := NewConcatIterator([]*Table{t2}, false)
-	it := y.NewMergeIterator([]y.Iterator{it1, it2}, false)
+	it := y.NewMergeIterator([]y.Iterator{it1, it2}, new(y.DefaultKeyComparator), false)
 	defer it.Close()
 
 	it.Rewind()
@@ -720,7 +720,7 @@ func BenchmarkReadMerged(b *testing.B) {
 			for _, tbl := range tables {
 				iters = append(iters, tbl.NewIterator(false))
 			}
-			it := y.NewMergeIterator(iters, false)
+			it := y.NewMergeIterator(iters, new(y.DefaultKeyComparator), false)
 			defer it.Close()
 			for it.Rewind(); it.Valid(); it.Next() {
 			}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -79,7 +79,7 @@ func TestTableIterator(t *testing.T) {
 	for _, n := range []int{99, 100, 101} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			f := buildTestTable(t, "key", n)
-			table, err := OpenTable(f, options.MemoryMap, nil)
+			table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 			require.NoError(t, err)
 			defer table.DecrRef()
 			it := table.NewIterator(false)
@@ -101,7 +101,7 @@ func TestSeekToFirst(t *testing.T) {
 	for _, n := range []int{99, 100, 101, 199, 200, 250, 9999, 10000} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			f := buildTestTable(t, "key", n)
-			table, err := OpenTable(f, options.MemoryMap, nil)
+			table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 			require.NoError(t, err)
 			defer table.DecrRef()
 			it := table.NewIterator(false)
@@ -119,7 +119,7 @@ func TestSeekToLast(t *testing.T) {
 	for _, n := range []int{99, 100, 101, 199, 200, 250, 9999, 10000} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			f := buildTestTable(t, "key", n)
-			table, err := OpenTable(f, options.MemoryMap, nil)
+			table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 			require.NoError(t, err)
 			defer table.DecrRef()
 			it := table.NewIterator(false)
@@ -140,7 +140,7 @@ func TestSeekToLast(t *testing.T) {
 
 func TestSeek(t *testing.T) {
 	f := buildTestTable(t, "k", 10000)
-	table, err := OpenTable(f, options.MemoryMap, nil)
+	table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer table.DecrRef()
 
@@ -175,7 +175,7 @@ func TestSeek(t *testing.T) {
 
 func TestSeekForPrev(t *testing.T) {
 	f := buildTestTable(t, "k", 10000)
-	table, err := OpenTable(f, options.MemoryMap, nil)
+	table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer table.DecrRef()
 
@@ -213,7 +213,7 @@ func TestIterateFromStart(t *testing.T) {
 	for _, n := range []int{99, 100, 101, 199, 200, 250, 9999, 10000} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			f := buildTestTable(t, "key", n)
-			table, err := OpenTable(f, options.MemoryMap, nil)
+			table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 			require.NoError(t, err)
 			defer table.DecrRef()
 			ti := table.NewIterator(false)
@@ -240,7 +240,7 @@ func TestIterateFromEnd(t *testing.T) {
 	for _, n := range []int{99, 100, 101, 199, 200, 250, 9999, 10000} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			f := buildTestTable(t, "key", n)
-			table, err := OpenTable(f, options.FileIO, nil)
+			table, err := OpenTable(f, options.FileIO, new(y.DefaultKeyComparator), nil)
 			require.NoError(t, err)
 			defer table.DecrRef()
 			ti := table.NewIterator(false)
@@ -263,7 +263,7 @@ func TestIterateFromEnd(t *testing.T) {
 
 func TestTable(t *testing.T) {
 	f := buildTestTable(t, "key", 10000)
-	table, err := OpenTable(f, options.FileIO, nil)
+	table, err := OpenTable(f, options.FileIO, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer table.DecrRef()
 	ti := table.NewIterator(false)
@@ -290,7 +290,7 @@ func TestTable(t *testing.T) {
 
 func TestIterateBackAndForth(t *testing.T) {
 	f := buildTestTable(t, "key", 10000)
-	table, err := OpenTable(f, options.MemoryMap, nil)
+	table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer table.DecrRef()
 
@@ -331,7 +331,7 @@ func TestIterateBackAndForth(t *testing.T) {
 
 func TestUniIterator(t *testing.T) {
 	f := buildTestTable(t, "key", 10000)
-	table, err := OpenTable(f, options.MemoryMap, nil)
+	table, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer table.DecrRef()
 	{
@@ -367,7 +367,7 @@ func TestConcatIteratorOneTable(t *testing.T) {
 		{"k2", "a2"},
 	})
 
-	tbl, err := OpenTable(f, options.MemoryMap, nil)
+	tbl, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl.DecrRef()
 
@@ -387,13 +387,13 @@ func TestConcatIterator(t *testing.T) {
 	f := buildTestTable(t, "keya", 10000)
 	f2 := buildTestTable(t, "keyb", 10000)
 	f3 := buildTestTable(t, "keyc", 10000)
-	tbl, err := OpenTable(f, options.MemoryMap, nil)
+	tbl, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl.DecrRef()
-	tbl2, err := OpenTable(f2, options.LoadToRAM, nil)
+	tbl2, err := OpenTable(f2, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl2.DecrRef()
-	tbl3, err := OpenTable(f3, options.LoadToRAM, nil)
+	tbl3, err := OpenTable(f3, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl3.DecrRef()
 
@@ -472,10 +472,10 @@ func TestMergingIterator(t *testing.T) {
 		{"k1", "b1"},
 		{"k2", "b2"},
 	})
-	tbl1, err := OpenTable(f1, options.LoadToRAM, nil)
+	tbl1, err := OpenTable(f1, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl1.DecrRef()
-	tbl2, err := OpenTable(f2, options.LoadToRAM, nil)
+	tbl2, err := OpenTable(f2, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl2.DecrRef()
 	it1 := tbl1.NewIterator(false)
@@ -512,10 +512,10 @@ func TestMergingIteratorReversed(t *testing.T) {
 		{"k1", "b1"},
 		{"k2", "b2"},
 	})
-	tbl1, err := OpenTable(f1, options.LoadToRAM, nil)
+	tbl1, err := OpenTable(f1, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl1.DecrRef()
-	tbl2, err := OpenTable(f2, options.LoadToRAM, nil)
+	tbl2, err := OpenTable(f2, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer tbl2.DecrRef()
 	it1 := tbl1.NewIterator(true)
@@ -551,10 +551,10 @@ func TestMergingIteratorTakeOne(t *testing.T) {
 	})
 	f2 := buildTable(t, [][]string{})
 
-	t1, err := OpenTable(f1, options.LoadToRAM, nil)
+	t1, err := OpenTable(f1, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer t1.DecrRef()
-	t2, err := OpenTable(f2, options.LoadToRAM, nil)
+	t2, err := OpenTable(f2, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer t2.DecrRef()
 
@@ -591,10 +591,10 @@ func TestMergingIteratorTakeTwo(t *testing.T) {
 		{"k2", "a2"},
 	})
 
-	t1, err := OpenTable(f1, options.LoadToRAM, nil)
+	t1, err := OpenTable(f1, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer t1.DecrRef()
-	t2, err := OpenTable(f2, options.LoadToRAM, nil)
+	t2, err := OpenTable(f2, options.LoadToRAM, new(y.DefaultKeyComparator), nil)
 	require.NoError(t, err)
 	defer t2.DecrRef()
 
@@ -636,7 +636,7 @@ func BenchmarkRead(b *testing.B) {
 	}
 
 	f.Write(builder.Finish())
-	tbl, err := OpenTable(f, options.MemoryMap, nil)
+	tbl, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	y.Check(err)
 	defer tbl.DecrRef()
 
@@ -666,7 +666,7 @@ func BenchmarkReadAndBuild(b *testing.B) {
 	}
 
 	f.Write(builder.Finish())
-	tbl, err := OpenTable(f, options.MemoryMap, nil)
+	tbl, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 	y.Check(err)
 	defer tbl.DecrRef()
 
@@ -706,7 +706,7 @@ func BenchmarkReadMerged(b *testing.B) {
 			y.Check(builder.Add([]byte(k), y.ValueStruct{Value: []byte(v), Meta: 123, UserMeta: 0}))
 		}
 		f.Write(builder.Finish())
-		tbl, err := OpenTable(f, options.MemoryMap, nil)
+		tbl, err := OpenTable(f, options.MemoryMap, new(y.DefaultKeyComparator), nil)
 		y.Check(err)
 		tables = append(tables, tbl)
 		defer tbl.DecrRef()

--- a/util.go
+++ b/util.go
@@ -76,14 +76,14 @@ func (s *levelHandler) validate() error {
 			return errors.Errorf("Level %d, j=%d numTables=%d", s.level, j, numTables)
 		}
 
-		if y.CompareKeys(s.tables[j-1].Biggest(), s.tables[j].Smallest()) >= 0 {
+		if s.db.opt.KeyComparator.CompareKeys(s.tables[j-1].Biggest(), s.tables[j].Smallest()) >= 0 {
 			return errors.Errorf(
 				"Inter: Biggest(j-1) \n%s\n vs Smallest(j): \n%s\n: level=%d j=%d numTables=%d",
 				hex.Dump(s.tables[j-1].Biggest()), hex.Dump(s.tables[j].Smallest()),
 				s.level, j, numTables)
 		}
 
-		if y.CompareKeys(s.tables[j].Smallest(), s.tables[j].Biggest()) > 0 {
+		if s.db.opt.KeyComparator.CompareKeys(s.tables[j].Smallest(), s.tables[j].Biggest()) > 0 {
 			return errors.Errorf(
 				"Intra: %q vs %q: level=%d j=%d numTables=%d",
 				s.tables[j].Smallest(), s.tables[j].Biggest(), s.level, j, numTables)

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -105,29 +105,32 @@ type elem struct {
 	reversed bool
 }
 
-type elemHeap []*elem
+type elemHeap struct {
+	heap          []*elem
+	keyComparator KeyComparator
+}
 
-func (eh elemHeap) Len() int            { return len(eh) }
-func (eh elemHeap) Swap(i, j int)       { eh[i], eh[j] = eh[j], eh[i] }
-func (eh *elemHeap) Push(x interface{}) { *eh = append(*eh, x.(*elem)) }
+func (eh elemHeap) Len() int            { return len(eh.heap) }
+func (eh elemHeap) Swap(i, j int)       { eh.heap[i], eh.heap[j] = eh.heap[j], eh.heap[i] }
+func (eh *elemHeap) Push(x interface{}) { eh.heap = append(eh.heap, x.(*elem)) }
 func (eh *elemHeap) Pop() interface{} {
 	// Remove the last element, because Go has already swapped 0th elem <-> last.
-	old := *eh
+	old := eh.heap
 	n := len(old)
 	x := old[n-1]
-	*eh = old[0 : n-1]
+	eh.heap = old[0 : n-1]
 	return x
 }
 func (eh elemHeap) Less(i, j int) bool {
-	cmp := CompareKeys(eh[i].itr.Key(), eh[j].itr.Key())
+	cmp := eh.keyComparator.CompareKeys(eh.heap[i].itr.Key(), eh.heap[j].itr.Key())
 	if cmp < 0 {
-		return !eh[i].reversed
+		return !eh.heap[i].reversed
 	}
 	if cmp > 0 {
-		return eh[i].reversed
+		return eh.heap[i].reversed
 	}
 	// The keys are equal. In this case, lower nice take precedence. This is important.
-	return eh[i].nice < eh[j].nice
+	return eh.heap[i].nice < eh.heap[j].nice
 }
 
 // MergeIterator merges multiple iterators.

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -144,9 +144,10 @@ type MergeIterator struct {
 }
 
 // NewMergeIterator returns a new MergeIterator from a list of Iterators.
-func NewMergeIterator(iters []Iterator, reversed bool) *MergeIterator {
+func NewMergeIterator(iters []Iterator, comp KeyComparator, reversed bool) *MergeIterator {
 	m := &MergeIterator{all: iters, reversed: reversed}
-	m.h = make(elemHeap, 0, len(iters))
+	m.h.heap = make([]*elem, 0, len(iters))
+	m.h.keyComparator = comp
 	m.initHeap()
 	return m
 }
@@ -162,22 +163,22 @@ func (s *MergeIterator) storeKey(smallest Iterator) {
 // initHeap checks all iterators and initializes our heap and array of keys.
 // Whenever we reverse direction, we need to run this.
 func (s *MergeIterator) initHeap() {
-	s.h = s.h[:0]
+	s.h.heap = s.h.heap[:0]
 	for idx, itr := range s.all {
 		if !itr.Valid() {
 			continue
 		}
 		e := &elem{itr: itr, nice: idx, reversed: s.reversed}
-		s.h = append(s.h, e)
+		s.h.heap = append(s.h.heap, e)
 	}
 	heap.Init(&s.h)
-	for len(s.h) > 0 {
-		it := s.h[0].itr
+	for len(s.h.heap) > 0 {
+		it := s.h.heap[0].itr
 		if it == nil || !it.Valid() {
 			heap.Pop(&s.h)
 			continue
 		}
-		s.storeKey(s.h[0].itr)
+		s.storeKey(s.h.heap[0].itr)
 		break
 	}
 }
@@ -187,46 +188,46 @@ func (s *MergeIterator) Valid() bool {
 	if s == nil {
 		return false
 	}
-	if len(s.h) == 0 {
+	if len(s.h.heap) == 0 {
 		return false
 	}
-	return s.h[0].itr.Valid()
+	return s.h.heap[0].itr.Valid()
 }
 
 // Key returns the key associated with the current iterator
 func (s *MergeIterator) Key() []byte {
-	if len(s.h) == 0 {
+	if len(s.h.heap) == 0 {
 		return nil
 	}
-	return s.h[0].itr.Key()
+	return s.h.heap[0].itr.Key()
 }
 
 // Value returns the value associated with the iterator.
 func (s *MergeIterator) Value() ValueStruct {
-	if len(s.h) == 0 {
+	if len(s.h.heap) == 0 {
 		return ValueStruct{}
 	}
-	return s.h[0].itr.Value()
+	return s.h.heap[0].itr.Value()
 }
 
 // Next returns the next element. If it is the same as the current key, ignore it.
 func (s *MergeIterator) Next() {
-	if len(s.h) == 0 {
+	if len(s.h.heap) == 0 {
 		return
 	}
 
-	smallest := s.h[0].itr
+	smallest := s.h.heap[0].itr
 	smallest.Next()
 
-	for len(s.h) > 0 {
-		smallest = s.h[0].itr
+	for len(s.h.heap) > 0 {
+		smallest = s.h.heap[0].itr
 		if !smallest.Valid() {
 			heap.Pop(&s.h)
 			continue
 		}
 
 		heap.Fix(&s.h, 0)
-		smallest = s.h[0].itr
+		smallest = s.h.heap[0].itr
 		if smallest.Valid() {
 			if !bytes.Equal(smallest.Key(), s.curKey) {
 				break

--- a/y/y.go
+++ b/y/y.go
@@ -51,11 +51,6 @@ var (
 
 	// Dummy channel for nil closers.
 	dummyCloserChan = make(chan struct{})
-
-	// CompareKeys returns an integer comparing two keys.
-	// The result will be 0 if key1==key2, negative if key1 < key2, and positive if key1 > key2.
-	// Defaults to CompareKeysWithTimestamp.
-	CompareKeys = CompareKeysWithTimestamp
 )
 
 // KeyComparator returns an integer comparing two keys.
@@ -132,11 +127,14 @@ func ParseTs(key []byte) uint64 {
 	return math.MaxUint64 - binary.BigEndian.Uint64(key[len(key)-8:])
 }
 
-// CompareKeysWithTimestamp checks the key without timestamp and checks the timestamp if keyNoTs
+// DefaultKeyComparator is the used as the default KeyComparator for a given Badger instance.
+type DefaultKeyComparator struct{}
+
+// CompareKeys checks the key without timestamp and checks the timestamp if keyNoTs
 // is same.
 // a<timestamp> would be sorted higher than aa<timestamp> if we use bytes.compare
 // All keys should have timestamp.
-func CompareKeysWithTimestamp(key1, key2 []byte) int {
+func (DefaultKeyComparator) CompareKeys(key1, key2 []byte) int {
 	AssertTrue(len(key1) > 8 && len(key2) > 8)
 	if cmp := bytes.Compare(key1[:len(key1)-8], key2[:len(key2)-8]); cmp != 0 {
 		return cmp

--- a/y/y.go
+++ b/y/y.go
@@ -51,6 +51,11 @@ var (
 
 	// Dummy channel for nil closers.
 	dummyCloserChan = make(chan struct{})
+
+	// CompareKeys returns an integer comparing two keys.
+	// The result will be 0 if key1==keys2, -1 if key1 < key2, and +1 if key1 > key2.
+	// Defaults to CompareKeysWithTimestamp.
+	CompareKeys = CompareKeysWithTimestamp
 )
 
 // OpenExistingFile opens an existing file, errors if it doesn't exist.
@@ -121,11 +126,11 @@ func ParseTs(key []byte) uint64 {
 	return math.MaxUint64 - binary.BigEndian.Uint64(key[len(key)-8:])
 }
 
-// CompareKeys checks the key without timestamp and checks the timestamp if keyNoTs
+// CompareKeysWithTimestamp checks the key without timestamp and checks the timestamp if keyNoTs
 // is same.
 // a<timestamp> would be sorted higher than aa<timestamp> if we use bytes.compare
 // All keys should have timestamp.
-func CompareKeys(key1, key2 []byte) int {
+func CompareKeysWithTimestamp(key1, key2 []byte) int {
 	AssertTrue(len(key1) > 8 && len(key2) > 8)
 	if cmp := bytes.Compare(key1[:len(key1)-8], key2[:len(key2)-8]); cmp != 0 {
 		return cmp

--- a/y/y.go
+++ b/y/y.go
@@ -58,6 +58,12 @@ var (
 	CompareKeys = CompareKeysWithTimestamp
 )
 
+// KeyComparator returns an integer comparing two keys.
+// The result will be 0 if key1==key2, negative if key1 < key2, and positive if key1 > key2.
+type KeyComparator interface {
+	CompareKeys(key1 []byte, key2 []byte) int
+}
+
 // OpenExistingFile opens an existing file, errors if it doesn't exist.
 func OpenExistingFile(filename string, flags uint32) (*os.File, error) {
 	openFlags := os.O_RDWR

--- a/y/y.go
+++ b/y/y.go
@@ -53,7 +53,7 @@ var (
 	dummyCloserChan = make(chan struct{})
 
 	// CompareKeys returns an integer comparing two keys.
-	// The result will be 0 if key1==keys2, negative if key1 < key2, and positive if key1 > key2.
+	// The result will be 0 if key1==key2, negative if key1 < key2, and positive if key1 > key2.
 	// Defaults to CompareKeysWithTimestamp.
 	CompareKeys = CompareKeysWithTimestamp
 )

--- a/y/y.go
+++ b/y/y.go
@@ -53,7 +53,7 @@ var (
 	dummyCloserChan = make(chan struct{})
 
 	// CompareKeys returns an integer comparing two keys.
-	// The result will be 0 if key1==keys2, -1 if key1 < key2, and +1 if key1 > key2.
+	// The result will be 0 if key1==keys2, negative if key1 < key2, and positive if key1 > key2.
 	// Defaults to CompareKeysWithTimestamp.
 	CompareKeys = CompareKeysWithTimestamp
 )


### PR DESCRIPTION
This PR adds a global variable in the `y` package called `CompareKey` that allows users to change the behaviour of the key comparator used to decide the key ordering.
I first wanted to provide that as an option but given the locations where the original `CompareKey` function is used, it would have been difficult to pass the option everywhere.
This solution seems to be the cheapest in terms of changes, the tradeoff being allowing only one key comparator function at a time for all Badger instances.
Let me know if you prefer an other way.

Fixes #776

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/815)
<!-- Reviewable:end -->
