### PR TITLE
Breaking Change: Introduce new APIs for Entry creation

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -445,8 +445,8 @@ func TestBackupLoadIncremental(t *testing.T) {
 		// pick 5 items to mark as expired.
 		err = db1.Update(func(txn *Txn) error {
 			for _, i := range (ints)[10:15] {
-				if err := txn.SetEntry(
-					NewEntry(entries[i].Key, entries[i].Value).WithTTL(-time.Hour)); err != nil {
+				entry := NewEntry(entries[i].Key, entries[i].Value).WithTTL(-time.Hour)
+				if err := txn.SetEntry(entry); err != nil {
 					return err
 				}
 				updates[i] = bitDelete // expired
@@ -460,8 +460,8 @@ func TestBackupLoadIncremental(t *testing.T) {
 		// pick 5 items to mark as discard.
 		err = db1.Update(func(txn *Txn) error {
 			for _, i := range ints[15:20] {
-				if err := txn.SetEntry(NewEntry(entries[i].Key, entries[i].Value).
-					WithDiscard()); err != nil {
+				entry := NewEntry(entries[i].Key, entries[i].Value).WithDiscard()
+				if err := txn.SetEntry(entry); err != nil {
 					return err
 				}
 				updates[i] = bitDiscardEarlierVersions

--- a/backup_test.go
+++ b/backup_test.go
@@ -52,7 +52,7 @@ func TestBackupRestore1(t *testing.T) {
 
 	err = db.Update(func(txn *Txn) error {
 		e := entries[0]
-		err := txn.SetWithMeta(e.key, e.val, e.userMeta)
+		err := txn.SetEntry(NewEntry(e.key, e.val).WithMeta(e.userMeta))
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ func TestBackupRestore1(t *testing.T) {
 
 	err = db.Update(func(txn *Txn) error {
 		e := entries[1]
-		err := txn.SetWithMeta(e.key, e.val, e.userMeta)
+		err := txn.SetEntry(NewEntry(e.key, e.val).WithMeta(e.userMeta))
 		if err != nil {
 			return err
 		}
@@ -140,20 +140,20 @@ func TestBackupRestore2(t *testing.T) {
 	rawValue := []byte("NotLongValue")
 	N := byte(251)
 	err = db1.Update(func(tx *Txn) error {
-		if err := tx.Set(key1, rawValue); err != nil {
+		if err := tx.SetEntry(NewEntry(key1, rawValue)); err != nil {
 			return err
 		}
-		return tx.Set(key2, rawValue)
+		return tx.SetEntry(NewEntry(key2, rawValue))
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i := byte(1); i < N; i++ {
 		err = db1.Update(func(tx *Txn) error {
-			if err := tx.Set(append(key1, i), rawValue); err != nil {
+			if err := tx.SetEntry(NewEntry(append(key1, i), rawValue)); err != nil {
 				return err
 			}
-			return tx.Set(append(key2, i), rawValue)
+			return tx.SetEntry(NewEntry(append(key2, i), rawValue))
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -204,10 +204,10 @@ func TestBackupRestore2(t *testing.T) {
 
 	for i := byte(1); i < N; i++ {
 		err = db2.Update(func(tx *Txn) error {
-			if err := tx.Set(append(key1, i), rawValue); err != nil {
+			if err := tx.SetEntry(NewEntry(append(key1, i), rawValue)); err != nil {
 				return err
 			}
-			return tx.Set(append(key2, i), rawValue)
+			return tx.SetEntry(NewEntry(append(key2, i), rawValue))
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -278,7 +278,7 @@ func populateEntries(db *DB, entries []*pb.KV) error {
 	return db.Update(func(txn *Txn) error {
 		var err error
 		for i, e := range entries {
-			if err = txn.Set(e.Key, e.Value); err != nil {
+			if err = txn.SetEntry(NewEntry(e.Key, e.Value)); err != nil {
 				return err
 			}
 			entries[i].Version = 1
@@ -445,8 +445,8 @@ func TestBackupLoadIncremental(t *testing.T) {
 		// pick 5 items to mark as expired.
 		err = db1.Update(func(txn *Txn) error {
 			for _, i := range (ints)[10:15] {
-				if err := txn.SetWithTTL(
-					entries[i].Key, entries[i].Value, -time.Hour); err != nil {
+				if err := txn.SetEntry(
+					NewEntry(entries[i].Key, entries[i].Value).WithTTL(-time.Hour)); err != nil {
 					return err
 				}
 				updates[i] = bitDelete // expired
@@ -460,7 +460,7 @@ func TestBackupLoadIncremental(t *testing.T) {
 		// pick 5 items to mark as discard.
 		err = db1.Update(func(txn *Txn) error {
 			for _, i := range ints[15:20] {
-				if err := txn.SetWithDiscard(entries[i].Key, entries[i].Value, 0); err != nil {
+				if err := txn.SetEntry(NewEntry(entries[i].Key, entries[i].Value).WithDiscard()); err != nil {
 					return err
 				}
 				updates[i] = bitDiscardEarlierVersions

--- a/backup_test.go
+++ b/backup_test.go
@@ -460,7 +460,8 @@ func TestBackupLoadIncremental(t *testing.T) {
 		// pick 5 items to mark as discard.
 		err = db1.Update(func(txn *Txn) error {
 			for _, i := range ints[15:20] {
-				if err := txn.SetEntry(NewEntry(entries[i].Key, entries[i].Value).WithDiscard()); err != nil {
+				if err := txn.SetEntry(NewEntry(entries[i].Key, entries[i].Value).
+					WithDiscard()); err != nil {
 					return err
 				}
 				updates[i] = bitDiscardEarlierVersions

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -131,7 +131,7 @@ func getBalance(txn *badger.Txn, account int) (uint64, error) {
 }
 
 func putBalance(txn *badger.Txn, account int, bal uint64) error {
-	return txn.Set(key(account), toSlice(bal))
+	return txn.SetEntry(badger.NewEntry(key(account), toSlice(bal)))
 }
 
 func min(a, b uint64) uint64 {

--- a/db.go
+++ b/db.go
@@ -1104,7 +1104,7 @@ func (seq *Sequence) Release() error {
 	err := seq.db.Update(func(txn *Txn) error {
 		var buf [8]byte
 		binary.BigEndian.PutUint64(buf[:], seq.next)
-		return txn.Set(seq.key, buf[:])
+		return txn.SetEntry(NewEntry(seq.key, buf[:]))
 	})
 	if err != nil {
 		return err
@@ -1134,7 +1134,7 @@ func (seq *Sequence) updateLease() error {
 		lease := seq.next + seq.bandwidth
 		var buf [8]byte
 		binary.BigEndian.PutUint64(buf[:], lease)
-		if err = txn.Set(seq.key, buf[:]); err != nil {
+		if err = txn.SetEntry(NewEntry(seq.key, buf[:])); err != nil {
 			return err
 		}
 		seq.leased = lease

--- a/db2_test.go
+++ b/db2_test.go
@@ -206,8 +206,8 @@ func TestBigKeyValuePairs(t *testing.T) {
 
 		txn := db.NewTransaction(true)
 		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.SetEntry(NewEntry(bigK, small)))
-		require.Regexp(t, regexp.MustCompile("Value.*exceeded"), txn.SetEntry(
-			NewEntry(small, bigV)))
+		require.Regexp(t, regexp.MustCompile("Value.*exceeded"),
+			txn.SetEntry(NewEntry(small, bigV)))
 
 		require.NoError(t, txn.SetEntry(NewEntry(small, small)))
 		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.SetEntry(NewEntry(bigK, bigV)))

--- a/db2_test.go
+++ b/db2_test.go
@@ -54,7 +54,7 @@ func TestTruncateVlogWithClose(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.Update(func(txn *Txn) error {
-		return txn.Set(key(0), data(4055))
+		return txn.SetEntry(NewEntry(key(0), data(4055)))
 	})
 	require.NoError(t, err)
 
@@ -67,7 +67,7 @@ func TestTruncateVlogWithClose(t *testing.T) {
 	require.NoError(t, err)
 	for i := 0; i < 32; i++ {
 		err := db.Update(func(txn *Txn) error {
-			return txn.Set(key(i), data(10))
+			return txn.SetEntry(NewEntry(key(i), data(10)))
 		})
 		require.NoError(t, err)
 	}
@@ -125,7 +125,7 @@ func TestTruncateVlogNoClose(t *testing.T) {
 	}
 	data := fmt.Sprintf("%4055d", 1)
 	err = kv.Update(func(txn *Txn) error {
-		return txn.Set([]byte(key(0)), []byte(data))
+		return txn.SetEntry(NewEntry([]byte(key(0)), []byte(data)))
 	})
 	require.NoError(t, err)
 }
@@ -147,7 +147,7 @@ func TestTruncateVlogNoClose2(t *testing.T) {
 	data := fmt.Sprintf("%10d", 1)
 	for i := 32; i < 64; i++ {
 		err := kv.Update(func(txn *Txn) error {
-			return txn.Set([]byte(key(i)), []byte(data))
+			return txn.SetEntry(NewEntry([]byte(key(i)), []byte(data)))
 		})
 		require.NoError(t, err)
 	}
@@ -205,11 +205,11 @@ func TestBigKeyValuePairs(t *testing.T) {
 		small := make([]byte, 65000)
 
 		txn := db.NewTransaction(true)
-		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.Set(bigK, small))
-		require.Regexp(t, regexp.MustCompile("Value.*exceeded"), txn.Set(small, bigV))
+		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.SetEntry(NewEntry(bigK, small)))
+		require.Regexp(t, regexp.MustCompile("Value.*exceeded"), txn.SetEntry(NewEntry(small, bigV)))
 
-		require.NoError(t, txn.Set(small, small))
-		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.Set(bigK, bigV))
+		require.NoError(t, txn.SetEntry(NewEntry(small, small)))
+		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.SetEntry(NewEntry(bigK, bigV)))
 
 		require.NoError(t, db.View(func(txn *Txn) error {
 			_, err := txn.Get(small)
@@ -225,7 +225,7 @@ func TestBigKeyValuePairs(t *testing.T) {
 
 		saveByKey := func(key string, value []byte) error {
 			return db.Update(func(txn *Txn) error {
-				return txn.Set([]byte(key), value)
+				return txn.SetEntry(NewEntry([]byte(key), value))
 			})
 		}
 
@@ -297,12 +297,12 @@ func TestPushValueLogLimit(t *testing.T) {
 			if i == 4 {
 				v := make([]byte, 2<<30)
 				err := db.Update(func(txn *Txn) error {
-					return txn.Set([]byte(key(i)), v)
+					return txn.SetEntry(NewEntry([]byte(key(i)), v))
 				})
 				require.NoError(t, err)
 			} else {
 				err := db.Update(func(txn *Txn) error {
-					return txn.Set([]byte(key(i)), data)
+					return txn.SetEntry(NewEntry([]byte(key(i)), data))
 				})
 				require.NoError(t, err)
 			}

--- a/db2_test.go
+++ b/db2_test.go
@@ -206,7 +206,8 @@ func TestBigKeyValuePairs(t *testing.T) {
 
 		txn := db.NewTransaction(true)
 		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.SetEntry(NewEntry(bigK, small)))
-		require.Regexp(t, regexp.MustCompile("Value.*exceeded"), txn.SetEntry(NewEntry(small, bigV)))
+		require.Regexp(t, regexp.MustCompile("Value.*exceeded"), txn.SetEntry(
+			NewEntry(small, bigV)))
 
 		require.NoError(t, txn.SetEntry(NewEntry(small, small)))
 		require.Regexp(t, regexp.MustCompile("Key.*exceeded"), txn.SetEntry(NewEntry(bigK, bigV)))

--- a/db_test.go
+++ b/db_test.go
@@ -127,9 +127,8 @@ func TestUpdateAndView(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		err := db.Update(func(txn *Txn) error {
 			for i := 0; i < 10; i++ {
-				err := txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)),
-					[]byte(fmt.Sprintf("val%d", i))))
-				if err != nil {
+				entry := NewEntry([]byte(fmt.Sprintf("key%d", i)), []byte(fmt.Sprintf("val%d", i)))
+				if err := txn.SetEntry(entry); err != nil {
 					return err
 				}
 			}
@@ -1139,7 +1138,7 @@ func TestLargeKeys(t *testing.T) {
 					t.Fatalf("failed with: %s", err)
 				}
 			} else if !kv.success {
-				t.Fatal("insertion should have failed")
+				t.Fatal("insertion should fail")
 			}
 		}
 		if err := tx.Commit(); err != nil {
@@ -1740,8 +1739,8 @@ func TestNoCrash(t *testing.T) {
 	// entering 100 entries will generate 100 vlog files
 	for i := 0; i < 100; i++ {
 		err := db.Update(func(txn *Txn) error {
-			return txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key-%d", i)),
-				[]byte(fmt.Sprintf("val-%d", i))))
+			entry := NewEntry([]byte(fmt.Sprintf("key-%d", i)), []byte(fmt.Sprintf("val-%d", i)))
+			return txn.SetEntry(entry)
 		})
 		require.NoError(t, err, "update to db failed")
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -87,7 +87,7 @@ func getItemValue(t *testing.T, item *Item) (val []byte) {
 
 func txnSet(t *testing.T, kv *DB, key []byte, val []byte, meta byte) {
 	txn := kv.NewTransaction(true)
-	require.NoError(t, txn.SetWithMeta(key, val, meta))
+	require.NoError(t, txn.SetEntry(NewEntry(key, val).WithMeta(meta)))
 	require.NoError(t, txn.Commit())
 }
 
@@ -127,7 +127,8 @@ func TestUpdateAndView(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		err := db.Update(func(txn *Txn) error {
 			for i := 0; i < 10; i++ {
-				err := txn.Set([]byte(fmt.Sprintf("key%d", i)), []byte(fmt.Sprintf("val%d", i)))
+				err := txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)),
+					[]byte(fmt.Sprintf("val%d", i))))
 				if err != nil {
 					return err
 				}
@@ -281,7 +282,7 @@ func TestTxnTooBig(t *testing.T) {
 		n := 1000
 		txn := db.NewTransaction(true)
 		for i := 0; i < n; {
-			if err := txn.Set(data(i), data(i)); err != nil {
+			if err := txn.SetEntry(NewEntry(data(i), data(i))); err != nil {
 				require.NoError(t, txn.Commit())
 				txn = db.NewTransaction(true)
 			} else {
@@ -325,7 +326,7 @@ func TestForceCompactL0(t *testing.T) {
 		version := uint64(i)
 		txn := db.NewTransactionAt(version, true)
 		for j := 0; j < m; j++ {
-			require.NoError(t, txn.Set(data(j), v))
+			require.NoError(t, txn.SetEntry(NewEntry(data(j), v)))
 		}
 		require.NoError(t, txn.CommitAt(version+1, nil))
 	}
@@ -352,7 +353,7 @@ func TestGetMore(t *testing.T) {
 		for i := 0; i < n; i += m {
 			txn := db.NewTransaction(true)
 			for j := i; j < i+m && j < n; j++ {
-				require.NoError(t, txn.Set(data(j), data(j)))
+				require.NoError(t, txn.SetEntry(NewEntry(data(j), data(j))))
 			}
 			require.NoError(t, txn.Commit())
 		}
@@ -372,9 +373,9 @@ func TestGetMore(t *testing.T) {
 		for i := 0; i < n; i += m {
 			txn := db.NewTransaction(true)
 			for j := i; j < i+m && j < n; j++ {
-				require.NoError(t, txn.Set(data(j),
+				require.NoError(t, txn.SetEntry(NewEntry(data(j),
 					// Use a long value that will certainly exceed value threshold.
-					[]byte(fmt.Sprintf("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz%9d", j))))
+					[]byte(fmt.Sprintf("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz%9d", j)))))
 			}
 			require.NoError(t, txn.Commit())
 		}
@@ -451,8 +452,8 @@ func TestExistsMore(t *testing.T) {
 			}
 			txn := db.NewTransaction(true)
 			for j := i; j < i+m && j < n; j++ {
-				require.NoError(t, txn.Set([]byte(fmt.Sprintf("%09d", j)),
-					[]byte(fmt.Sprintf("%09d", j))))
+				require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("%09d", j)),
+					[]byte(fmt.Sprintf("%09d", j)))))
 			}
 			require.NoError(t, txn.Commit())
 		}
@@ -705,7 +706,7 @@ func TestIterateParallel(t *testing.T) {
 		for i := 0; i < N; i++ {
 			wg.Add(1)
 			txn := db.NewTransaction(true)
-			require.NoError(t, txn.Set(key(i), []byte("1000")))
+			require.NoError(t, txn.SetEntry(NewEntry(key(i), []byte("1000"))))
 			txns = append(txns, txn)
 		}
 		for _, txn := range txns {
@@ -784,13 +785,13 @@ func TestPidFile(t *testing.T) {
 func TestInvalidKey(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		err := db.Update(func(txn *Txn) error {
-			err := txn.Set([]byte("!badger!head"), nil)
+			err := txn.SetEntry(NewEntry([]byte("!badger!head"), nil))
 			require.Equal(t, ErrInvalidKey, err)
 
-			err = txn.Set([]byte("!badger!"), nil)
+			err = txn.SetEntry(NewEntry([]byte("!badger!"), nil))
 			require.Equal(t, ErrInvalidKey, err)
 
-			err = txn.Set([]byte("!badger"), []byte("BadgerDB"))
+			err = txn.SetEntry(NewEntry([]byte("!badger"), []byte("BadgerDB")))
 			require.NoError(t, err)
 			return err
 		})
@@ -874,7 +875,7 @@ func TestSetIfAbsentAsync(t *testing.T) {
 		txn := kv.NewTransaction(true)
 		_, err = txn.Get(bkey(i))
 		require.Equal(t, ErrKeyNotFound, err)
-		require.NoError(t, txn.SetWithMeta(bkey(i), nil, byte(i%127)))
+		require.NoError(t, txn.SetEntry(NewEntry(bkey(i), nil).WithMeta(byte(i%127))))
 		txn.CommitWith(f)
 	}
 
@@ -950,7 +951,7 @@ func TestDiscardVersionsBelow(t *testing.T) {
 		// Write 4 versions of the same key
 		for i := 0; i < 4; i++ {
 			err := db.Update(func(txn *Txn) error {
-				return txn.Set([]byte("answer"), []byte(fmt.Sprintf("%d", i)))
+				return txn.SetEntry(NewEntry([]byte("answer"), []byte(fmt.Sprintf("%d", i))))
 			})
 			require.NoError(t, err)
 		}
@@ -978,7 +979,7 @@ func TestDiscardVersionsBelow(t *testing.T) {
 
 		// Set new version and discard older ones.
 		err := db.Update(func(txn *Txn) error {
-			return txn.SetWithDiscard([]byte("answer"), []byte("5"), 0)
+			return txn.SetEntry(NewEntry([]byte("answer"), []byte("5")).WithDiscard())
 		})
 		require.NoError(t, err)
 
@@ -1006,12 +1007,12 @@ func TestExpiry(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		// Write two keys, one with a TTL
 		err := db.Update(func(txn *Txn) error {
-			return txn.Set([]byte("answer1"), []byte("42"))
+			return txn.SetEntry(NewEntry([]byte("answer1"), []byte("42")))
 		})
 		require.NoError(t, err)
 
 		err = db.Update(func(txn *Txn) error {
-			return txn.SetWithTTL([]byte("answer2"), []byte("43"), 1*time.Second)
+			return txn.SetEntry(NewEntry([]byte("answer2"), []byte("43")).WithTTL(1 * time.Second))
 		})
 		require.NoError(t, err)
 
@@ -1060,7 +1061,7 @@ func TestExpiryImproperDBClose(t *testing.T) {
 	dur := 1 * time.Hour
 	expiryTime := uint64(time.Now().Add(dur).Unix())
 	err = db0.Update(func(txn *Txn) error {
-		err = txn.SetWithTTL([]byte("test_key"), []byte("test_value"), dur)
+		err = txn.SetEntry(NewEntry([]byte("test_key"), []byte("test_value")).WithTTL(dur))
 		require.NoError(t, err)
 		return nil
 	})
@@ -1131,7 +1132,7 @@ func TestLargeKeys(t *testing.T) {
 
 			v := make([]byte, len(kv.value))
 			copy(v, kv.value)
-			if err := tx.Set(k, v); err != nil {
+			if err := tx.SetEntry(NewEntry(k, v)); err != nil {
 				// Skip over this record.
 			}
 		}
@@ -1175,7 +1176,7 @@ func TestGetSetDeadlock(t *testing.T) {
 	key := []byte("key1")
 	require.NoError(t, db.Update(func(txn *Txn) error {
 		rand.Read(val)
-		require.NoError(t, txn.Set(key, val))
+		require.NoError(t, txn.SetEntry(NewEntry(key, val)))
 		return nil
 	}))
 
@@ -1189,8 +1190,8 @@ func TestGetSetDeadlock(t *testing.T) {
 			require.NoError(t, err)
 
 			rand.Read(val)
-			require.NoError(t, txn.Set(key, val))
-			require.NoError(t, txn.Set([]byte("key2"), val))
+			require.NoError(t, txn.SetEntry(NewEntry(key, val)))
+			require.NoError(t, txn.SetEntry(NewEntry([]byte("key2"), val)))
 			return nil
 		})
 		done <- true
@@ -1230,7 +1231,7 @@ func TestWriteDeadlock(t *testing.T) {
 		for i := 0; i < 1500; i++ {
 			key := fmt.Sprintf("%d", i)
 			rand.Read(val)
-			require.NoError(t, txn.Set([]byte(key), val))
+			require.NoError(t, txn.SetEntry(NewEntry([]byte(key), val)))
 			print(&count)
 		}
 		return nil
@@ -1254,7 +1255,7 @@ func TestWriteDeadlock(t *testing.T) {
 
 			key := y.Copy(item.Key())
 			rand.Read(val)
-			require.NoError(t, txn.Set(key, val))
+			require.NoError(t, txn.SetEntry(NewEntry(key, val)))
 			print(&count)
 		}
 		return nil
@@ -1421,7 +1422,7 @@ func TestReadOnly(t *testing.T) {
 
 	// Attempt to set a value on a read-only connection
 	txn := kv1.NewTransaction(true)
-	err = txn.SetWithMeta([]byte("key"), []byte("value"), 0x00)
+	err = txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "No sets or deletes are allowed in a read-only transaction")
 	err = txn.Commit()
@@ -1473,7 +1474,7 @@ func TestMinReadTs(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		for i := 0; i < 10; i++ {
 			require.NoError(t, db.Update(func(txn *Txn) error {
-				return txn.Set([]byte("x"), []byte("y"))
+				return txn.SetEntry(NewEntry([]byte("x"), []byte("y")))
 			}))
 		}
 		time.Sleep(time.Millisecond)
@@ -1487,7 +1488,7 @@ func TestMinReadTs(t *testing.T) {
 		readTxn := db.NewTransaction(false)
 		for i := 0; i < 10; i++ {
 			require.NoError(t, db.Update(func(txn *Txn) error {
-				return txn.Set([]byte("x"), []byte("y"))
+				return txn.SetEntry(NewEntry([]byte("x"), []byte("y")))
 			}))
 		}
 		require.Equal(t, uint64(20), db.orc.readTs())
@@ -1535,7 +1536,7 @@ func TestGoroutineLeak(t *testing.T) {
 			}()
 			subWg.Wait()
 			err := db.Update(func(txn *Txn) error {
-				return txn.Set([]byte("key"), []byte("value"))
+				return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
 			})
 			require.NoError(t, err)
 			wg.Wait()
@@ -1573,7 +1574,7 @@ func ExampleOpen() {
 	}
 
 	txn := db.NewTransaction(true) // Read-write txn
-	err = txn.Set([]byte("key"), []byte("value"))
+	err = txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1633,7 +1634,7 @@ func ExampleTxn_NewIterator() {
 	// Fill in 1000 items
 	n := 1000
 	for i := 0; i < n; i++ {
-		err := txn.Set(bkey(i), bval(i))
+		err := txn.SetEntry(NewEntry(bkey(i), bval(i)))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -1703,7 +1704,7 @@ func TestSyncForRace(t *testing.T) {
 	rand.Read(v[:rand.Intn(sz)])
 	txn := db.NewTransaction(true)
 	for i := 0; i < 10000; i++ {
-		require.NoError(t, txn.Set([]byte(fmt.Sprintf("key%d", i)), v))
+		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))
 		if i%3 == 0 {
 			require.NoError(t, txn.Commit())
 			txn = db.NewTransaction(true)
@@ -1733,7 +1734,8 @@ func TestNoCrash(t *testing.T) {
 	// entering 100 entries will generate 100 vlog files
 	for i := 0; i < 100; i++ {
 		err := db.Update(func(txn *Txn) error {
-			return txn.Set([]byte(fmt.Sprintf("key-%d", i)), []byte(fmt.Sprintf("val-%d", i)))
+			return txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key-%d", i)),
+				[]byte(fmt.Sprintf("val-%d", i))))
 		})
 		require.NoError(t, err, "update to db failed")
 	}
@@ -1765,7 +1767,8 @@ func TestForceFlushMemtable(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		err = db.Update(func(txn *Txn) error {
-			return txn.Set([]byte(fmt.Sprintf("key-%d", i)), []byte(fmt.Sprintf("value-%d", i)))
+			return txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key-%d", i)),
+				[]byte(fmt.Sprintf("value-%d", i))))
 		})
 		require.NoError(t, err, "unable to set key and value")
 	}

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -28,7 +28,7 @@ func TestBuildKeyValueSizeHistogram(t *testing.T) {
 			entries := int64(40)
 			err := db.Update(func(txn *Txn) error {
 				for i := int64(0); i < entries; i++ {
-					err := txn.Set([]byte(string(i)), []byte("B"))
+					err := txn.SetEntry(NewEntry([]byte(string(i)), []byte("B")))
 					if err != nil {
 						return err
 					}
@@ -64,15 +64,15 @@ func TestBuildKeyValueSizeHistogram(t *testing.T) {
 		runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 			entries := int64(3)
 			err := db.Update(func(txn *Txn) error {
-				if err := txn.Set([]byte("A"), []byte("B")); err != nil {
+				if err := txn.SetEntry(NewEntry([]byte("A"), []byte("B"))); err != nil {
 					return err
 				}
 
-				if err := txn.Set([]byte("AA"), []byte("BB")); err != nil {
+				if err := txn.SetEntry(NewEntry([]byte("AA"), []byte("BB"))); err != nil {
 					return err
 				}
 
-				return txn.Set([]byte("AAA"), []byte("BBB"))
+				return txn.SetEntry(NewEntry([]byte("AAA"), []byte("BBB")))
 			})
 			require.NoError(t, err)
 

--- a/integration/testgc/main.go
+++ b/integration/testgc/main.go
@@ -42,7 +42,7 @@ func (s *testSuite) write(db *badger.DB) error {
 			vali := atomic.AddUint64(&s.count, 1)
 			val := encoded(vali)
 			val = append(val, suffix...)
-			if err := txn.Set(key, val); err != nil {
+			if err := txn.SetEntry(badger.NewEntry(key, val)); err != nil {
 				return err
 			}
 		}
@@ -54,7 +54,7 @@ func (s *testSuite) write(db *badger.DB) error {
 			}
 			key := encoded(keyi)
 			val := append(key, suffix...)
-			if err := txn.Set(key, val); err != nil {
+			if err := txn.SetEntry(badger.NewEntry(key, val)); err != nil {
 				return err
 			}
 		}

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -72,7 +72,7 @@ func TestDropAllManaged(t *testing.T) {
 		for i := start; i < start+N; i++ {
 			wg.Add(1)
 			txn := db.NewTransactionAt(math.MaxUint64, true)
-			require.NoError(t, txn.Set([]byte(key("key", int(i))), val(true)))
+			require.NoError(t, txn.SetEntry(NewEntry([]byte(key("key", int(i))), val(true))))
 			require.NoError(t, txn.CommitAt(uint64(i), func(err error) {
 				require.NoError(t, err)
 				wg.Done()
@@ -284,7 +284,7 @@ func TestWriteAfterClose(t *testing.T) {
 	require.Equal(t, int(N), numKeys(db))
 	require.NoError(t, db.Close())
 	err = db.Update(func(txn *Txn) error {
-		return txn.Set([]byte("a"), []byte("b"))
+		return txn.SetEntry(NewEntry([]byte("a"), []byte("b")))
 	})
 	require.Equal(t, ErrBlockedWrites, err)
 }
@@ -313,7 +313,7 @@ func TestDropAllRace(t *testing.T) {
 			case <-ticker.C:
 				i++
 				txn := db.NewTransactionAt(math.MaxUint64, true)
-				require.NoError(t, txn.Set([]byte(key("key", i)), val(false)))
+				require.NoError(t, txn.SetEntry(NewEntry([]byte(key("key", i)), val(false))))
 				if err := txn.CommitAt(uint64(i), func(err error) {
 					if err != nil {
 						atomic.AddInt32(&errors, 1)
@@ -333,7 +333,7 @@ func TestDropAllRace(t *testing.T) {
 	for i := 1; i <= N; i++ {
 		wg.Add(1)
 		txn := db.NewTransactionAt(math.MaxUint64, true)
-		require.NoError(t, txn.Set([]byte(key("key", i)), val(false)))
+		require.NoError(t, txn.SetEntry(NewEntry([]byte(key("key", i)), val(false))))
 		require.NoError(t, txn.CommitAt(uint64(i), func(err error) {
 			require.NoError(t, err)
 			wg.Done()
@@ -529,7 +529,7 @@ func TestDropPrefixRace(t *testing.T) {
 			case <-ticker.C:
 				i++
 				txn := db.NewTransactionAt(math.MaxUint64, true)
-				require.NoError(t, txn.Set([]byte(key("key", i)), val(false)))
+				require.NoError(t, txn.SetEntry(NewEntry([]byte(key("key", i)), val(false))))
 				if err := txn.CommitAt(uint64(i), func(err error) {
 					if err != nil {
 						atomic.AddInt32(&errors, 1)
@@ -549,7 +549,7 @@ func TestDropPrefixRace(t *testing.T) {
 	for i := 1; i <= N; i++ {
 		wg.Add(1)
 		txn := db.NewTransactionAt(math.MaxUint64, true)
-		require.NoError(t, txn.Set([]byte(key("key", i)), val(false)))
+		require.NoError(t, txn.SetEntry(NewEntry([]byte(key("key", i)), val(false))))
 		require.NoError(t, txn.CommitAt(uint64(i), func(err error) {
 			require.NoError(t, err)
 			wg.Done()

--- a/merge.go
+++ b/merge.go
@@ -109,7 +109,7 @@ func (op *MergeOperator) compact() error {
 		}
 		// Write value back to the DB. It is important that we do not set the bitMergeEntry bit
 		// here. When compaction happens, all the older merged entries will be removed.
-		return txn.SetWithDiscard(op.key, val, 0)
+		return txn.SetEntry(NewEntry(op.key, val).WithDiscard())
 	})
 
 	if err == ErrKeyNotFound || err == errNoMerge {
@@ -144,7 +144,7 @@ func (op *MergeOperator) runCompactions(dur time.Duration) {
 // routine into the values that were recorded by previous invocations to Add().
 func (op *MergeOperator) Add(val []byte) error {
 	return op.db.Update(func(txn *Txn) error {
-		return txn.setMergeEntry(op.key, val)
+		return txn.SetEntry(NewEntry(op.key, val).withMergeBit())
 	})
 }
 

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -52,7 +52,8 @@ func TestPublisherOrdering(t *testing.T) {
 		subWg.Wait()
 		for i := 0; i < 5; i++ {
 			db.Update(func(txn *Txn) error {
-				return txn.Set([]byte(fmt.Sprintf("key%d", i)), []byte(fmt.Sprintf("value%d", i)))
+				return txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)),
+					[]byte(fmt.Sprintf("value%d", i))))
 			})
 		}
 		wg.Wait()
@@ -62,7 +63,7 @@ func TestPublisherOrdering(t *testing.T) {
 	})
 }
 
-func TestMutiplePrefix(t *testing.T) {
+func TestMultiplePrefix(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -90,10 +91,10 @@ func TestMutiplePrefix(t *testing.T) {
 		}()
 		subWg.Wait()
 		db.Update(func(txn *Txn) error {
-			return txn.Set([]byte("key"), []byte("value"))
+			return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
 		})
 		db.Update(func(txn *Txn) error {
-			return txn.Set([]byte("hello"), []byte("badger"))
+			return txn.SetEntry(NewEntry([]byte("hello"), []byte("badger")))
 		})
 		wg.Wait()
 	})

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -52,8 +52,8 @@ func TestPublisherOrdering(t *testing.T) {
 		subWg.Wait()
 		for i := 0; i < 5; i++ {
 			db.Update(func(txn *Txn) error {
-				return txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)),
-					[]byte(fmt.Sprintf("value%d", i))))
+				e := NewEntry([]byte(fmt.Sprintf("key%d", i)), []byte(fmt.Sprintf("value%d", i)))
+				return txn.SetEntry(e)
 			})
 		}
 		wg.Wait()

--- a/stream_test.go
+++ b/stream_test.go
@@ -77,7 +77,7 @@ func TestStream(t *testing.T) {
 	for _, prefix := range []string{"p0", "p1", "p2"} {
 		txn := db.NewTransactionAt(math.MaxUint64, true)
 		for i := 1; i <= 100; i++ {
-			require.NoError(t, txn.Set(keyWithPrefix(prefix, i), value(i)))
+			require.NoError(t, txn.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
 			count++
 		}
 		require.NoError(t, txn.CommitAt(5, nil))

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -186,7 +186,8 @@ func TestStreamWriter3(t *testing.T) {
 				keybyte := make([]byte, 8)
 				keyNo := uint64(counter)
 				binary.BigEndian.PutUint64(keybyte, keyNo)
-				require.NoError(t, txn.SetEntry(NewEntry(keybyte, val)), "error while inserting entries")
+				require.NoError(t, txn.SetEntry(NewEntry(keybyte, val)),
+					"error while inserting entries")
 				require.NoError(t, txn.Commit(), "error while commit")
 				counter = counter + 2
 			}

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -186,7 +186,7 @@ func TestStreamWriter3(t *testing.T) {
 				keybyte := make([]byte, 8)
 				keyNo := uint64(counter)
 				binary.BigEndian.PutUint64(keybyte, keyNo)
-				require.NoError(t, txn.Set(keybyte, val), "error while inserting entries")
+				require.NoError(t, txn.SetEntry(NewEntry(keybyte, val)), "error while inserting entries")
 				require.NoError(t, txn.Commit(), "error while commit")
 				counter = counter + 2
 			}

--- a/structs.go
+++ b/structs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"time"
 
 	"github.com/dgraph-io/badger/y"
 )
@@ -130,4 +131,42 @@ func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 func (e Entry) print(prefix string) {
 	fmt.Printf("%s Key: %s Meta: %d UserMeta: %d Offset: %d len(val)=%d",
 		prefix, e.Key, e.meta, e.UserMeta, e.offset, len(e.Value))
+}
+
+// NewEntry creates a new entry with key and value passed in args. This newly created entry can be
+// set in a transaction by calling txn.SetEntry(). All other properties of Entry can be set by
+// calling WithMeta, WithDiscard, WithTTL methods on it.
+// This function uses key and value reference, hence users must not modify key and value until the
+// end of transaction.
+func NewEntry(key, value []byte) *Entry {
+	return &Entry{
+		Key:   key,
+		Value: value,
+	}
+}
+
+// WithMeta adds meta data to Entry e. This byte is stored alongside the key and can be used as an
+// aid to interpret the value or store other contextual bits corresponding to the key-value pair of
+// entry.
+func (e *Entry) WithMeta(meta byte) *Entry {
+	e.UserMeta = meta
+	return e
+}
+
+// WithDiscard adds a marker to Entry e. This means all the previous versions of the key (of the
+// Entry) will be eligible for garbage collection.
+// This method is only useful if you have set a higher limit for options.NumVersionsToKeep. The
+// default setting is 1, in which case, this function doesn't add any more benefit. If however, you
+// have a higher setting for NumVersionsToKeep (in Dgraph, we set it to infinity), you can use this
+// method to indicate that all the older versions can be discarded and removed during compactions.
+func (e *Entry) WithDiscard() *Entry {
+	e.meta = bitDiscardEarlierVersions
+	return e
+}
+
+// WithTTL adds time to live duration to Entry e. Entry stored with a TTL would automatically expire
+// after the time has elapsed, and be eligible for garbage collection.
+func (e *Entry) WithTTL(dur time.Duration) *Entry {
+	e.ExpiresAt = uint64(time.Now().Add(dur).Unix())
+	return e
 }

--- a/structs.go
+++ b/structs.go
@@ -170,3 +170,10 @@ func (e *Entry) WithTTL(dur time.Duration) *Entry {
 	e.ExpiresAt = uint64(time.Now().Add(dur).Unix())
 	return e
 }
+
+// withMergeBit sets merge bit in entry's metadata. This
+// function is called by MergeOperator's Add method.
+func (e *Entry) withMergeBit() *Entry {
+	e.meta = bitMergeEntry
+	return e
+}

--- a/structs.go
+++ b/structs.go
@@ -136,8 +136,8 @@ func (e Entry) print(prefix string) {
 // NewEntry creates a new entry with key and value passed in args. This newly created entry can be
 // set in a transaction by calling txn.SetEntry(). All other properties of Entry can be set by
 // calling WithMeta, WithDiscard, WithTTL methods on it.
-// This function uses key and value reference, hence users must not modify key and value until the
-// end of transaction.
+// This function uses key and value reference, hence users must
+// not modify key and value until the end of transaction.
 func NewEntry(key, value []byte) *Entry {
 	return &Entry{
 		Key:   key,
@@ -145,9 +145,9 @@ func NewEntry(key, value []byte) *Entry {
 	}
 }
 
-// WithMeta adds meta data to Entry e. This byte is stored alongside the key and can be used as an
-// aid to interpret the value or store other contextual bits corresponding to the key-value pair of
-// entry.
+// WithMeta adds meta data to Entry e. This byte is stored alongside the key
+// and can be used as an aid to interpret the value or store other contextual
+// bits corresponding to the key-value pair of entry.
 func (e *Entry) WithMeta(meta byte) *Entry {
 	e.UserMeta = meta
 	return e
@@ -165,7 +165,7 @@ func (e *Entry) WithDiscard() *Entry {
 }
 
 // WithTTL adds time to live duration to Entry e. Entry stored with a TTL would automatically expire
-// after the time has elapsed, and be eligible for garbage collection.
+// after the time has elapsed, and will be eligible for garbage collection.
 func (e *Entry) WithTTL(dur time.Duration) *Entry {
 	e.ExpiresAt = uint64(time.Now().Add(dur).Unix())
 	return e

--- a/txn.go
+++ b/txn.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/dgraph-io/badger/y"
 	farm "github.com/dgryski/go-farm"
@@ -302,78 +301,6 @@ func (txn *Txn) checkSize(e *Entry) error {
 	}
 	txn.count, txn.size = count, size
 	return nil
-}
-
-// Set adds a key-value pair to the database.
-//
-// It will return ErrReadOnlyTxn if update flag was set to false when creating the
-// transaction.
-//
-// The current transaction keeps a reference to the key and val byte slice
-// arguments. Users must not modify key and val until the end of the transaction.
-func (txn *Txn) Set(key, val []byte) error {
-	e := &Entry{
-		Key:   key,
-		Value: val,
-	}
-	return txn.SetEntry(e)
-}
-
-// SetWithMeta adds a key-value pair to the database, along with a metadata
-// byte.
-//
-// This byte is stored alongside the key, and can be used as an aid to
-// interpret the value or store other contextual bits corresponding to the
-// key-value pair.
-//
-// The current transaction keeps a reference to the key and val byte slice
-// arguments. Users must not modify key and val until the end of the transaction.
-func (txn *Txn) SetWithMeta(key, val []byte, meta byte) error {
-	e := &Entry{Key: key, Value: val, UserMeta: meta}
-	return txn.SetEntry(e)
-}
-
-// SetWithDiscard acts like SetWithMeta, but adds a marker to discard earlier
-// versions of the key.
-//
-// This method is only useful if you have set a higher limit for
-// options.NumVersionsToKeep. The default setting is 1, in which case, this
-// function doesn't add any more benefit than just calling the normal
-// SetWithMeta (or Set) function. If however, you have a higher setting for
-// NumVersionsToKeep (in Dgraph, we set it to infinity), you can use this method
-// to indicate that all the older versions can be discarded and removed during
-// compactions.
-//
-// The current transaction keeps a reference to the key and val byte slice
-// arguments. Users must not modify key and val until the end of the
-// transaction.
-func (txn *Txn) SetWithDiscard(key, val []byte, meta byte) error {
-	e := &Entry{
-		Key:      key,
-		Value:    val,
-		UserMeta: meta,
-		meta:     bitDiscardEarlierVersions,
-	}
-	return txn.SetEntry(e)
-}
-
-// SetWithTTL adds a key-value pair to the database, along with a time-to-live
-// (TTL) setting. A key stored with a TTL would automatically expire after the
-// time has elapsed, and be eligible for garbage collection.
-//
-// The current transaction keeps a reference to the key and val byte slice
-// arguments. Users must not modify key and val until the end of the
-// transaction.
-func (txn *Txn) SetWithTTL(key, val []byte, dur time.Duration) error {
-	expire := time.Now().Add(dur).Unix()
-	e := &Entry{Key: key, Value: val, ExpiresAt: uint64(expire)}
-	return txn.SetEntry(e)
-}
-
-// setMergeEntry is similar to SetEntry but it sets the bitMergeEntry flag
-func (txn *Txn) setMergeEntry(key, val []byte) error {
-	e := &Entry{Key: key, Value: val, meta: bitMergeEntry}
-	return txn.SetEntry(e)
 }
 
 func exceedsSize(prefix string, max int64, key []byte) error {

--- a/txn.go
+++ b/txn.go
@@ -339,9 +339,7 @@ func (txn *Txn) modify(e *Entry) error {
 }
 
 // Set adds a key-value pair to the database.
-//
-// It will return ErrReadOnlyTxn if update flag was set to false when creating the
-// transaction.
+// It will return ErrReadOnlyTxn if update flag was set to false when creating the transaction.
 //
 // The current transaction keeps a reference to the key and val byte slice
 // arguments. Users must not modify key and val until the end of the transaction.

--- a/txn.go
+++ b/txn.go
@@ -338,6 +338,17 @@ func (txn *Txn) modify(e *Entry) error {
 	return nil
 }
 
+// Set adds a key-value pair to the database.
+//
+// It will return ErrReadOnlyTxn if update flag was set to false when creating the
+// transaction.
+//
+// The current transaction keeps a reference to the key and val byte slice
+// arguments. Users must not modify key and val until the end of the transaction.
+func (txn *Txn) Set(key, val []byte) error {
+	return txn.SetEntry(NewEntry(key, val))
+}
+
 // SetEntry takes an Entry struct and adds the key-value pair in the struct,
 // along with other metadata to the database.
 //

--- a/txn_test.go
+++ b/txn_test.go
@@ -40,7 +40,7 @@ func TestTxnSimple(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			k := []byte(fmt.Sprintf("key=%d", i))
 			v := []byte(fmt.Sprintf("val=%d", i))
-			txn.Set(k, v)
+			txn.SetEntry(NewEntry(k, v))
 		}
 
 		item, err := txn.Get([]byte("key=8"))
@@ -66,7 +66,7 @@ func TestTxnReadAfterWrite(t *testing.T) {
 				defer wg.Done()
 				key := []byte(fmt.Sprintf("key%d", i))
 				err := db.Update(func(tx *Txn) error {
-					return tx.Set(key, key)
+					return tx.SetEntry(NewEntry(key, key))
 				})
 				require.NoError(t, err)
 				err = db.View(func(tx *Txn) error {
@@ -92,7 +92,7 @@ func TestTxnCommitAsync(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		txn := db.NewTransaction(true)
 		for i := 0; i < 40; i++ {
-			err := txn.Set(key(i), []byte(strconv.Itoa(100)))
+			err := txn.SetEntry(NewEntry(key(i), []byte(strconv.Itoa(100))))
 			require.NoError(t, err)
 		}
 		require.NoError(t, txn.Commit())
@@ -131,11 +131,11 @@ func TestTxnCommitAsync(t *testing.T) {
 				txn := db.NewTransaction(true)
 				delta := rand.Intn(100)
 				for i := 0; i < 20; i++ {
-					err := txn.Set(key(i), []byte(strconv.Itoa(100-delta)))
+					err := txn.SetEntry(NewEntry(key(i), []byte(strconv.Itoa(100-delta))))
 					require.NoError(t, err)
 				}
 				for i := 20; i < 40; i++ {
-					err := txn.Set(key(i), []byte(strconv.Itoa(100+delta)))
+					err := txn.SetEntry(NewEntry(key(i), []byte(strconv.Itoa(100+delta))))
 					require.NoError(t, err)
 				}
 				// We are only doing writes, so there won't be any conflicts.
@@ -156,7 +156,7 @@ func TestTxnVersions(t *testing.T) {
 		for i := 1; i < 10; i++ {
 			txn := db.NewTransaction(true)
 
-			txn.Set(k, []byte(fmt.Sprintf("valversion=%d", i)))
+			txn.SetEntry(NewEntry(k, []byte(fmt.Sprintf("valversion=%d", i))))
 			require.NoError(t, txn.Commit())
 			require.Equal(t, uint64(i), db.orc.readTs())
 		}
@@ -264,8 +264,8 @@ func TestTxnWriteSkew(t *testing.T) {
 		txn := db.NewTransaction(true)
 		defer txn.Discard()
 		val := []byte(strconv.Itoa(100))
-		txn.Set(ax, val)
-		txn.Set(ay, val)
+		txn.SetEntry(NewEntry(ax, val))
+		txn.SetEntry(NewEntry(ay, val))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
@@ -286,7 +286,7 @@ func TestTxnWriteSkew(t *testing.T) {
 		sum := getBal(txn1, ax)
 		sum += getBal(txn1, ay)
 		require.Equal(t, 200, sum)
-		txn1.Set(ax, []byte("0")) // Deduct 100 from ax.
+		txn1.SetEntry(NewEntry(ax, []byte("0"))) // Deduct 100 from ax.
 
 		// Let's read this back.
 		sum = getBal(txn1, ax)
@@ -300,7 +300,7 @@ func TestTxnWriteSkew(t *testing.T) {
 		sum = getBal(txn2, ax)
 		sum += getBal(txn2, ay)
 		require.Equal(t, 200, sum)
-		txn2.Set(ay, []byte("0")) // Deduct 100 from ay.
+		txn2.SetEntry(NewEntry(ay, []byte("0"))) // Deduct 100 from ay.
 
 		// Let's read this back.
 		sum = getBal(txn2, ax)
@@ -330,27 +330,27 @@ func TestTxnIterationEdgeCase(t *testing.T) {
 
 		// c1
 		txn := db.NewTransaction(true)
-		txn.Set(kc, []byte("c1"))
+		txn.SetEntry(NewEntry(kc, []byte("c1")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
 		// a2, c2
 		txn = db.NewTransaction(true)
-		txn.Set(ka, []byte("a2"))
-		txn.Set(kc, []byte("c2"))
+		txn.SetEntry(NewEntry(ka, []byte("a2")))
+		txn.SetEntry(NewEntry(kc, []byte("c2")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(2), db.orc.readTs())
 
 		// b3
 		txn = db.NewTransaction(true)
-		txn.Set(ka, []byte("a3"))
-		txn.Set(kb, []byte("b3"))
+		txn.SetEntry(NewEntry(ka, []byte("a3")))
+		txn.SetEntry(NewEntry(kb, []byte("b3")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(3), db.orc.readTs())
 
 		// b4, c4(del) (Uncommitted)
 		txn4 := db.NewTransaction(true)
-		require.NoError(t, txn4.Set(kb, []byte("b4")))
+		require.NoError(t, txn4.SetEntry(NewEntry(kb, []byte("b4"))))
 		require.NoError(t, txn4.Delete(kc))
 		require.Equal(t, uint64(3), db.orc.readTs())
 
@@ -420,21 +420,21 @@ func TestTxnIterationEdgeCase2(t *testing.T) {
 
 		// c1
 		txn := db.NewTransaction(true)
-		txn.Set(kc, []byte("c1"))
+		txn.SetEntry(NewEntry(kc, []byte("c1")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
 		// a2, c2
 		txn = db.NewTransaction(true)
-		txn.Set(ka, []byte("a2"))
-		txn.Set(kc, []byte("c2"))
+		txn.SetEntry(NewEntry(ka, []byte("a2")))
+		txn.SetEntry(NewEntry(kc, []byte("c2")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(2), db.orc.readTs())
 
 		// b3
 		txn = db.NewTransaction(true)
-		txn.Set(ka, []byte("a3"))
-		txn.Set(kb, []byte("b3"))
+		txn.SetEntry(NewEntry(ka, []byte("a3")))
+		txn.SetEntry(NewEntry(kb, []byte("b3")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(3), db.orc.readTs())
 
@@ -513,18 +513,18 @@ func TestTxnIterationEdgeCase3(t *testing.T) {
 
 		// c1
 		txn := db.NewTransaction(true)
-		txn.Set(kc, []byte("c1"))
+		txn.SetEntry(NewEntry(kc, []byte("c1")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
 		// b2
 		txn = db.NewTransaction(true)
-		txn.Set(kb, []byte("b2"))
+		txn.SetEntry(NewEntry(kb, []byte("b2")))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(2), db.orc.readTs())
 
 		txn2 := db.NewTransaction(true)
-		require.NoError(t, txn2.Set(kd, []byte("d2")))
+		require.NoError(t, txn2.SetEntry(NewEntry(kd, []byte("d2"))))
 		require.NoError(t, txn2.Delete(kc))
 
 		txn = db.NewTransaction(true)
@@ -619,8 +619,8 @@ func TestIteratorAllVersionsWithDeleted(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		// Write two keys
 		err := db.Update(func(txn *Txn) error {
-			txn.Set([]byte("answer1"), []byte("42"))
-			txn.Set([]byte("answer2"), []byte("43"))
+			txn.SetEntry(NewEntry([]byte("answer1"), []byte("42")))
+			txn.SetEntry(NewEntry([]byte("answer2"), []byte("43")))
 			return nil
 		})
 		require.NoError(t, err)
@@ -672,7 +672,7 @@ func TestIteratorAllVersionsWithDeleted2(t *testing.T) {
 		for i := 0; i < 4; i++ {
 			err := db.Update(func(txn *Txn) error {
 				if i%2 == 0 {
-					txn.Set([]byte("key"), []byte("value"))
+					txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
 					return nil
 				}
 				txn.Delete([]byte("key"))
@@ -738,7 +738,7 @@ func TestManagedDB(t *testing.T) {
 	// Write data at t=3.
 	txn := db.NewTransactionAt(3, true)
 	for i := 0; i <= 3; i++ {
-		require.NoError(t, txn.Set(key(i), val(i)))
+		require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
 	}
 	require.Panics(t, func() { txn.Commit() })
 	require.NoError(t, txn.CommitAt(3, nil))
@@ -770,7 +770,7 @@ func TestManagedDB(t *testing.T) {
 		if err == nil {
 			continue // Don't overwrite existing keys.
 		}
-		require.NoError(t, txn.Set(key(i), val(i)))
+		require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
 	}
 	require.NoError(t, txn.CommitAt(7, nil))
 
@@ -825,14 +825,14 @@ func TestArmV7Issue311Fix(t *testing.T) {
 	}
 
 	err = db.Update(func(txn *Txn) error {
-		return txn.Set([]byte{0x11}, []byte{0x22})
+		return txn.SetEntry(NewEntry([]byte{0x11}, []byte{0x22}))
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = db.Update(func(txn *Txn) error {
-		return txn.Set([]byte{0x11}, []byte{0x22})
+		return txn.SetEntry(NewEntry([]byte{0x11}, []byte{0x22}))
 	})
 
 	if err != nil {

--- a/txn_test.go
+++ b/txn_test.go
@@ -40,7 +40,7 @@ func TestTxnSimple(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			k := []byte(fmt.Sprintf("key=%d", i))
 			v := []byte(fmt.Sprintf("val=%d", i))
-			txn.SetEntry(NewEntry(k, v))
+			require.NoError(t, txn.SetEntry(NewEntry(k, v)))
 		}
 
 		item, err := txn.Get([]byte("key=8"))
@@ -156,7 +156,7 @@ func TestTxnVersions(t *testing.T) {
 		for i := 1; i < 10; i++ {
 			txn := db.NewTransaction(true)
 
-			txn.SetEntry(NewEntry(k, []byte(fmt.Sprintf("valversion=%d", i))))
+			require.NoError(t, txn.SetEntry(NewEntry(k, []byte(fmt.Sprintf("valversion=%d", i)))))
 			require.NoError(t, txn.Commit())
 			require.Equal(t, uint64(i), db.orc.readTs())
 		}
@@ -264,8 +264,8 @@ func TestTxnWriteSkew(t *testing.T) {
 		txn := db.NewTransaction(true)
 		defer txn.Discard()
 		val := []byte(strconv.Itoa(100))
-		txn.SetEntry(NewEntry(ax, val))
-		txn.SetEntry(NewEntry(ay, val))
+		require.NoError(t, txn.SetEntry(NewEntry(ax, val)))
+		require.NoError(t, txn.SetEntry(NewEntry(ay, val)))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
@@ -286,7 +286,7 @@ func TestTxnWriteSkew(t *testing.T) {
 		sum := getBal(txn1, ax)
 		sum += getBal(txn1, ay)
 		require.Equal(t, 200, sum)
-		txn1.SetEntry(NewEntry(ax, []byte("0"))) // Deduct 100 from ax.
+		require.NoError(t, txn1.SetEntry(NewEntry(ax, []byte("0")))) // Deduct 100 from ax.
 
 		// Let's read this back.
 		sum = getBal(txn1, ax)
@@ -300,7 +300,7 @@ func TestTxnWriteSkew(t *testing.T) {
 		sum = getBal(txn2, ax)
 		sum += getBal(txn2, ay)
 		require.Equal(t, 200, sum)
-		txn2.SetEntry(NewEntry(ay, []byte("0"))) // Deduct 100 from ay.
+		require.NoError(t, txn2.SetEntry(NewEntry(ay, []byte("0")))) // Deduct 100 from ay.
 
 		// Let's read this back.
 		sum = getBal(txn2, ax)
@@ -330,21 +330,21 @@ func TestTxnIterationEdgeCase(t *testing.T) {
 
 		// c1
 		txn := db.NewTransaction(true)
-		txn.SetEntry(NewEntry(kc, []byte("c1")))
+		require.NoError(t, txn.SetEntry(NewEntry(kc, []byte("c1"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
 		// a2, c2
 		txn = db.NewTransaction(true)
-		txn.SetEntry(NewEntry(ka, []byte("a2")))
-		txn.SetEntry(NewEntry(kc, []byte("c2")))
+		require.NoError(t, txn.SetEntry(NewEntry(ka, []byte("a2"))))
+		require.NoError(t, txn.SetEntry(NewEntry(kc, []byte("c2"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(2), db.orc.readTs())
 
 		// b3
 		txn = db.NewTransaction(true)
-		txn.SetEntry(NewEntry(ka, []byte("a3")))
-		txn.SetEntry(NewEntry(kb, []byte("b3")))
+		require.NoError(t, txn.SetEntry(NewEntry(ka, []byte("a3"))))
+		require.NoError(t, txn.SetEntry(NewEntry(kb, []byte("b3"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(3), db.orc.readTs())
 
@@ -420,21 +420,21 @@ func TestTxnIterationEdgeCase2(t *testing.T) {
 
 		// c1
 		txn := db.NewTransaction(true)
-		txn.SetEntry(NewEntry(kc, []byte("c1")))
+		require.NoError(t, txn.SetEntry(NewEntry(kc, []byte("c1"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
 		// a2, c2
 		txn = db.NewTransaction(true)
-		txn.SetEntry(NewEntry(ka, []byte("a2")))
-		txn.SetEntry(NewEntry(kc, []byte("c2")))
+		require.NoError(t, txn.SetEntry(NewEntry(ka, []byte("a2"))))
+		require.NoError(t, txn.SetEntry(NewEntry(kc, []byte("c2"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(2), db.orc.readTs())
 
 		// b3
 		txn = db.NewTransaction(true)
-		txn.SetEntry(NewEntry(ka, []byte("a3")))
-		txn.SetEntry(NewEntry(kb, []byte("b3")))
+		require.NoError(t, txn.SetEntry(NewEntry(ka, []byte("a3"))))
+		require.NoError(t, txn.SetEntry(NewEntry(kb, []byte("b3"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(3), db.orc.readTs())
 
@@ -513,13 +513,13 @@ func TestTxnIterationEdgeCase3(t *testing.T) {
 
 		// c1
 		txn := db.NewTransaction(true)
-		txn.SetEntry(NewEntry(kc, []byte("c1")))
+		require.NoError(t, txn.SetEntry(NewEntry(kc, []byte("c1"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(1), db.orc.readTs())
 
 		// b2
 		txn = db.NewTransaction(true)
-		txn.SetEntry(NewEntry(kb, []byte("b2")))
+		require.NoError(t, txn.SetEntry(NewEntry(kb, []byte("b2"))))
 		require.NoError(t, txn.Commit())
 		require.Equal(t, uint64(2), db.orc.readTs())
 
@@ -619,9 +619,8 @@ func TestIteratorAllVersionsWithDeleted(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		// Write two keys
 		err := db.Update(func(txn *Txn) error {
-			txn.SetEntry(NewEntry([]byte("answer1"), []byte("42")))
-			txn.SetEntry(NewEntry([]byte("answer2"), []byte("43")))
-			return nil
+			require.NoError(t, txn.SetEntry(NewEntry([]byte("answer1"), []byte("42"))))
+			return txn.SetEntry(NewEntry([]byte("answer2"), []byte("43")))
 		})
 		require.NoError(t, err)
 
@@ -672,11 +671,10 @@ func TestIteratorAllVersionsWithDeleted2(t *testing.T) {
 		for i := 0; i < 4; i++ {
 			err := db.Update(func(txn *Txn) error {
 				if i%2 == 0 {
-					txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
+					require.NoError(t, txn.SetEntry(NewEntry([]byte("key"), []byte("value"))))
 					return nil
 				}
-				txn.Delete([]byte("key"))
-				return nil
+				return txn.Delete([]byte("key"))
 			})
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
Currently no functions are exposed to create and modify Entry, to
be set in a transaction. Functions Set, SetWithMeta, SetWithDiscard,
SetWithTTL, all are part of Txn struct. These functions internally
create an entry and then call txn.SetEntry. All of Set functions,
set a specific property of Entry apart from key and value. This
restricts us from setting multiple property for same entry such as
meta and TTL.
This PR adds functions to set different properties on an existing
Entry. After setting desired properties, user can call txn.SetEntry
to add entry in the transaction. We have also delete all Entry creation
related functions from Txn Struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/822)
<!-- Reviewable:end -->
