### PR TITLE
badger: return error when manifest checksum does not match

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -321,7 +321,8 @@ func (r *countingReader) ReadByte() (b byte, err error) {
 }
 
 var (
-	errBadMagic = errors.New("manifest has bad magic")
+	errBadMagic    = errors.New("manifest has bad magic")
+	errBadChecksum = errors.New("manifest has checksum mismatch")
 )
 
 // ReplayManifestFile reads the manifest file and constructs two manifest objects.  (We need one
@@ -366,7 +367,7 @@ func ReplayManifestFile(fp *os.File) (ret Manifest, truncOffset int64, err error
 			return Manifest{}, 0, err
 		}
 		if crc32.Checksum(buf, y.CastagnoliCrcTable) != binary.BigEndian.Uint32(lenCrcBuf[4:8]) {
-			break
+			return Manifest{}, 0, errBadChecksum
 		}
 
 		var changeSet pb.ManifestChangeSet

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -104,6 +104,10 @@ func TestManifestVersion(t *testing.T) {
 	helpTestManifestFileCorruption(t, 4, "unsupported version")
 }
 
+func TestManifestChecksum(t *testing.T) {
+	helpTestManifestFileCorruption(t, 15, "checksum mismatch")
+}
+
 func key(prefix string, i int) string {
 	return prefix + fmt.Sprintf("%04d", i)
 }


### PR DESCRIPTION
Previously the error would fail silently.

Fixes #690.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/865)
<!-- Reviewable:end -->
