### PR TITLE
Do not crash if directory doesn't exist in Readonly mode

### DIFF
--- a/db.go
+++ b/db.go
@@ -210,7 +210,7 @@ func Open(opt Options) (db *DB, err error) {
 		}
 		if !dirExists {
 			if opt.ReadOnly {
-				return nil, y.Wrapf(err, "Cannot find Dir for read-only open: %q", path)
+				return nil, errors.Errorf("Cannot find directory %q for read-only open", path)
 			}
 			// Try to create the directory
 			err = os.Mkdir(path, 0700)


### PR DESCRIPTION
We should return the correct error when the directory doesn't exist. Current implementation did not return any error.

Fixes https://github.com/dgraph-io/badger/issues/843
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/844)
<!-- Reviewable:end -->
