### PR TITLE
Fix bug by using the UserMeta field

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -96,7 +96,7 @@ func (p *publisher) publishUpdates(reqs requests) {
 						kv := &pb.KV{
 							Key:       y.ParseKey(k),
 							Value:     y.SafeCopy(nil, e.Value),
-							Meta:      []byte{e.UserMeta},
+							UserMeta:  []byte{e.UserMeta},
 							ExpiresAt: e.ExpiresAt,
 							Version:   y.ParseTs(k),
 						}


### PR DESCRIPTION
Dgraph only uses the UserMeta field (not the Meta field) to set meta information about a key. Hence it's critical to use the `UserMeta` field to publish updates in the use case of cross data-center replication via Kafka.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/873)
<!-- Reviewable:end -->
