### PR TITLE
Improve documentation and API for DB.Subscribe

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -531,7 +531,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 
 				y.Check(batch.Flush())
 			}
-			_ = db.Subscribe(ctx, updater, accountIDS[0], accountIDS[1:]...)
+			_ = db.Subscribe(ctx, updater, accountIDS...)
 		}()
 	}
 

--- a/db.go
+++ b/db.go
@@ -59,8 +59,6 @@ type closers struct {
 	pub        *y.Closer
 }
 
-type callback func(kv *pb.KVList)
-
 // DB provides the various functions required to interact with Badger.
 // DB is thread-safe.
 type DB struct {
@@ -1424,12 +1422,22 @@ func (db *DB) DropPrefix(prefix []byte) error {
 	return nil
 }
 
-// Subscribe can be used watch key changes for the given key prefix.
-func (db *DB) Subscribe(ctx context.Context, cb callback, prefix []byte, prefixes ...[]byte) error {
+// KVList contains a list of key-value pairs.
+type KVList = pb.KVList
+
+// Subscribe can be used watch key changes for the given key prefixes.
+// At least one prefix should be passed, or an error will be returned.
+// You can use an empty prefix to monitor all changes to the DB.
+// This function blocks until the given context is done or an error occurs.
+// The given function will be called with a new KVList containing the modified keys and the
+// corresponding values.
+func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList), prefixes ...[]byte) error {
 	if cb == nil {
 		return ErrNilCallback
 	}
-	prefixes = append(prefixes, prefix)
+	if len(prefixes) == 0 {
+		return ErrNoPrefixes
+	}
 	c := y.NewCloser(1)
 	recvCh, id := db.pub.newSubscriber(c, prefixes...)
 	slurp := func(batch *pb.KVList) {

--- a/db.go
+++ b/db.go
@@ -1425,7 +1425,7 @@ func (db *DB) DropPrefix(prefix []byte) error {
 // KVList contains a list of key-value pairs.
 type KVList = pb.KVList
 
-// Subscribe can be used watch key changes for the given key prefixes.
+// Subscribe can be used to watch key changes for the given key prefixes.
 // At least one prefix should be passed, or an error will be returned.
 // You can use an empty prefix to monitor all changes to the DB.
 // This function blocks until the given context is done or an error occurs.

--- a/db_test.go
+++ b/db_test.go
@@ -1798,3 +1798,61 @@ func TestMain(m *testing.M) {
 	}()
 	os.Exit(m.Run())
 }
+
+func ExampleDB_Subscribe() {
+	prefix := []byte{'a'}
+
+	// This key should be printed, since it matches the prefix.
+	aKey := []byte("a-key")
+	aValue := []byte("a-value")
+
+	// This key should not be printed.
+	bKey := []byte("b-key")
+	bValue := []byte("b-value")
+
+	// We open the DB.
+	dir, err := ioutil.TempDir("", "badger-test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	db, err := Open(DefaultOptions(dir))
+	defer db.Close()
+
+	// We create the context here so we can cancel it after sending the writes.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// We use the WaitGroup to make sure we wait for the subscription to stop before continuing.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cb := func(kvs *KVList) {
+			for _, kv := range kvs.Kv {
+				fmt.Printf("%s is now set to %s\n", kv.Key, kv.Value)
+			}
+		}
+		if err := db.Subscribe(ctx, cb, prefix); err != nil && err != context.Canceled {
+			log.Fatal(err)
+		}
+		log.Printf("subscription closed")
+	}()
+
+	// We write both keys, but only one should be printed in the Output.
+	err = db.Update(func(txn *Txn) error { return txn.Set(aKey, aValue) })
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = db.Update(func(txn *Txn) error { return txn.Set(bKey, bValue) })
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("stopping subscription")
+	cancel()
+	log.Printf("waiting for subscription to close")
+	wg.Wait()
+	// Output:
+	// a-key is now set to a-value
+}

--- a/db_test.go
+++ b/db_test.go
@@ -1810,7 +1810,7 @@ func ExampleDB_Subscribe() {
 	bKey := []byte("b-key")
 	bValue := []byte("b-value")
 
-	// We open the DB.
+	// Open the DB.
 	dir, err := ioutil.TempDir("", "badger-test")
 	if err != nil {
 		log.Fatal(err)
@@ -1819,11 +1819,11 @@ func ExampleDB_Subscribe() {
 	db, err := Open(DefaultOptions(dir))
 	defer db.Close()
 
-	// We create the context here so we can cancel it after sending the writes.
+	// Create the context here so we can cancel it after sending the writes.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// We use the WaitGroup to make sure we wait for the subscription to stop before continuing.
+	// Use the WaitGroup to make sure we wait for the subscription to stop before continuing.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -1839,7 +1839,7 @@ func ExampleDB_Subscribe() {
 		log.Printf("subscription closed")
 	}()
 
-	// We write both keys, but only one should be printed in the Output.
+	// Write both keys, but only one should be printed in the Output.
 	err = db.Update(func(txn *Txn) error { return txn.Set(aKey, aValue) })
 	if err != nil {
 		log.Fatal(err)

--- a/errors.go
+++ b/errors.go
@@ -114,4 +114,7 @@ var (
 
 	// ErrNilCallback is returned when subscriber's callback is nil.
 	ErrNilCallback = errors.New("Callback cannot be nil")
+
+	// ErrNoPrefixes is returned when subscriber doesn't provide any prefix.
+	ErrNoPrefixes = errors.New("At least one key prefix is required")
 )


### PR DESCRIPTION
The previous API had the following issues:

- `cb` parameter was of unexported type `callback`
- `callback` received a `*pb.KVList` forcing the user to import that extra package
- awkward usage of variadic arguments for prefix/prefixes
- lack of documentation

Fixed by:
- making `cb` of anonymous function type
- created type `KVList` as alias of `pb.KVList` plus its documentation
- simplified variadic arguments and added check for number of prefixes given
- added docs (which I hope are correct?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/914)
<!-- Reviewable:end -->
