### PR TITLE
Sync files with F_FULLFSYNC on Darwing for Go < 1.12

### DIFF
--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/badger/y"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +76,7 @@ func doBackup(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = f.Sync(); err != nil {
+	if err = y.FileSync(f); err != nil {
 		return err
 	}
 

--- a/db.go
+++ b/db.go
@@ -472,7 +472,7 @@ func syncDir(dir string) error {
 	if err != nil {
 		return errors.Wrapf(err, "While opening directory: %s.", dir)
 	}
-	err = f.Sync()
+	err = y.FileSync(f)
 	closeErr := f.Close()
 	if err != nil {
 		return errors.Wrapf(err, "While syncing directory: %s.", dir)

--- a/manifest.go
+++ b/manifest.go
@@ -216,7 +216,7 @@ func (mf *manifestFile) addChanges(changesParam []*pb.ManifestChange) error {
 	}
 
 	mf.appendLock.Unlock()
-	return mf.fp.Sync()
+	return y.FileSync(mf.fp)
 }
 
 // Has to be 4 bytes.  The value can never change, ever, anyway.
@@ -255,7 +255,7 @@ func helpRewrite(dir string, m *Manifest) (*os.File, int, error) {
 		fp.Close()
 		return nil, 0, err
 	}
-	if err := fp.Sync(); err != nil {
+	if err := y.FileSync(fp); err != nil {
 		fp.Close()
 		return nil, 0, err
 	}

--- a/value.go
+++ b/value.go
@@ -147,7 +147,7 @@ func (lf *logFile) read(p valuePointer, s *y.Slice) (buf []byte, err error) {
 func (lf *logFile) doneWriting(offset uint32) error {
 	// Sync before acquiring lock.  (We call this from write() and thus know we have shared access
 	// to the fd.)
-	if err := lf.fd.Sync(); err != nil {
+	if err := y.FileSync(lf.fd); err != nil {
 		return errors.Wrapf(err, "Unable to sync value log: %q", lf.path)
 	}
 	// Close and reopen the file read-only.  Acquire lock because fd will become invalid for a bit.
@@ -176,7 +176,7 @@ func (lf *logFile) doneWriting(offset uint32) error {
 
 // You must hold lf.lock to sync()
 func (lf *logFile) sync() error {
-	return lf.fd.Sync()
+	return y.FileSync(lf.fd)
 }
 
 var errStop = errors.New("Stop iteration")

--- a/y/file_sync.go
+++ b/y/file_sync.go
@@ -1,0 +1,28 @@
+// +build !darwin go1.12
+
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package y
+
+import "os"
+
+// FileSync calls os.File.Sync with the right parameters.
+// This function can be removed once we stop supporting Go 1.11
+// on MacOS.
+//
+// More info: https://golang.org/issue/26650.
+func FileSync(f *os.File) error { return f.Sync() }

--- a/y/file_sync_darwin.go
+++ b/y/file_sync_darwin.go
@@ -1,0 +1,37 @@
+// +build darwin,!go1.12
+
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package y
+
+import (
+	"os"
+	"syscall"
+)
+
+// FileSync calls os.File.Sync with the right parameters.
+// This function can be removed once we stop supporting Go 1.11
+// on MacOS.
+//
+// More info: https://golang.org/issue/26650.
+func FileSync(f *os.File) error {
+	_, _, err := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), syscall.F_FULLFSYNC, 0)
+	if err == 0 {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
As documented in https:///golang.org/issues/26650, versions of Go below 1.12
do not use the correct method to sync files on Darwin (MacOS).

This can lead to data loss or corruption, so we should fix it on our codebase.

The proposed solution uses build constraints so this change should only impact
badger on MacOS for versions before Go 1.12.

Fixes #563.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/871)
<!-- Reviewable:end -->
