### PR TITLE
Store discardMap in vlog file when it's too large

### DIFF
--- a/db.go
+++ b/db.go
@@ -354,7 +354,9 @@ func (db *DB) Close() error {
 func (db *DB) close() (err error) {
 	db.elog.Printf("Closing database")
 
-	db.vlog.FlushDiscardStats()
+	if err := db.vlog.FlushDiscardStats(); err != nil {
+		return errors.Wrap(err, "failed to flush discard stats")
+	}
 
 	atomic.StoreInt32(&db.blockWrites, 1)
 

--- a/db.go
+++ b/db.go
@@ -354,7 +354,7 @@ func (db *DB) Close() error {
 func (db *DB) close() (err error) {
 	db.elog.Printf("Closing database")
 
-	if err := db.vlog.FlushDiscardStats(); err != nil {
+	if err := db.vlog.flushDiscardStats(); err != nil {
 		return errors.Wrap(err, "failed to flush discard stats")
 	}
 

--- a/db2_test.go
+++ b/db2_test.go
@@ -334,7 +334,7 @@ func TestDiscardMapTooBig(t *testing.T) {
 		}
 		return stat
 	}
-	dir, err := ioutil.TempDir("", "badgertest")
+	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/db2_test.go
+++ b/db2_test.go
@@ -334,7 +334,7 @@ func TestDiscardMapTooBig(t *testing.T) {
 		}
 		return stat
 	}
-	dir, err := ioutil.TempDir(".", "badgertest")
+	dir, err := ioutil.TempDir("", "badgertest")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -354,7 +354,7 @@ func TestDiscardMapTooBig(t *testing.T) {
 		m: createDiscardStats(),
 	}
 
-	db.Close()
+	require.NoError(t, db.Close())
 	// reopen the same DB
 	db, err = Open(ops)
 	require.NoError(t, err, "error while openning db")

--- a/db2_test.go
+++ b/db2_test.go
@@ -324,3 +324,39 @@ func TestPushValueLogLimit(t *testing.T) {
 		}
 	})
 }
+
+// Regression test for https://github.com/dgraph-io/badger/issues/830
+func TestDiscardMapTooBig(t *testing.T) {
+	createDiscardStats := func() map[uint32]int64 {
+		stat := map[uint32]int64{}
+		for i := uint32(0); i < 8000; i++ {
+			stat[i] = 0
+		}
+		return stat
+	}
+	dir, err := ioutil.TempDir(".", "badgertest")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ops := DefaultOptions
+	ops.Dir = dir
+	ops.ValueDir = dir
+	db, err := Open(ops)
+	require.NoError(t, err, "error while openning db")
+
+	// Add some data so that memtable flush happens on close
+	require.NoError(t, db.Update(func(txn *Txn) error {
+		return txn.Set([]byte("foo"), []byte("bar"))
+	}))
+
+	// overwrite discardstat with large value
+	db.vlog.lfDiscardStats = &lfDiscardStats{
+		m: createDiscardStats(),
+	}
+
+	db.Close()
+	// reopen the same DB
+	db, err = Open(ops)
+	require.NoError(t, err, "error while openning db")
+	require.NoError(t, db.Close())
+}

--- a/levels.go
+++ b/levels.go
@@ -619,7 +619,9 @@ func (s *levelsController) compactBuildTables(
 	sort.Slice(newTables, func(i, j int) bool {
 		return y.CompareKeys(newTables[i].Biggest(), newTables[j].Biggest()) < 0
 	})
-	s.kv.vlog.updateDiscardStats(discardStats)
+	if err := s.kv.vlog.updateDiscardStats(discardStats); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to update discard stats")
+	}
 	s.kv.opt.Debugf("Discard stats: %v", discardStats)
 	return newTables, func() error { return decrRefs(newTables) }, nil
 }

--- a/value.go
+++ b/value.go
@@ -1434,7 +1434,7 @@ func (vlog *valueLog) populateDiscardStats() error {
 	if vs.Meta&bitValuePointer > 0 {
 		var vp valuePointer
 		vp.Decode(vs.Value)
-		result, cb, err := vlog.Read(vp, nil)
+		result, cb, err := vlog.Read(vp, new(y.Slice))
 		defer runCallback(cb)
 		if err != nil {
 			return errors.Wrapf(err, "failed to read value pointer from vlog file: %+v", vp)


### PR DESCRIPTION
The discardMap stores the discard status for all value log files in the
db and this could get too large when there are many value log files in
badger. When there are many vlog files, the size of discard map could be
more than what we can keep in the LSM tree.

With this commit, we insert the discardMap into badger using the write
channel which would automatically put the discard map into the value log
file and use it's pointer in the LSM tree if the LSM tree cannot hold it.

Fixes https://github.com/dgraph-io/badger/issues/830
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/858)
<!-- Reviewable:end -->
