### PR TITLE
Delete vlog file instead of truncating it completely

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -178,7 +178,7 @@ func OpenTable(fd *os.File, mode options.FileLoadingMode, cksum []byte) (*Table,
 		t.mmap, err = y.Mmap(fd, false, fileInfo.Size())
 		if err != nil {
 			_ = fd.Close()
-			return nil, y.Wrapf(err, "Unable to map file")
+			return nil, y.Wrapf(err, "Unable to map file: %q", fileInfo.Name())
 		}
 	case options.FileIO:
 		t.mmap = nil

--- a/value.go
+++ b/value.go
@@ -726,8 +726,10 @@ func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) e
 	if err != nil {
 		return errFile(err, lf.path, "Unable to replay logfile")
 	}
-	// The entire file should be truncated (i.e. it should be deleted)
-	if endOffset == 0 {
+	// The entire file should be truncated (i.e. it should be deleted).
+	// If fid == maxFid then it's okay to truncate the entire file since will be
+	// used for future additions
+	if endOffset == 0 && lf.fid != vlog.maxFid {
 		return errDeleteVlogFile
 	}
 	if int64(endOffset) == fi.Size() {
@@ -792,11 +794,8 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 		// Replay and possible truncation done. Now we can open the file as per
 		// user specified options.
 		if err := vlog.replayLog(lf, offset, replayFn); err != nil {
-			if err != errDeleteVlogFile {
-				return err
-			}
 			// Log file is corrupted. Delete it
-			if vlog.maxFid != fid {
+			if err == errDeleteVlogFile {
 				delete(vlog.filesMap, fid)
 				path := vlog.fpath(lf.fid)
 				if err := os.Remove(path); err != nil {
@@ -804,6 +803,7 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 				}
 				continue
 			}
+			return err
 		}
 		vlog.db.opt.Infof("Replay took: %s\n", time.Since(now))
 

--- a/value.go
+++ b/value.go
@@ -88,7 +88,7 @@ func (lf *logFile) openReadOnly() error {
 
 	if err = lf.mmap(fi.Size()); err != nil {
 		_ = lf.fd.Close()
-		return y.Wrapf(err, "Unable to map file")
+		return y.Wrapf(err, "Unable to map file: %q", fi.Name())
 	}
 
 	return nil

--- a/value.go
+++ b/value.go
@@ -726,12 +726,6 @@ func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) e
 	if err != nil {
 		return errFile(err, lf.path, "Unable to replay logfile")
 	}
-	// The entire file should be truncated (i.e. it should be deleted).
-	// If fid == maxFid then it's okay to truncate the entire file since will be
-	// used for future additions
-	if endOffset == 0 && lf.fid != vlog.maxFid {
-		return errDeleteVlogFile
-	}
 	if int64(endOffset) == fi.Size() {
 		return nil
 	}
@@ -742,7 +736,12 @@ func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) e
 	if !vlog.opt.Truncate {
 		return ErrTruncateNeeded
 	}
-
+	// The entire file should be truncated (i.e. it should be deleted).
+	// If fid == maxFid then it's okay to truncate the entire file since will be
+	// used for future additions
+	if endOffset == 0 && lf.fid != vlog.maxFid {
+		return errDeleteVlogFile
+	}
 	if err := lf.fd.Truncate(int64(endOffset)); err != nil {
 		return errFile(err, lf.path, fmt.Sprintf(
 			"Truncation needed at offset %d. Can be done manually as well.", endOffset))

--- a/value_test.go
+++ b/value_test.go
@@ -945,6 +945,7 @@ func TestValueLogTruncate(t *testing.T) {
 	opts := DefaultOptions
 	opts.Dir = dir
 	opts.ValueDir = dir
+	opts.Truncate = true
 
 	db, err := Open(opts)
 	require.NoError(t, err)


### PR DESCRIPTION
With this commit, we delete the vlog file which is completely corrupted.
Earlier we would truncate such vlog file and that meant we had vlog
files with size 0 and mmap would complain about it.

Fixes https://github.com/dgraph-io/badger/issues/817

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/823)
<!-- Reviewable:end -->
