### PR TITLE
Speed up StreamWriter

### DIFF
--- a/badger/cmd/fill.go
+++ b/badger/cmd/fill.go
@@ -107,7 +107,7 @@ func fillSorted(db *badger.DB, num uint64) error {
 		writeCh <- kvs
 	}
 
-	// Let's create 16 streams.
+	// Let's create some streams.
 	width := num / 16
 	streamId := uint32(0)
 	for start := uint64(0); start < num; start += width {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -58,7 +58,7 @@ func (db *DB) NewStreamWriter() *StreamWriter {
 		db: db,
 		// throttle shouldn't make much difference. Memory consumption is based on the number of
 		// concurrent streams being processed.
-		throttle: y.NewThrottle(64),
+		throttle: y.NewThrottle(16),
 		writers:  make(map[uint32]*sortedWriter),
 		closer:   y.NewCloser(0),
 	}

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -67,7 +67,7 @@ func (db *DB) NewStreamWriter() *StreamWriter {
 		// concurrent streams being processed.
 		throttle: y.NewThrottle(16),
 		writers:  make(map[uint32]*sortedWriter),
-		tableCh:  make(chan *toTable, 10),
+		tableCh:  make(chan *toTable, 3),
 		closer:   y.NewCloser(1),
 	}
 	go sw.handleRequests()

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -47,13 +47,7 @@ type StreamWriter struct {
 	head       valuePointer
 	maxVersion uint64
 	writers    map[uint32]*sortedWriter
-	tableCh    chan *toTable
 	closer     *y.Closer
-}
-
-type toTable struct {
-	kvs *pb.KVList
-	req *request
 }
 
 // NewStreamWriter creates a StreamWriter. Right after creating StreamWriter, Prepare must be
@@ -67,7 +61,6 @@ func (db *DB) NewStreamWriter() *StreamWriter {
 		// concurrent streams being processed.
 		throttle: y.NewThrottle(16),
 		writers:  make(map[uint32]*sortedWriter),
-		tableCh:  make(chan *toTable, 3),
 		closer:   y.NewCloser(0),
 	}
 }


### PR DESCRIPTION
Use a goroutine to split up the serial part of writing in StreamWriter to allow another core to work on the table encoding. On my desktop, this can write at the rate of 200MBps (1.6Gbps), finishing 1B keys (16B keys, 16B values) in around 3m20s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/825)
<!-- Reviewable:end -->
