### PR TITLE
Update stale.yml to ignore issues with "skip/stale" label.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,7 +3,8 @@ daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
-# exemptLabels:
+exemptLabels:
+  - bounty/dataloss
 # Label to use when marking an issue as stale
 staleLabel: status/stale
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,7 +4,7 @@ daysUntilStale: 30
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - bounty/dataloss
+  - skip/stale
 # Label to use when marking an issue as stale
 staleLabel: status/stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Bounty challenge is currently indefinite and should not be closed
automatically by Stale.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/912)
<!-- Reviewable:end -->
