### PR TITLE
[BREAKING CHANGE] Unexport Loader type and its methods.

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -127,20 +127,20 @@ func writeTo(list *pb.KVList, w io.Writer) error {
 	return err
 }
 
-type Loader struct {
+type loader struct {
 	db       *DB
 	throttle *y.Throttle
 	entries  []*Entry
 }
 
-func (db *DB) NewLoader(maxPendingWrites int) *Loader {
-	return &Loader{
+func (db *DB) newLoader(maxPendingWrites int) *loader {
+	return &loader{
 		db:       db,
 		throttle: y.NewThrottle(maxPendingWrites),
 	}
 }
 
-func (l *Loader) Set(kv *pb.KV) error {
+func (l *loader) set(kv *pb.KV) error {
 	var userMeta, meta byte
 	if len(kv.UserMeta) > 0 {
 		userMeta = kv.UserMeta[0]
@@ -162,7 +162,7 @@ func (l *Loader) Set(kv *pb.KV) error {
 	return nil
 }
 
-func (l *Loader) send() error {
+func (l *loader) send() error {
 	if err := l.throttle.Do(); err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func (l *Loader) send() error {
 	return nil
 }
 
-func (l *Loader) Finish() error {
+func (l *loader) finish() error {
 	if len(l.entries) > 0 {
 		if err := l.send(); err != nil {
 			return err
@@ -195,7 +195,7 @@ func (db *DB) Load(r io.Reader, maxPendingWrites int) error {
 	br := bufio.NewReaderSize(r, 16<<10)
 	unmarshalBuf := make([]byte, 1<<10)
 
-	loader := db.NewLoader(maxPendingWrites)
+	ldr := db.newLoader(maxPendingWrites)
 	for {
 		var sz uint64
 		err := binary.Read(br, binary.LittleEndian, &sz)
@@ -219,7 +219,7 @@ func (db *DB) Load(r io.Reader, maxPendingWrites int) error {
 		}
 
 		for _, kv := range list.Kv {
-			if err := loader.Set(kv); err != nil {
+			if err := ldr.set(kv); err != nil {
 				return err
 			}
 
@@ -231,7 +231,7 @@ func (db *DB) Load(r io.Reader, maxPendingWrites int) error {
 		}
 	}
 
-	if err := loader.Finish(); err != nil {
+	if err := ldr.finish(); err != nil {
 		return err
 	}
 	db.orc.txnMark.Done(db.orc.nextTxnTs - 1)

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -540,12 +540,12 @@ func runTest(cmd *cobra.Command, args []string) error {
 				accountIDS = append(accountIDS, key(i))
 			}
 			updater := func(kvs *pb.KVList) {
-				loader := subscribeDB.NewLoader(16)
+				batch := subscribeDB.NewWriteBatch()
 				for _, kv := range kvs.GetKv() {
-					y.Check(loader.Set(kv))
+					y.Check(batch.Set(kv.Key, kv.Value))
 				}
 
-				y.Check(loader.Finish())
+				y.Check(batch.Flush())
 			}
 			_ = db.Subscribe(ctx, updater, accountIDS[0], accountIDS[1:]...)
 		}()


### PR DESCRIPTION
This type is only used internally to restore a backup. It should not be
exported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/887)
<!-- Reviewable:end -->

Fixes #883 