### PR TITLE
Use actual value of uint16-16 in ErrValueThreshold

### DIFF
--- a/db.go
+++ b/db.go
@@ -192,7 +192,7 @@ func Open(opt Options) (db *DB, err error) {
 	opt.maxBatchSize = (15 * opt.MaxTableSize) / 100
 	opt.maxBatchCount = opt.maxBatchSize / int64(skl.MaxNodeSize)
 
-	if opt.ValueThreshold > math.MaxUint16-16 {
+	if opt.ValueThreshold > ValueThresholdLimit {
 		return nil, ErrValueThreshold
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -30,7 +30,7 @@ var (
 	// ErrValueThreshold is returned when ValueThreshold is set to a value close to or greater than
 	// uint16.
 	ErrValueThreshold = errors.Errorf(
-		"Invalid ValueThreshold, must be lower than %d", math.MaxUint16-16)
+		"Invalid ValueThreshold, must be less than %d", math.MaxUint16-16+1)
 
 	// ErrKeyNotFound is returned when key isn't found on a txn.Get.
 	ErrKeyNotFound = errors.New("Key not found")

--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,8 @@
 package badger
 
 import (
+	"math"
+
 	"github.com/pkg/errors"
 )
 
@@ -27,7 +29,8 @@ var (
 
 	// ErrValueThreshold is returned when ValueThreshold is set to a value close to or greater than
 	// uint16.
-	ErrValueThreshold = errors.New("Invalid ValueThreshold, must be lower than uint16")
+	ErrValueThreshold = errors.Errorf(
+		"Invalid ValueThreshold, must be lower than %d", math.MaxUint16-16)
 
 	// ErrKeyNotFound is returned when key isn't found on a txn.Get.
 	ErrKeyNotFound = errors.New("Key not found")

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// ValueThresholdLimit is the maximum permissible value of opt.ValueThreshold.
+	ValueThresholdLimit = math.MaxUint16 - 16 + 1
+)
+
 var (
 	// ErrValueLogSize is returned when opt.ValueLogFileSize option is not within the valid
 	// range.
@@ -30,7 +35,7 @@ var (
 	// ErrValueThreshold is returned when ValueThreshold is set to a value close to or greater than
 	// uint16.
 	ErrValueThreshold = errors.Errorf(
-		"Invalid ValueThreshold, must be less than %d", math.MaxUint16-16+1)
+		"Invalid ValueThreshold, must be less than %d", ValueThresholdLimit)
 
 	// ErrKeyNotFound is returned when key isn't found on a txn.Get.
 	ErrKeyNotFound = errors.New("Key not found")


### PR DESCRIPTION
The ErrValueThreshold doesn't really show what should be the max value
of value threshold. This commit adds the actual value of value threshold
to the error message.

Fixes https://github.com/dgraph-io/badger/issues/867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/877)
<!-- Reviewable:end -->
