### PR TITLE
Fix subscriber bank test total check

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -555,7 +555,9 @@ func runTest(cmd *cobra.Command, args []string) error {
 			db.Subscribe(ctx, updater, accountIDS[0], accountIDS[1:]...)
 		}()
 	}
+
 	wg.Wait()
+
 	if checkSubscriber {
 		cancel()
 		subWg.Wait()
@@ -569,6 +571,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 			return nil
 		}))
 	}
+
 	if atomic.LoadInt32(&stopAll) == 0 {
 		log.Println("Test OK")
 		return nil


### PR DESCRIPTION
If checkSubscriber is not set via commandline flag,
we should avoid total balance check for subscribe DB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/839)
<!-- Reviewable:end -->
