### PR TITLE
Skip directory sync on windows

### DIFF
--- a/db.go
+++ b/db.go
@@ -469,22 +469,6 @@ func (db *DB) Sync() error {
 	return db.vlog.sync(math.MaxUint32)
 }
 
-// When you create or delete a file, you have to ensure the directory entry for the file is synced
-// in order to guarantee the file is visible (if the system crashes).  (See the man page for fsync,
-// or see https://github.com/coreos/etcd/issues/6368 for an example.)
-func syncDir(dir string) error {
-	f, err := openDir(dir)
-	if err != nil {
-		return errors.Wrapf(err, "While opening directory: %s.", dir)
-	}
-	err = y.FileSync(f)
-	closeErr := f.Close()
-	if err != nil {
-		return errors.Wrapf(err, "While syncing directory: %s.", dir)
-	}
-	return errors.Wrapf(closeErr, "While closing directory: %s.", dir)
-}
-
 // getMemtables returns the current memtables and get references.
 func (db *DB) getMemTables() ([]*skl.Skiplist, func()) {
 	db.RLock()

--- a/dir_unix.go
+++ b/dir_unix.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dgraph-io/badger/v2/y"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -99,3 +100,19 @@ func (guard *directoryLockGuard) release() error {
 
 // openDir opens a directory for syncing.
 func openDir(path string) (*os.File, error) { return os.Open(path) }
+
+// When you create or delete a file, you have to ensure the directory entry for the file is synced
+// in order to guarantee the file is visible (if the system crashes). (See the man page for fsync,
+// or see https://github.com/coreos/etcd/issues/6368 for an example.)
+func syncDir(dir string) error {
+	f, err := openDir(dir)
+	if err != nil {
+		return errors.Wrapf(err, "While opening directory: %s.", dir)
+	}
+	err = y.FileSync(f)
+	closeErr := f.Close()
+	if err != nil {
+		return errors.Wrapf(err, "While syncing directory: %s.", dir)
+	}
+	return errors.Wrapf(closeErr, "While closing directory: %s.", dir)
+}

--- a/dir_windows.go
+++ b/dir_windows.go
@@ -104,3 +104,7 @@ func (g *directoryLockGuard) release() error {
 	g.path = ""
 	return syscall.CloseHandle(g.h)
 }
+
+// Windows doesn't support syncing directories to the file system. See
+// https://github.com/dgraph-io/badger/issues/699#issuecomment-504133587 for more details.
+func syncDir(dir string) error { return nil }


### PR DESCRIPTION
Windows doesn't support syncing directories. This commit adds a no-op method for syncing directories on windows.
See https://github.com/dgraph-io/badger/issues/699#issuecomment-504133587 for more details.

Fixes https://github.com/dgraph-io/badger/issues/699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/892)
<!-- Reviewable:end -->
