### PR TITLE
Fix a bug in StreamWriter which causes key overlap in levels.

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var headStreamId uint32 = math.MaxUint32
+const headStreamId uint32 = math.MaxUint32
 
 // StreamWriter is used to write data coming from multiple streams. The streams must not have any
 // overlapping key ranges. Within each stream, the keys must be sorted. Badger Stream framework is
@@ -271,11 +271,11 @@ func (w *sortedWriter) createTable(data []byte) error {
 	lc := w.db.lc
 
 	var lhandler *levelHandler
-	// We should start the levels from 2, because we need level 1 to set the !badger!head key. We
+	// We should start the levels from 1, because we need level 0 to set the !badger!head key. We
 	// cannot mix up this key with other keys from the DB, otherwise we would introduce a range
 	// overlap violation.
-	y.AssertTrue(len(lc.levels) > 2)
-	for _, l := range lc.levels[2:] {
+	y.AssertTrue(len(lc.levels) > 1)
+	for _, l := range lc.levels[1:] {
 		ratio := float64(l.getTotalSize()) / float64(l.maxTotalSize)
 		if ratio < 1.0 {
 			lhandler = l
@@ -288,9 +288,9 @@ func (w *sortedWriter) createTable(data []byte) error {
 		lhandler = lc.levels[len(lc.levels)-1]
 	}
 	if w.streamId == headStreamId {
-		// This is a special !badger!head key. We should store it at level 1, separate from all the
+		// This is a special !badger!head key. We should store it at level 0, separate from all the
 		// other keys to avoid an overlap.
-		lhandler = lc.levels[1]
+		lhandler = lc.levels[0]
 	}
 	// Now that table can be opened successfully, let's add this to the MANIFEST.
 	change := &pb.ManifestChange{

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -200,10 +200,10 @@ type sortedWriter struct {
 	streamId uint32
 }
 
-func (sw *StreamWriter) newWriter(streamID uint32) *sortedWriter {
+func (sw *StreamWriter) newWriter(streamId uint32) *sortedWriter {
 	return &sortedWriter{
 		db:       sw.db,
-		streamId: streamID,
+		streamId: streamId,
 		throttle: sw.throttle,
 		builder:  table.NewTableBuilder(),
 	}

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var headStreamId uint32 = math.MaxUint32
+
 // StreamWriter is used to write data coming from multiple streams. The streams must not have any
 // overlapping key ranges. Within each stream, the keys must be sorted. Badger Stream framework is
 // capable of generating such an output. So, this StreamWriter can be used at the other end to build
@@ -157,7 +159,7 @@ func (sw *StreamWriter) Flush() error {
 	// Encode and write the value log head into a new table.
 	data := make([]byte, vptrSize)
 	sw.head.Encode(data)
-	headWriter := sw.newWriter(math.MaxUint32)
+	headWriter := sw.newWriter(headStreamId)
 	if err := headWriter.Add(
 		y.KeyWithTs(head, sw.maxVersion),
 		y.ValueStruct{Value: data}); err != nil {
@@ -195,13 +197,13 @@ type sortedWriter struct {
 
 	builder  *table.Builder
 	lastKey  []byte
-	streamID uint32
+	streamId uint32
 }
 
 func (sw *StreamWriter) newWriter(streamID uint32) *sortedWriter {
 	return &sortedWriter{
 		db:       sw.db,
-		streamID: streamID,
+		streamId: streamID,
 		throttle: sw.throttle,
 		builder:  table.NewTableBuilder(),
 	}
@@ -269,7 +271,11 @@ func (w *sortedWriter) createTable(data []byte) error {
 	lc := w.db.lc
 
 	var lhandler *levelHandler
-	for _, l := range lc.levels[1:] {
+	// We should start the levels from 2, because we need level 1 to set the !badger!head key. We
+	// cannot mix up this key with other keys from the DB, otherwise we would introduce a range
+	// overlap violation.
+	y.AssertTrue(len(lc.levels) > 2)
+	for _, l := range lc.levels[2:] {
 		ratio := float64(l.getTotalSize()) / float64(l.maxTotalSize)
 		if ratio < 1.0 {
 			lhandler = l
@@ -277,7 +283,14 @@ func (w *sortedWriter) createTable(data []byte) error {
 		}
 	}
 	if lhandler == nil {
+		// If we're exceeding the size of the lowest level, shove it in the lowest level. Can't do
+		// better than that.
 		lhandler = lc.levels[len(lc.levels)-1]
+	}
+	if w.streamId == headStreamId {
+		// This is a special !badger!head key. We should store it at level 1, separate from all the
+		// other keys to avoid an overlap.
+		lhandler = lc.levels[1]
 	}
 	// Now that table can be opened successfully, let's add this to the MANIFEST.
 	change := &pb.ManifestChange{
@@ -293,6 +306,6 @@ func (w *sortedWriter) createTable(data []byte) error {
 		return err
 	}
 	w.db.opt.Infof("Table created: %d at level: %d for stream: %d. Size: %s\n",
-		fileID, lhandler.level, w.streamID, humanize.Bytes(uint64(tbl.Size())))
+		fileID, lhandler.level, w.streamId, humanize.Bytes(uint64(tbl.Size())))
 	return nil
 }

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -273,15 +273,6 @@ func TestStreamWriter5(t *testing.T) {
 			Version: 1,
 		})
 
-		// dir, err := ioutil.TempDir(".", "badger-test")
-		// require.NoError(t, err)
-
-		// opt := db.opt
-		// opt.Dir = dir
-		// opt.ValueDir = dir
-		// db2, err := Open(opt)
-		// require.NoError(t, err)
-
 		sw := db.NewStreamWriter()
 		require.NoError(t, sw.Prepare(), "sw.Prepare() failed")
 		require.NoError(t, sw.Write(list), "sw.Write() failed")
@@ -289,7 +280,7 @@ func TestStreamWriter5(t *testing.T) {
 		require.NoError(t, db.Close())
 
 		var err error
-		db, err = Open(db.opt)
+		_, err = Open(db.opt)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Badger currently put the `!badger!head` key in one of the tables at the last level that StreamWriter writes to.  This can cause issues if any other table in that level has an overlapping key range, considering this key did not come from the Stream Framework iteration.

This PR clears out level 1 for this head key. All other keys start from level 2. At the end, this key is written to level 1, so there's no chance of overlap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/824)
<!-- Reviewable:end -->
