### PR TITLE
free head pointer to avoid memory leaks

### DIFF
--- a/skl/skl.go
+++ b/skl/skl.go
@@ -97,6 +97,9 @@ func (s *Skiplist) DecrRef() {
 	// Indicate we are closed. Good for testing.  Also, lets GC reclaim memory. Race condition
 	// here would suggest we are accessing skiplist when we are supposed to have no reference!
 	s.arena = nil
+	// Since the head references the arena's buf, as long as the head is kept around
+	// GC can't release the buf.
+	s.head = nil
 }
 
 func (s *Skiplist) valid() bool { return s.arena != nil }


### PR DESCRIPTION
```
func (s *Arena) getNode(offset uint32) *node {
	if offset == 0 {
		return nil
	}

	return (*node)(unsafe.Pointer(&s.buf[offset]))
}
```

https://groups.google.com/forum/#!msg/golang-nuts/yNis7bQG_rY/yaJFoSx1hgIJ


>If the unsafe.Pointer points to a Go object, the garbage collector will know about the object and the memory belonging to the object will not be freed.
...
>If the unsafe.Pointer points to a memory block allocated by Go, there usually is type information associated with the pointer. If the type information exists, it is stored in a place that belongs to Go's memory allocator.   If the type information does not exist, the garbage collector resorts to a conservative strategy (this means: the object will not be freed and the garbage collector will find all pointers stored in the object).


https://blog.golang.org/go-slices-usage-and-internals
> Since the slice references the original array, as long as the slice is kept around the garbage collector can't release the array; the few useful bytes of the file keep the entire contents in memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/849)
<!-- Reviewable:end -->
