### PR TITLE
Add options to transform backup data back and forth to a different format

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -69,10 +69,28 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 				}
 			}
 
+			// Convert key and/or values to a different format if requested before writing
+			// the key-value pair.
+			keyCopy := item.KeyCopy(nil)
+			if stream.db.opt.BackupKeyFn != nil {
+				var err error
+				keyCopy, err = stream.db.opt.BackupKeyFn(keyCopy)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if stream.db.opt.BackupValueFn != nil {
+				var err error
+				valCopy, err = stream.db.opt.BackupValueFn(valCopy)
+				if err != nil {
+					return nil, err
+				}
+			}
+
 			// clear txn bits
 			meta := item.meta &^ (bitTxn | bitFinTxn)
 			kv := &pb.KV{
-				Key:       item.KeyCopy(nil),
+				Key:       keyCopy,
 				Value:     valCopy,
 				UserMeta:  []byte{item.UserMeta()},
 				Version:   item.Version(),
@@ -86,7 +104,7 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 				// If we need to discard earlier versions of this item, add a delete
 				// marker just below the current version.
 				list.Kv = append(list.Kv, &pb.KV{
-					Key:     item.KeyCopy(nil),
+					Key:     keyCopy,
 					Version: item.Version() - 1,
 					Meta:    []byte{bitDelete},
 				})
@@ -219,6 +237,23 @@ func (db *DB) Load(r io.Reader, maxPendingWrites int) error {
 		}
 
 		for _, kv := range list.Kv {
+			// If the keys or values were transformed before backup, reverse those
+			// changes before restoring the key-value pair.
+			if db.opt.RestoreKeyFn != nil {
+				var err error
+				kv.Key, err = db.opt.RestoreKeyFn(kv.Key)
+				if err != nil {
+					return err
+				}
+			}
+			if db.opt.RestoreValueFn != nil {
+				var err error
+				kv.Value, err = db.opt.RestoreValueFn(kv.Value)
+				if err != nil {
+					return err
+				}
+			}
+
 			if err := ldr.set(kv); err != nil {
 				return err
 			}

--- a/options.go
+++ b/options.go
@@ -113,6 +113,24 @@ type Options struct {
 	// Not recommended for most users.
 	managedTxns bool
 
+	// BackupKeyFn is used during backup when the user wishes to store the keys in some other
+	// format.
+	BackupKeyFn func([]byte) ([]byte, error)
+
+	// BackupValueFn is used during backup when the user wishes to store the keys in some other
+	// format.
+	BackupValueFn func([]byte) ([]byte, error)
+
+	// RestoreKeyFn is used while loading a backup when the user wishes to restore keys that were
+	// backed up in a different format. It essentially should revert the changes made by
+	// BackupKeyFn.
+	RestoreKeyFn func([]byte) ([]byte, error)
+
+	// RestoreValueFn is used while loading a backup when the user wishes to restore values that were
+	// backed up in a different format. It essentially should revert the changes made by
+	// BackupValueFn.
+	RestoreValueFn func([]byte) ([]byte, error)
+
 	// 4. Flags for testing purposes
 	// ------------------------------
 	maxBatchCount int64 // max entries in batch

--- a/options.go
+++ b/options.go
@@ -64,6 +64,11 @@ type Options struct {
 	CompactL0OnClose  bool
 	LogRotatesToFlush int32
 
+	BackupKeyFn    func([]byte) ([]byte, error)
+	BackupValueFn  func([]byte) ([]byte, error)
+	RestoreKeyFn   func([]byte) ([]byte, error)
+	RestoreValueFn func([]byte) ([]byte, error)
+
 	// Transaction start and commit timestamps are managed by end-user.
 	// This is only useful for databases built on top of Badger (like Dgraph).
 	// Not recommended for most users.
@@ -370,5 +375,41 @@ func (opt Options) WithCompactL0OnClose(val bool) Options {
 // The default value of LogRotatesToFlush is 2.
 func (opt Options) WithLogRotatesToFlush(val int32) Options {
 	opt.LogRotatesToFlush = val
+	return opt
+}
+
+// WithBackupKeyFn returns a new Options value with BackupKeyFn set to the given value.
+//
+// BackupKeyFn is used during backup when the user wishes to store the keys in some other format.
+func (opt Options) WithBackupKeyFn(fn func([]byte) ([]byte, error)) Options {
+	opt.BackupKeyFn = fn
+	return opt
+}
+
+// WithBackupValueFn returns a new Options value with BackupValueFn set to the given value.
+//
+// BackupValueFn is used during backup when the user wishes to store the values in some other
+// format.
+func (opt Options) WithBackupValueFn(fn func([]byte) ([]byte, error)) Options {
+	opt.BackupValueFn = fn
+	return opt
+}
+
+// WithRestoreKeyFn returns a new Options value with RestoreKeyFn set to the given value.
+//
+// RestoreKeyFn is used while loading a backup when the user wishes to restore keys that were
+// backed up in a different format. It essentially should revert the changes made by BackupKeyFn.
+func (opt Options) WithRestoreKeyFn(fn func([]byte) ([]byte, error)) Options {
+	opt.RestoreKeyFn = fn
+	return opt
+}
+
+// WithRestoreValueFn returns a new Options value with RestoreValueFn set to the given value.
+//
+// RestoreValueFn is used while loading a backup when the user wishes to restore values that were
+// backed up in a different format. It essentially should revert the changes made by
+// BackupValueFn.
+func (opt Options) WithRestoreValueFn(fn func([]byte) ([]byte, error)) Options {
+	opt.RestoreValueFn = fn
 	return opt
 }

--- a/options.go
+++ b/options.go
@@ -113,24 +113,6 @@ type Options struct {
 	// Not recommended for most users.
 	managedTxns bool
 
-	// BackupKeyFn is used during backup when the user wishes to store the keys in some other
-	// format.
-	BackupKeyFn func([]byte) ([]byte, error)
-
-	// BackupValueFn is used during backup when the user wishes to store the keys in some other
-	// format.
-	BackupValueFn func([]byte) ([]byte, error)
-
-	// RestoreKeyFn is used while loading a backup when the user wishes to restore keys that were
-	// backed up in a different format. It essentially should revert the changes made by
-	// BackupKeyFn.
-	RestoreKeyFn func([]byte) ([]byte, error)
-
-	// RestoreValueFn is used while loading a backup when the user wishes to restore values that were
-	// backed up in a different format. It essentially should revert the changes made by
-	// BackupValueFn.
-	RestoreValueFn func([]byte) ([]byte, error)
-
 	// 4. Flags for testing purposes
 	// ------------------------------
 	maxBatchCount int64 // max entries in batch


### PR DESCRIPTION
In order to support backwards-compatible backups in Dgraph, the data
needs to be stored in some other format than just the raw key and
values. This change introduces the option to set methods to transform
the data to and forth a separate format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/895)
<!-- Reviewable:end -->
