### PR TITLE
Do not open value log in RW mode if Truncate is false

### DIFF
--- a/value.go
+++ b/value.go
@@ -707,11 +707,15 @@ func errFile(err error, path string, msg string) error {
 }
 
 func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) error {
-	// We should open the file in RW mode, so it can be truncated.
 	var err error
-	lf.fd, err = os.OpenFile(lf.path, os.O_RDWR, 0)
+	mode := os.O_RDONLY
+	if vlog.opt.Truncate {
+		// We should open the file in RW mode, so it can be truncated.
+		mode = os.O_RDWR
+	}
+	lf.fd, err = os.OpenFile(lf.path, mode, 0)
 	if err != nil {
-		return errFile(err, lf.path, "Open file in RW mode")
+		return errFile(err, lf.path, "Open file")
 	}
 	defer lf.fd.Close()
 


### PR DESCRIPTION
When opening a database, value log files are always opened in `read-write` mode.
This happens even if the `Truncate` option is set to `false` in which case we do not plan to do any truncation.
This prevents use cases where a database is generated once and then shared system wide (without write permissions for everyone) or even placed on a `read-only` file system to be used repeatedly for lookups only.

This commit changes the mode value log files are opened in depending on the `Truncate` option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/821)
<!-- Reviewable:end -->
