### PR TITLE
Fix race condition in flushDiscardStats function

### DIFF
--- a/value.go
+++ b/value.go
@@ -1396,9 +1396,12 @@ func (vlog *valueLog) updateDiscardStats(stats map[uint32]int64) error {
 
 // flushDiscardStats inserts discard stats into badger. Returns error on failure.
 func (vlog *valueLog) flushDiscardStats() error {
+	vlog.lfDiscardStats.Lock()
 	if len(vlog.lfDiscardStats.m) == 0 {
 		return nil
 	}
+	vlog.lfDiscardStats.Unlock()
+
 	entries := []*Entry{{
 		Key:   y.KeyWithTs(lfDiscardStatsKey, 1),
 		Value: vlog.encodedDiscardStats(),

--- a/value.go
+++ b/value.go
@@ -1398,6 +1398,7 @@ func (vlog *valueLog) updateDiscardStats(stats map[uint32]int64) error {
 func (vlog *valueLog) flushDiscardStats() error {
 	vlog.lfDiscardStats.Lock()
 	if len(vlog.lfDiscardStats.m) == 0 {
+		vlog.lfDiscardStats.Unlock()
 		return nil
 	}
 	vlog.lfDiscardStats.Unlock()


### PR DESCRIPTION
A couple of builds failed on teamcity with data race error. See https://teamcity.dgraph.io/viewLog.html?buildId=16131&tab=buildResultsDiv&buildTypeId=Badger_UnitTests#testNameId2998050314356001114 

This PR fixes the data race in `flushDsicardStats` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/921)
<!-- Reviewable:end -->
