### PR TITLE
StreamWriter Add method bug fixes

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -259,17 +259,15 @@ func (w *sortedWriter) Add(key []byte, vs y.ValueStruct) error {
 	if bytes.Compare(key, w.lastKey) <= 0 {
 		return ErrUnsortedKey
 	}
-	sameKey := y.SameKey(key, w.lastKey)
-	w.lastKey = y.SafeCopy(w.lastKey, key)
 
-	if err := w.builder.Add(key, vs); err != nil {
-		return err
-	}
+	sameKey := y.SameKey(key, w.lastKey)
 	// Same keys should go into the same SSTable.
 	if !sameKey && w.builder.ReachedCapacity(w.db.opt.MaxTableSize) {
 		return w.send()
 	}
-	return nil
+
+	w.lastKey = y.SafeCopy(w.lastKey, key)
+	return w.builder.Add(key, vs)
 }
 
 func (w *sortedWriter) send() error {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -263,7 +263,9 @@ func (w *sortedWriter) Add(key []byte, vs y.ValueStruct) error {
 	sameKey := y.SameKey(key, w.lastKey)
 	// Same keys should go into the same SSTable.
 	if !sameKey && w.builder.ReachedCapacity(w.db.opt.MaxTableSize) {
-		return w.send()
+		if err := w.send(); err != nil {
+			return err
+		}
 	}
 
 	w.lastKey = y.SafeCopy(w.lastKey, key)

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -316,15 +316,15 @@ func TestStreamWriter6(t *testing.T) {
 		require.Equal(t, 4, len(tables), "Count of tables not matching")
 		for _, tab := range tables {
 			if tab.Level > 0 {
-				require.Equal(t, 2, int(tab.KeyCount), fmt.Sprintf("failed for level: %d", tab.Level))
+				require.Equal(t, 2, int(tab.KeyCount),
+					fmt.Sprintf("failed for level: %d", tab.Level))
 			} else {
 				require.Equal(t, 1, int(tab.KeyCount)) // level 0 table will have head key
 			}
 		}
 		require.NoError(t, db.Close())
 
-		var err error
-		_, err = Open(db.opt)
+		_, err := Open(db.opt)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This PR fixes two bugs in StreamWriter:

- Ensures all versions of the same key go into in the same table.
- Key comparison should be done via y.CompareKeys instead of bytes.Compare, because the version suffix can change strict lexicographical ordering.

This PR also calls level validation at the end of SteamWriter to catch any issues with the ordering quickly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/853)
<!-- Reviewable:end -->
