### PR TITLE
Add test to verify StreamWriter Oracle reinitialization

### DIFF
--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -18,6 +18,7 @@ package badger
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"math/rand"
 	"testing"
@@ -215,4 +216,36 @@ func TestStreamWriter3(t *testing.T) {
 			require.Nil(t, err, "error should be nil while iterating")
 		})
 	}
+}
+
+// After inserting all data from streams, StreamWriter reinitializes Oracle and updates its nextTs
+// to maxVersion found in all entries inserted(if db is running in non managed mode). It also
+// updates Oracle's txnMark and readMark. If Oracle is not reinitialized, it might cause issue
+// while updating readMark and txnMark when its nextTs is ahead of maxVersion. This tests verifies
+// Oracle reinitialization is happening. Try commenting line 171 in stream_writer.go with code
+// (sw.db.orc = newOracle(sw.db.opt), this test should fail.
+func TestStreamWriter4(t *testing.T) {
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		// first insert some entries in db
+		for i := 0; i < 10; i++ {
+			err := db.Update(func(txn *Txn) error {
+				key := []byte(fmt.Sprintf("key-%d", i))
+				value := []byte(fmt.Sprintf("val-%d", i))
+				return txn.Set(key, value)
+			})
+			require.NoError(t, err, "error while updating db")
+		}
+
+		list := &pb.KVList{}
+		list.Kv = append(list.Kv, &pb.KV{
+			Key:     []byte("key-1"),
+			Value:   []byte("value-1"),
+			Version: 1,
+		})
+
+		sw := db.NewStreamWriter()
+		require.NoError(t, sw.Prepare(), "sw.Prepare() failed")
+		require.NoError(t, sw.Write(list), "sw.Write() failed")
+		require.NoError(t, sw.Flush(), "sw.Flush() failed")
+	})
 }


### PR DESCRIPTION
This test verifies Oracle reinitialization, once stream
writer is done writing all entries. Reinitialization is
required when db is running in non managed mode and we
need to update Oracle's nextTs to maxVersion found in
all entries inserted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/818)
<!-- Reviewable:end -->
