### PR TITLE
Stream Writer: Stop oracle before starting new one

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -157,6 +157,9 @@ func (sw *StreamWriter) Flush() error {
 	}
 
 	if !sw.db.opt.managedTxns {
+		if sw.db.orc != nil {
+			sw.db.orc.Stop()
+		}
 		sw.db.orc = newOracle(sw.db.opt)
 		sw.db.orc.nextTxnTs = sw.maxVersion
 		sw.db.orc.txnMark.Done(sw.maxVersion)

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -282,8 +282,9 @@ func TestStreamWriter5(t *testing.T) {
 		require.NoError(t, db.Close())
 
 		var err error
-		_, err = Open(db.opt)
+		db, err = Open(db.opt)
 		require.NoError(t, err)
+		require.NoError(t, db.Close())
 	})
 }
 
@@ -324,7 +325,8 @@ func TestStreamWriter6(t *testing.T) {
 		}
 		require.NoError(t, db.Close())
 
-		_, err := Open(db.opt)
+		db, err := Open(db.opt)
 		require.NoError(t, err)
+		require.NoError(t, db.Close())
 	})
 }


### PR DESCRIPTION
This PR fixes two issues
1. It stops the running oracle before creating a new one If we do not stop the existing one, the go routines will keep running in the background.
2. Stop the running DB when the test completes. We don't want to have go routines running in the background while other tests are running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/890)
<!-- Reviewable:end -->
