### PR TITLE
stop compaction after flushing the memtable and don't close the channel while closing the doWrite

### DIFF
--- a/db.go
+++ b/db.go
@@ -1394,10 +1394,12 @@ func (db *DB) dropAll() (func(), error) {
 
 // DropPrefix would drop all the keys with the provided prefix. It does this in the following way:
 // - Stop accepting new writes.
-// - Stop memtable flushes and compactions.
+// - Stop memtable flushes before aquiring lock. Because we're acquring lock here
+//   and memtable flush stalls for lock, which leads to deadlock
 // - Flush out all memtables, skipping over keys with the given prefix, Kp.
 // - Write out the value log header to memtables when flushing, so we don't accidentally bring Kp
 //   back after a restart.
+// - Stop compaction.
 // - Compact L0->L1, skipping over Kp.
 // - Compact rest of the levels, Li->Li, picking tables which have Kp.
 // - Resume memtable flushes, compactions and writes.


### PR DESCRIPTION
FIX for 2 bugs
̍1) datarace on closechannel

channel is threadsafe only for read and write but not for closing. 
Anyways we are blocking the write, So there is no need to close the channel in doWrite 
By this solution we can avoid the lock. refer #915 

2)  handleFlush is stalling on DropPrefix
It's because we are stopping the compaction before flushing the memtable. 
so l0 are not pushing to the bottom level and we're stalling indefinitely for getting space to flush the memtable to l0

So, I'm moving the stop compaction after flushing the memtable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/918)
<!-- Reviewable:end -->
