### PR TITLE
Fix busy-wait loop in Watermark

### DIFF
--- a/y/watermark.go
+++ b/y/watermark.go
@@ -190,13 +190,32 @@ func (w *WaterMark) process(closer *Closer) {
 			until = min
 			loops++
 		}
-		for i := doneUntil + 1; i <= until; i++ {
-			toNotify := waiters[i]
+
+		notifyAndRemove := func(idx uint64, toNotify []chan struct{}) {
 			for _, ch := range toNotify {
 				close(ch)
 			}
-			delete(waiters, i) // Release the memory back.
+			delete(waiters, idx) // Release the memory back.
 		}
+
+		if until-doneUntil <= uint64(len(waiters)) {
+			// Issue #908 showed that if doneUntil is close to 2^60, while until is zero, this loop
+			// can hog up CPU just iterating over integers creating a busy-wait loop. So, only do
+			// this path if until - doneUntil is less than the number of waiters.
+			for idx := doneUntil + 1; idx <= until; idx++ {
+				toNotify := waiters[idx]
+				notifyAndRemove(idx, toNotify)
+			}
+
+		} else {
+			for idx, toNotify := range waiters {
+				if idx > until {
+					continue
+				}
+				notifyAndRemove(idx, toNotify)
+			}
+		}
+
 		if until != doneUntil {
 			AssertTrue(atomic.CompareAndSwapUint64(&w.doneUntil, doneUntil, until))
 			w.elog.Printf("%s: Done until %d. Loops: %d\n", w.Name, until, loops)

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -210,10 +210,9 @@ func (w *WaterMark) process(closer *Closer) {
 
 		} else {
 			for idx, toNotify := range waiters {
-				if idx > until {
-					continue
+				if idx <= until {
+					notifyAndRemove(idx, toNotify)
 				}
-				notifyAndRemove(idx, toNotify)
 			}
 		}
 

--- a/y/watermark.go
+++ b/y/watermark.go
@@ -203,8 +203,9 @@ func (w *WaterMark) process(closer *Closer) {
 			// can hog up CPU just iterating over integers creating a busy-wait loop. So, only do
 			// this path if until - doneUntil is less than the number of waiters.
 			for idx := doneUntil + 1; idx <= until; idx++ {
-				toNotify := waiters[idx]
-				notifyAndRemove(idx, toNotify)
+				if toNotify, ok := waiters[idx]; ok {
+					notifyAndRemove(idx, toNotify)
+				}
 			}
 
 		} else {


### PR DESCRIPTION
When doneUntil is very large, process loop in watermark can end up in a busy-wait loop. Fix that by choosing to iterate either over integer range or over waiters, depending upon whichever produces a shorter loop.

Fixes #908 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/920)
<!-- Reviewable:end -->
