### PR TITLE
Drop discard stat if we cannot unmarshal it

### DIFF
--- a/value.go
+++ b/value.go
@@ -1388,7 +1388,11 @@ func (vlog *valueLog) populateDiscardStats() error {
 
 	var statsMap map[uint32]int64
 	if err := json.Unmarshal(vs.Value, &statsMap); err != nil {
-		return err
+		// It's safe to ignore the error since the discard stat might have been corrupted and
+		// it would be rebuilt during compactions.
+		vlog.opt.Debugf("Failed to unmarshal: %s. Dropping Value Log Discard stats.", err)
+		vlog.lfDiscardStats = &lfDiscardStats{m: make(map[uint32]int64)}
+		return nil
 	}
 	vlog.opt.Debugf("Value Log Discard stats: %v", statsMap)
 	vlog.lfDiscardStats = &lfDiscardStats{m: statsMap}


### PR DESCRIPTION
Under certain circumstances, the discard stat map stored in the SST
could get corrupted. In this case the DB would fail to start. We should
be able to start the DB even when the discard stats are corrupted.

With this commit, we do not end badger with failure when we cannot read
the discard stats from the file. We set the discard stats to empty value
since the discard stats will be rebuilt during compactions.

Fixes https://github.com/dgraph-io/badger/issues/830
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/835)
<!-- Reviewable:end -->
