### PR TITLE
[breaking/format] Support for max value size of uint32

### DIFF
--- a/db.go
+++ b/db.go
@@ -192,17 +192,17 @@ func Open(opt Options) (db *DB, err error) {
 	opt.maxBatchSize = (15 * opt.MaxTableSize) / 100
 	opt.maxBatchCount = opt.maxBatchSize / int64(skl.MaxNodeSize)
 
-	// We are limiting opt.ValueThreshold to LSMOnlyOptions.ValueThreshold for now.
-	if opt.ValueThreshold > LSMOnlyOptions.ValueThreshold {
+	// We are limiting opt.ValueThreshold to maxValueThreshold for now.
+	if opt.ValueThreshold > maxValueThreshold {
 		return nil, errors.Errorf("Invalid ValueThreshold, must be less or equal to %d",
-			LSMOnlyOptions.ValueThreshold)
+			maxValueThreshold)
 	}
 
 	// If ValueThreshold is greater than opt.maxBatchSize, we won't be able to push any data using
 	// the transaction APIs. Transaction batches entries into batches of size opt.maxBatchSize.
 	if int64(opt.ValueThreshold) > opt.maxBatchSize {
-		return nil, errors.Errorf("Valuethreshold size too big. Either reduce opt.ValueThreshold " +
-			"or increase opt.MaxTableSize.")
+		return nil, errors.Errorf("Valuethreshold greater than max batch size of %d. Either "+
+			"reduce opt.ValueThreshold or increase opt.MaxTableSize.", opt.maxBatchSize)
 	}
 
 	if opt.ReadOnly {

--- a/db.go
+++ b/db.go
@@ -192,7 +192,7 @@ func Open(opt Options) (db *DB, err error) {
 	opt.maxBatchSize = (15 * opt.MaxTableSize) / 100
 	opt.maxBatchCount = opt.maxBatchSize / int64(skl.MaxNodeSize)
 
-	if opt.ValueThreshold > math.MaxUint16-16 {
+	if opt.ValueThreshold > math.MaxUint32-100 { // TODO: correct this.
 		return nil, ErrValueThreshold
 	}
 
@@ -248,9 +248,10 @@ func Open(opt Options) (db *DB, err error) {
 			}
 		}()
 	}
-	if !(opt.ValueLogFileSize <= 2<<30 && opt.ValueLogFileSize >= 1<<20) {
-		return nil, ErrValueLogSize
-	}
+	// TODO: fix this.
+	// if !(opt.ValueLogFileSize <= 2<<30 && opt.ValueLogFileSize >= 1<<20) {
+	// 	return nil, ErrValueLogSize
+	// }
 	if !(opt.ValueLogLoadingMode == options.FileIO ||
 		opt.ValueLogLoadingMode == options.MemoryMap) {
 		return nil, ErrInvalidLoadingMode

--- a/db.go
+++ b/db.go
@@ -192,9 +192,10 @@ func Open(opt Options) (db *DB, err error) {
 	opt.maxBatchSize = (15 * opt.MaxTableSize) / 100
 	opt.maxBatchCount = opt.maxBatchSize / int64(skl.MaxNodeSize)
 
-	// ValueThreshold cannot be greater than ValueThresholdLimit.
-	if opt.ValueThreshold > ValueThresholdLimit {
-		return nil, ErrValueThreshold
+	// We are limiting opt.ValueThreshold to LSMOnlyOptions.ValueThreshold for now.
+	if opt.ValueThreshold > LSMOnlyOptions.ValueThreshold {
+		return nil, errors.Errorf("Invalid ValueThreshold, must be less or equal to %d",
+			LSMOnlyOptions.ValueThreshold)
 	}
 
 	// If ValueThreshold is greater than opt.maxBatchSize, we won't be able to push any data using

--- a/db2_test.go
+++ b/db2_test.go
@@ -383,24 +383,19 @@ func TestDiscardMapTooBig(t *testing.T) {
 	require.NoError(t, db.Close())
 }
 
-// Tests for value size uint32
+// Test for values of size uint32.
 func TestBigValues(t *testing.T) {
-	// This test takes too much memory. So, run separately.
 	if !*manual {
 		t.Skip("Skipping test meant to be run manually.")
 		return
 	}
 	opts := DefaultOptions
-	opts.ValueThreshold = 1 << 30
-	opts.MaxTableSize = 5 << 30
-	opts.ValueLogFileSize = 5 << 30
-	opts.ValueLogMaxEntries = 2
-	opts.NumLevelZeroTables = 2
-	opts.NumLevelZeroTablesStall = 3
+	opts.ValueThreshold = 1 << 20
+	opts.ValueLogMaxEntries = 100
 	runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
-		keyCount := 10
+		keyCount := 1000
 
-		data := fmt.Sprintf("%2000000000d", 1)
+		data := bytes.Repeat([]byte("a"), (1 << 20)) // Valuesize 1 MB.
 		key := func(i int) string {
 			return fmt.Sprintf("%65000d", i)
 		}
@@ -430,7 +425,7 @@ func TestBigValues(t *testing.T) {
 			require.NoError(t, saveByKey(key(i), []byte(data)))
 		}
 
-		for i := 0; i < 1; i++ {
+		for i := 0; i < keyCount; i++ {
 			require.NoError(t, getByKey(key(i)))
 		}
 	})

--- a/db_test.go
+++ b/db_test.go
@@ -1471,9 +1471,17 @@ func TestLSMOnly(t *testing.T) {
 	dopts := DefaultOptions
 	require.NotEqual(t, dopts.ValueThreshold, opts.ValueThreshold)
 
-	dopts.ValueThreshold = 1 << 32
+	dopts.ValueThreshold = 1 << 21
 	_, err = Open(dopts)
 	require.Equal(t, ErrValueThreshold, err)
+
+	// Also test for error, when ValueThresholdSize is greater than maxBatchSize.
+	dopts.ValueThreshold = ValueThresholdLimit
+	dopts.MaxTableSize = ValueThresholdLimit // maxBatchSize is calculated from MaxTableSize.
+	_, err = Open(dopts)
+	require.Error(t, err, "db creation should have been failed")
+	require.Contains(t, err.Error(), "Valuethreshold size too big",
+		"valuethreshold cannot be > maxBatchSize")
 
 	opts.ValueLogMaxEntries = 100
 	db, err := Open(opts)

--- a/db_test.go
+++ b/db_test.go
@@ -1471,7 +1471,7 @@ func TestLSMOnly(t *testing.T) {
 	dopts := DefaultOptions
 	require.NotEqual(t, dopts.ValueThreshold, opts.ValueThreshold)
 
-	dopts.ValueThreshold = 1 << 16
+	dopts.ValueThreshold = 1 << 32
 	_, err = Open(dopts)
 	require.Equal(t, ErrValueThreshold, err)
 

--- a/db_test.go
+++ b/db_test.go
@@ -1473,7 +1473,7 @@ func TestLSMOnly(t *testing.T) {
 
 	dopts.ValueThreshold = 1 << 21
 	_, err = Open(dopts)
-	require.Equal(t, "Invalid ValueThreshold", err.Error())
+	require.Contains(t, err.Error(), "Invalid ValueThreshold")
 
 	// Also test for error, when ValueThresholdSize is greater than maxBatchSize.
 	dopts.ValueThreshold = LSMOnlyOptions.ValueThreshold

--- a/db_test.go
+++ b/db_test.go
@@ -1473,11 +1473,12 @@ func TestLSMOnly(t *testing.T) {
 
 	dopts.ValueThreshold = 1 << 21
 	_, err = Open(dopts)
-	require.Equal(t, ErrValueThreshold, err)
+	require.Equal(t, "Invalid ValueThreshold", err.Error())
 
 	// Also test for error, when ValueThresholdSize is greater than maxBatchSize.
-	dopts.ValueThreshold = ValueThresholdLimit
-	dopts.MaxTableSize = ValueThresholdLimit // maxBatchSize is calculated from MaxTableSize.
+	dopts.ValueThreshold = LSMOnlyOptions.ValueThreshold
+	// maxBatchSize is calculated from MaxTableSize.
+	dopts.MaxTableSize = int64(LSMOnlyOptions.ValueThreshold)
 	_, err = Open(dopts)
 	require.Error(t, err, "db creation should have been failed")
 	require.Contains(t, err.Error(), "Valuethreshold size too big",

--- a/db_test.go
+++ b/db_test.go
@@ -1481,8 +1481,7 @@ func TestLSMOnly(t *testing.T) {
 	dopts.MaxTableSize = int64(LSMOnlyOptions.ValueThreshold)
 	_, err = Open(dopts)
 	require.Error(t, err, "db creation should have been failed")
-	require.Contains(t, err.Error(), "Valuethreshold size too big",
-		"valuethreshold cannot be > maxBatchSize")
+	require.Contains(t, err.Error(), "Valuethreshold greater than max batch size")
 
 	opts.ValueLogMaxEntries = 100
 	db, err := Open(opts)

--- a/errors.go
+++ b/errors.go
@@ -25,11 +25,6 @@ var (
 	// range.
 	ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 2GB")
 
-	// ErrValueThreshold is returned when ValueThreshold is set
-	// to a value greater than ValueThresholdLimit.
-	ErrValueThreshold = errors.Errorf(
-		"Invalid ValueThreshold, must be less than or equal to %d", ValueThresholdLimit)
-
 	// ErrKeyNotFound is returned when key isn't found on a txn.Get.
 	ErrKeyNotFound = errors.New("Key not found")
 

--- a/errors.go
+++ b/errors.go
@@ -25,9 +25,10 @@ var (
 	// range.
 	ErrValueLogSize = errors.New("Invalid ValueLogFileSize, must be between 1MB and 2GB")
 
-	// ErrValueThreshold is returned when ValueThreshold is set to a value close to or greater than
-	// uint16.
-	ErrValueThreshold = errors.New("Invalid ValueThreshold, must be lower than uint16")
+	// ErrValueThreshold is returned when ValueThreshold is set
+	// to a value greater than ValueThresholdLimit.
+	ErrValueThreshold = errors.Errorf(
+		"Invalid ValueThreshold, must be less than or equal to %d", ValueThresholdLimit)
 
 	// ErrKeyNotFound is returned when key isn't found on a txn.Get.
 	ErrKeyNotFound = errors.New("Key not found")

--- a/options.go
+++ b/options.go
@@ -155,11 +155,6 @@ var DefaultOptions = Options{
 	ChecksumVerificationMode: options.NoVerification,
 }
 
-const (
-	// ValueThresholdLimit is the maximum permissible value of opt.ValueThreshold.
-	ValueThresholdLimit = (1 << 20) // 1 MB.
-)
-
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold
 // so values would be collocated with the LSM tree, with value log largely acting
 // as a write-ahead log only. These options would reduce the disk usage of value
@@ -169,7 +164,7 @@ var LSMOnlyOptions = Options{}
 func init() {
 	LSMOnlyOptions = DefaultOptions
 
-	LSMOnlyOptions.ValueThreshold = ValueThresholdLimit // 1 MB for now, can be changed in future.
+	LSMOnlyOptions.ValueThreshold = (1 << 20) // 1 MB for now, can be changed in future.
 	// Let's not set any other options, because they can cause issues with the
 	// size of key-value a user can pass to Badger. For e.g., if we set
 	// ValueLogFileSize to 64MB, a user can't pass a value more than that.

--- a/options.go
+++ b/options.go
@@ -155,8 +155,13 @@ var DefaultOptions = Options{
 	ChecksumVerificationMode: options.NoVerification,
 }
 
+const (
+	// ValueThresholdLimit is the maximum permissible value of opt.ValueThreshold.
+	ValueThresholdLimit = (1 << 20) // 1 MB.
+)
+
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold
-// so values would be colocated with the LSM tree, with value log largely acting
+// so values would be collocated with the LSM tree, with value log largely acting
 // as a write-ahead log only. These options would reduce the disk usage of value
 // log, and make Badger act more like a typical LSM tree.
 var LSMOnlyOptions = Options{}
@@ -164,8 +169,7 @@ var LSMOnlyOptions = Options{}
 func init() {
 	LSMOnlyOptions = DefaultOptions
 
-	// TODO: exact value of ValueThreshold ??
-	LSMOnlyOptions.ValueThreshold = 4294967195 // Max value length which fits in uint32.
+	LSMOnlyOptions.ValueThreshold = ValueThresholdLimit // 1 MB for now, can be changed in future.
 	// Let's not set any other options, because they can cause issues with the
 	// size of key-value a user can pass to Badger. For e.g., if we set
 	// ValueLogFileSize to 64MB, a user can't pass a value more than that.
@@ -175,5 +179,5 @@ func init() {
 	// achieve a heavier usage of LSM tree.
 	// NOTE: If a user does not want to set 64KB as the ValueThreshold because
 	// of performance reasons, 1KB would be a good option too, allowing
-	// values smaller than 1KB to be colocated with the keys in the LSM tree.
+	// values smaller than 1KB to be collocated with the keys in the LSM tree.
 }

--- a/options.go
+++ b/options.go
@@ -164,7 +164,8 @@ var LSMOnlyOptions = Options{}
 func init() {
 	LSMOnlyOptions = DefaultOptions
 
-	LSMOnlyOptions.ValueThreshold = 65500 // Max value length which fits in uint16.
+	// TODO: exact value of ValueThreshold ??
+	LSMOnlyOptions.ValueThreshold = 4294967195 // Max value length which fits in uint32.
 	// Let's not set any other options, because they can cause issues with the
 	// size of key-value a user can pass to Badger. For e.g., if we set
 	// ValueLogFileSize to 64MB, a user can't pass a value more than that.

--- a/options.go
+++ b/options.go
@@ -155,6 +155,10 @@ var DefaultOptions = Options{
 	ChecksumVerificationMode: options.NoVerification,
 }
 
+const (
+	maxValueThreshold = (1 << 20) // 1 MB
+)
+
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold
 // so values would be collocated with the LSM tree, with value log largely acting
 // as a write-ahead log only. These options would reduce the disk usage of value
@@ -164,7 +168,7 @@ var LSMOnlyOptions = Options{}
 func init() {
 	LSMOnlyOptions = DefaultOptions
 
-	LSMOnlyOptions.ValueThreshold = (1 << 20) // 1 MB for now, can be changed in future.
+	LSMOnlyOptions.ValueThreshold = maxValueThreshold // 1 MB.
 	// Let's not set any other options, because they can cause issues with the
 	// size of key-value a user can pass to Badger. For e.g., if we set
 	// ValueLogFileSize to 64MB, a user can't pass a value more than that.

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -120,8 +120,8 @@ func (s *Arena) getKey(offset uint32, size uint16) []byte {
 
 // getVal returns byte slice at offset. The given size should be just the value
 // size and should NOT include the meta bytes.
-func (s *Arena) getVal(offset uint32, size uint16) (ret y.ValueStruct) {
-	ret.Decode(s.buf[offset : offset+uint32(size)])
+func (s *Arena) getVal(offset uint32, size uint32) (ret y.ValueStruct) {
+	ret.Decode(s.buf[offset : offset+size])
 	return
 }
 

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -53,7 +53,7 @@ type node struct {
 	// Multiple parts of the value are encoded as a single uint64 so that it
 	// can be atomically loaded and stored:
 	//   value offset: uint32 (bits 0-31)
-	//   value size  : uint16 (bits 32-47)
+	//   value size  : uint16 (bits 32-63)
 	value uint64
 
 	// A byte slice is 24 bytes. We are trying to save space here.
@@ -113,13 +113,13 @@ func newNode(arena *Arena, key []byte, v y.ValueStruct, height int) *node {
 	return node
 }
 
-func encodeValue(valOffset uint32, valSize uint16) uint64 {
+func encodeValue(valOffset uint32, valSize uint32) uint64 {
 	return uint64(valSize)<<32 | uint64(valOffset)
 }
 
-func decodeValue(value uint64) (valOffset uint32, valSize uint16) {
+func decodeValue(value uint64) (valOffset uint32, valSize uint32) {
 	valOffset = uint32(value)
-	valSize = uint16(value >> 32)
+	valSize = uint32(value >> 32)
 	return
 }
 
@@ -135,7 +135,7 @@ func NewSkiplist(arenaSize int64) *Skiplist {
 	}
 }
 
-func (s *node) getValueOffset() (uint32, uint16) {
+func (s *node) getValueOffset() (uint32, uint32) {
 	value := atomic.LoadUint64(&s.value)
 	return decodeValue(value)
 }

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -123,7 +123,7 @@ func TestBasic(t *testing.T) {
 
 	l.Put(y.KeyWithTs([]byte("key4"), 1), y.ValueStruct{Value: val5, Meta: 60, UserMeta: 0})
 	v = l.Get(y.KeyWithTs([]byte("key4"), 1))
-	require.True(t, v.Value != nil)
+	require.NotNil(t, v.Value)
 	require.EqualValues(t, val5, v.Value)
 	require.EqualValues(t, 60, v.Meta)
 }
@@ -185,7 +185,7 @@ func TestConcurrentBasicBigValues(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			v := l.Get(key(i))
-			require.True(t, v.Value != nil)
+			require.NotNil(t, v.Value)
 			require.EqualValues(t, BigValue(i), v.Value)
 		}(i)
 	}

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -91,6 +91,7 @@ func TestBasic(t *testing.T) {
 	val2 := newValue(52)
 	val3 := newValue(62)
 	val4 := newValue(72)
+	val5 := []byte(fmt.Sprintf("%0102400d", 1)) // Have size 100 KB which is > math.MaxUint16.
 
 	// Try inserting values.
 	// Somehow require.Nil doesn't work when checking for unsafe.Pointer(nil).
@@ -119,6 +120,12 @@ func TestBasic(t *testing.T) {
 	require.True(t, v.Value != nil)
 	require.EqualValues(t, "00072", string(v.Value))
 	require.EqualValues(t, 12, v.Meta)
+
+	l.Put(y.KeyWithTs([]byte("key4"), 1), y.ValueStruct{Value: val5, Meta: 60, UserMeta: 0})
+	v = l.Get(y.KeyWithTs([]byte("key4"), 1))
+	require.True(t, v.Value != nil)
+	require.EqualValues(t, val5, v.Value)
+	require.EqualValues(t, 60, v.Meta)
 }
 
 // TestConcurrentBasic tests concurrent writes followed by concurrent reads.
@@ -146,6 +153,40 @@ func TestConcurrentBasic(t *testing.T) {
 			v := l.Get(key(i))
 			require.True(t, v.Value != nil)
 			require.EqualValues(t, newValue(i), v.Value)
+		}(i)
+	}
+	wg.Wait()
+	require.EqualValues(t, n, length(l))
+}
+
+func TestConcurrentBasicBigValues(t *testing.T) {
+	const n = 100
+	arenaSize := int64(120 << 20) // 120 MB
+	l := NewSkiplist(arenaSize)
+	var wg sync.WaitGroup
+	key := func(i int) []byte {
+		return y.KeyWithTs([]byte(fmt.Sprintf("%05d", i)), 0)
+	}
+	BigValue := func(i int) []byte {
+		return []byte(fmt.Sprintf("%1048576dd", i)) // Have 1 MB value which is > math.MaxUint16.
+	}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			l.Put(key(i),
+				y.ValueStruct{Value: BigValue(i), Meta: 0, UserMeta: 0})
+		}(i)
+	}
+	wg.Wait()
+	// Check values. Concurrent reads.
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			v := l.Get(key(i))
+			require.True(t, v.Value != nil)
+			require.EqualValues(t, BigValue(i), v.Value)
 		}(i)
 	}
 	wg.Wait()

--- a/table/builder.go
+++ b/table/builder.go
@@ -37,26 +37,26 @@ func newBuffer(sz int) *bytes.Buffer {
 type header struct {
 	plen uint16 // Overlap with base key.
 	klen uint16 // Length of the diff.
-	vlen uint16 // Length of value.
+	vlen uint32 // Length of value.
 }
 
 // Encode encodes the header.
 func (h header) Encode(b []byte) {
 	binary.BigEndian.PutUint16(b[0:2], h.plen)
 	binary.BigEndian.PutUint16(b[2:4], h.klen)
-	binary.BigEndian.PutUint16(b[4:6], h.vlen)
+	binary.BigEndian.PutUint32(b[4:8], h.vlen)
 }
 
 // Decode decodes the header.
 func (h *header) Decode(buf []byte) int {
 	h.plen = binary.BigEndian.Uint16(buf[0:2])
 	h.klen = binary.BigEndian.Uint16(buf[2:4])
-	h.vlen = binary.BigEndian.Uint16(buf[4:6])
+	h.vlen = binary.BigEndian.Uint32(buf[4:8])
 	return h.Size()
 }
 
 // Size returns size of the header. Currently it's just a constant.
-func (h header) Size() int { return 6 }
+func (h header) Size() int { return 8 }
 
 // Builder is used in building a table.
 type Builder struct {
@@ -128,15 +128,15 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	h := header{
 		plen: uint16(len(key) - len(diffKey)),
 		klen: uint16(len(diffKey)),
-		vlen: uint16(v.EncodedSize()),
+		vlen: uint32(v.EncodedSize()),
 	}
 
 	// store current entry's offset
-	y.AssertTrue(b.buf.Len() < math.MaxUint32)
+	y.AssertTrue(b.buf.Len() < math.MaxUint32) // TODO: now value size is uint32, should we change this?
 	b.entryOffsets = append(b.entryOffsets, uint32(b.buf.Len())-b.baseOffset)
 
 	// Layout: header, diffKey, value.
-	var hbuf [6]byte
+	var hbuf [8]byte
 	h.Encode(hbuf[:])
 	b.buf.Write(hbuf[:])
 	b.buf.Write(diffKey) // We only need to store the key difference.

--- a/table/builder.go
+++ b/table/builder.go
@@ -132,7 +132,7 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	}
 
 	// store current entry's offset
-	y.AssertTrue(b.buf.Len() < math.MaxUint32) // TODO: now value size is uint32, should we change this?
+	y.AssertTrue(b.buf.Len() < math.MaxUint32)
 	b.entryOffsets = append(b.entryOffsets, uint32(b.buf.Len())-b.baseOffset)
 
 	// Layout: header, diffKey, value.

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -634,6 +634,42 @@ func TestMergingIteratorTakeTwo(t *testing.T) {
 	require.False(t, it.Valid())
 }
 
+func TestTableBigValues(t *testing.T) {
+	value := func(i int) []byte {
+		return []byte(fmt.Sprintf("%1048576d", i)) // Return 1MB value which is > math.MaxUint16.
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
+	f, err := y.OpenSyncedFile(filename, true)
+	require.NoError(t, err, "unable to create file")
+
+	n := 100 // Insert 100 keys.
+	builder := NewTableBuilder()
+	for i := 0; i < n; i++ {
+		key := y.KeyWithTs([]byte(key("", i)), 0)
+		vs := y.ValueStruct{Value: value(i)}
+		require.NoError(t, builder.Add(key, vs))
+	}
+
+	f.Write(builder.Finish())
+	tbl, err := OpenTable(f, options.LoadToRAM, options.OnTableAndBlockRead)
+	require.NoError(t, err, "uanble to open table")
+	defer tbl.DecrRef()
+
+	itr := tbl.NewIterator(false)
+	require.True(t, itr.Valid())
+
+	count := 0
+	for itr.Rewind(); itr.Valid(); itr.Next() {
+		require.Equal(t, []byte(key("", count)), y.ParseKey(itr.Key()), "keys are not equal")
+		require.Equal(t, value(count), itr.Value().Value, "values are not equal")
+		count++
+	}
+	require.False(t, itr.Valid(), "table iterator should be invalid now")
+	require.Equal(t, n, count)
+}
+
 func BenchmarkRead(b *testing.B) {
 	n := int(5 * 1e6)
 	tbl := getTableForBenchmarks(b, n)

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -47,14 +47,14 @@ func sizeVarint(x uint64) (n int) {
 }
 
 // EncodedSize is the size of the ValueStruct when encoded
-func (v *ValueStruct) EncodedSize() uint16 {
+func (v *ValueStruct) EncodedSize() uint32 {
 	sz := len(v.Value) + 2 // meta, usermeta.
 	if v.ExpiresAt == 0 {
-		return uint16(sz + 1)
+		return uint32(sz + 1)
 	}
 
 	enc := sizeVarint(v.ExpiresAt)
-	return uint16(sz + enc)
+	return uint32(sz + enc)
 }
 
 // Decode uses the length of the slice to infer the length of the Value field.


### PR DESCRIPTION
Currently, we store value size in uint16(in skiplist and table). This limits us to have value size to 64KB. This PR adds changes to store value size in uint32.
Impacted parts:
* Value size in skiplist
* Value size in header of table entries
* LSMOnlyOptions.ValueThreshold value

Fixes https://github.com/dgraph-io/badger/issues/812

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/893)
<!-- Reviewable:end -->
