### PR TITLE
Add --show-internal option to info tool

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -45,7 +45,7 @@ type flagOptions struct {
 	keyLookup     string
 	itemMeta      bool
 	keyHistory    bool
-	allowInternal bool
+	showInternal  bool
 }
 
 var (
@@ -65,7 +65,7 @@ func init() {
 	infoCmd.Flags().BoolVar(&opt.itemMeta, "show-meta", true, "Output item meta data as well")
 	infoCmd.Flags().BoolVar(&opt.keyHistory, "history", false, "Show all versions of a key")
 	infoCmd.Flags().BoolVar(
-		&opt.allowInternal, "show-internal", false, "Show internal keys along with other keys."+
+		&opt.showInternal, "show-internal", false, "Show internal keys along with other keys."+
 			" This option should be used along with --show-key option")
 }
 
@@ -136,7 +136,7 @@ func showKeys(db *badger.DB, prefix []byte) error {
 	iopt.Prefix = []byte(prefix)
 	iopt.PrefetchValues = false
 	iopt.AllVersions = opt.keyHistory
-	iopt.InternalAccess = opt.allowInternal
+	iopt.InternalAccess = opt.showInternal
 	it := txn.NewIterator(iopt)
 	defer it.Close()
 

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -45,6 +45,7 @@ type flagOptions struct {
 	keyLookup     string
 	itemMeta      bool
 	keyHistory    bool
+	allowInternal bool
 }
 
 var (
@@ -63,6 +64,9 @@ func init() {
 	infoCmd.Flags().StringVarP(&opt.keyLookup, "lookup", "l", "", "Hex of the key to lookup")
 	infoCmd.Flags().BoolVar(&opt.itemMeta, "show-meta", true, "Output item meta data as well")
 	infoCmd.Flags().BoolVar(&opt.keyHistory, "history", false, "Show all versions of a key")
+	infoCmd.Flags().BoolVar(
+		&opt.allowInternal, "allow-internal", false, "Show internal keys along with other keys."+
+			" This option should be used along with --show-key option")
 }
 
 var infoCmd = &cobra.Command{
@@ -132,6 +136,7 @@ func showKeys(db *badger.DB, prefix []byte) error {
 	iopt.Prefix = []byte(prefix)
 	iopt.PrefetchValues = false
 	iopt.AllVersions = opt.keyHistory
+	iopt.InternalAccess = opt.allowInternal
 	it := txn.NewIterator(iopt)
 	defer it.Close()
 

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -65,7 +65,7 @@ func init() {
 	infoCmd.Flags().BoolVar(&opt.itemMeta, "show-meta", true, "Output item meta data as well")
 	infoCmd.Flags().BoolVar(&opt.keyHistory, "history", false, "Show all versions of a key")
 	infoCmd.Flags().BoolVar(
-		&opt.allowInternal, "allow-internal", false, "Show internal keys along with other keys."+
+		&opt.allowInternal, "show-internal", false, "Show internal keys along with other keys."+
 			" This option should be used along with --show-key option")
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -334,7 +334,7 @@ type IteratorOptions struct {
 	Prefix      []byte // Only iterate over this given prefix.
 	prefixIsKey bool   // If set, use the prefix for bloom filter lookup.
 
-	internalAccess bool // Used to allow internal access to badger keys.
+	InternalAccess bool // Used to allow internal access to badger keys.
 }
 
 func (opt *IteratorOptions) pickTable(t table.TableInterface) bool {
@@ -539,7 +539,7 @@ func (it *Iterator) parseItem() bool {
 	}
 
 	// Skip badger keys.
-	if !it.opt.internalAccess && bytes.HasPrefix(key, badgerPrefix) {
+	if !it.opt.InternalAccess && bytes.HasPrefix(key, badgerPrefix) {
 		mi.Next()
 		return false
 	}

--- a/value.go
+++ b/value.go
@@ -476,7 +476,7 @@ func (vlog *valueLog) deleteMoveKeysFor(fid uint32, tr trace.Trace) error {
 	tr.LazyPrintf("Iterating over move keys to find invalids for fid: %d", fid)
 	err := db.View(func(txn *Txn) error {
 		opt := DefaultIteratorOptions
-		opt.internalAccess = true
+		opt.InternalAccess = true
 		opt.PrefetchValues = false
 		itr := txn.NewIterator(opt)
 		defer itr.Close()


### PR DESCRIPTION
This commit adds `--show-internal` flag which dumps internal keys along
with other keys stored in badger.

It can be used as `badger info --show-keys --show-internal --dir /foo`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/857)
<!-- Reviewable:end -->
