### PR TITLE
Enable stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+# exemptLabels:
+# Label to use when marking an issue as stale
+staleLabel: status/stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue was marked as stale and no activity has occurred since then,
+  therefore it will now be closed. Please, reopen it if the issue is still
+  relevant.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,5 +14,5 @@ markComment: >
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
   This issue was marked as stale and no activity has occurred since then,
-  therefore it will now be closed. Please, reopen it if the issue is still
+  therefore it will now be closed. Please, reopen if the issue is still
   relevant.


### PR DESCRIPTION
The bot will mark issues as stale after 30 days of inactivity and close them 7 days later.
The issues marked as stale will use the `status/stale` label.

So far I didn't set any `exemptLabels` but it's something we can consider later on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/863)
<!-- Reviewable:end -->
