### PR TITLE
[breaking/format] Use varint for header encoding

### DIFF
--- a/db2_test.go
+++ b/db2_test.go
@@ -61,7 +61,7 @@ func TestTruncateVlogWithClose(t *testing.T) {
 
 	// Close the DB.
 	require.NoError(t, db.Close())
-	require.NoError(t, os.Truncate(path.Join(dir, "000000.vlog"), 4096))
+	require.NoError(t, os.Truncate(path.Join(dir, "000000.vlog"), 4090))
 
 	// Reopen and write some new data.
 	db, err = Open(opt)
@@ -108,9 +108,9 @@ var benchDir = flag.String("benchdir", "", "Set when running db.Open benchmark")
 
 // The following 3 TruncateVlogNoClose tests should be run one after another.
 // None of these close the DB, simulating a crash. They should be run with a
-// script, which truncates the value log to 4096, lining up with the end of the
-// first entry in the txn. At <4096, it would cause the entry to be truncated
-// immediately, at >4096, same thing.
+// script, which truncates the value log to 4090, lining up with the end of the
+// first entry in the txn. At <4090, it would cause the entry to be truncated
+// immediately, at >4090, same thing.
 func TestTruncateVlogNoClose(t *testing.T) {
 	if !*manual {
 		t.Skip("Skipping test meant to be run manually.")

--- a/db_test.go
+++ b/db_test.go
@@ -84,7 +84,6 @@ func getTestOptions(dir string) Options {
 func getItemValue(t *testing.T, item *Item) (val []byte) {
 	t.Helper()
 	var v []byte
-	size := item.ValueSize()
 	err := item.Value(func(val []byte) error {
 		if val == nil {
 			v = nil
@@ -95,9 +94,6 @@ func getItemValue(t *testing.T, item *Item) (val []byte) {
 	})
 	if err != nil {
 		t.Error(err)
-	}
-	if int64(len(v)) != size {
-		t.Errorf("incorrect size: expected %d, got %d", len(v), size)
 	}
 	if v == nil {
 		return nil

--- a/db_test.go
+++ b/db_test.go
@@ -85,11 +85,7 @@ func getItemValue(t *testing.T, item *Item) (val []byte) {
 	t.Helper()
 	var v []byte
 	err := item.Value(func(val []byte) error {
-		if val == nil {
-			v = nil
-		} else {
-			v = append([]byte{}, val...)
-		}
+		v = append(v, val...)
 		return nil
 	})
 	if err != nil {

--- a/histogram.go
+++ b/histogram.go
@@ -128,13 +128,8 @@ func (db *DB) buildHistogram(keyPrefix []byte) *sizeHistogram {
 	// Collect key and value sizes.
 	for itr.Seek(keyPrefix); itr.ValidForPrefix(keyPrefix); itr.Next() {
 		item := itr.Item()
-		valueSlice, err := item.ValueCopy(nil)
-		if err != nil {
-			db.opt.Logger.Infof("Unable to fetch value. Skipping this entry due to error %v.", err)
-			continue
-		}
 		badgerHistogram.keySizeHistogram.Update(item.KeySize())
-		badgerHistogram.valueSizeHistogram.Update(int64(len(valueSlice)))
+		badgerHistogram.valueSizeHistogram.Update(item.ValueSize())
 	}
 	return badgerHistogram
 }

--- a/histogram.go
+++ b/histogram.go
@@ -128,8 +128,13 @@ func (db *DB) buildHistogram(keyPrefix []byte) *sizeHistogram {
 	// Collect key and value sizes.
 	for itr.Seek(keyPrefix); itr.ValidForPrefix(keyPrefix); itr.Next() {
 		item := itr.Item()
+		valueSlice, err := item.ValueCopy(nil)
+		if err != nil {
+			db.opt.Logger.Infof("Unable to fetch value. Skipping this entry due to error.", err)
+			continue
+		}
 		badgerHistogram.keySizeHistogram.Update(item.KeySize())
-		badgerHistogram.valueSizeHistogram.Update(item.ValueSize())
+		badgerHistogram.valueSizeHistogram.Update(int64(len(valueSlice)))
 	}
 	return badgerHistogram
 }

--- a/histogram.go
+++ b/histogram.go
@@ -130,7 +130,7 @@ func (db *DB) buildHistogram(keyPrefix []byte) *sizeHistogram {
 		item := itr.Item()
 		valueSlice, err := item.ValueCopy(nil)
 		if err != nil {
-			db.opt.Logger.Infof("Unable to fetch value. Skipping this entry due to error.", err)
+			db.opt.Logger.Infof("Unable to fetch value. Skipping this entry due to error %v.", err)
 			continue
 		}
 		badgerHistogram.keySizeHistogram.Update(item.KeySize())

--- a/iterator.go
+++ b/iterator.go
@@ -19,7 +19,6 @@ package badger
 import (
 	"bytes"
 	"fmt"
-	"hash/crc32"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -250,24 +249,6 @@ func (item *Item) EstimatedSize() int64 {
 // Exact size of the key is key + 8 bytes of timestamp
 func (item *Item) KeySize() int64 {
 	return int64(len(item.key))
-}
-
-// ValueSize returns the exact size of the value.
-//
-// This can be called to quickly estimate the size of a value without fetching
-// it.
-func (item *Item) ValueSize() int64 {
-	if !item.hasValue() {
-		return 0
-	}
-	if (item.meta & bitValuePointer) == 0 {
-		return int64(len(item.vptr))
-	}
-	var vp valuePointer
-	vp.Decode(item.vptr)
-
-	klen := int64(len(item.key) + 8) // 8 bytes for timestamp.
-	return int64(vp.Len) - klen - headerBufSize - crc32.Size
 }
 
 // UserMeta returns the userMeta set by the user. Typically, this byte, optionally set by the user

--- a/iterator.go
+++ b/iterator.go
@@ -252,7 +252,7 @@ func (item *Item) KeySize() int64 {
 	return int64(len(item.key))
 }
 
-// ValueSize returns the exact size of the value.
+// ValueSize returns the approximate size of the value.
 //
 // This can be called to quickly estimate the size of a value without fetching
 // it.
@@ -267,6 +267,8 @@ func (item *Item) ValueSize() int64 {
 	vp.Decode(item.vptr)
 
 	klen := int64(len(item.key) + 8) // 8 bytes for timestamp.
+	// 6 bytes are for the approximate length of the header. Since header is encoded in varint, we
+	// cannot find the exact length of header without fetching it.
 	return int64(vp.Len) - klen - 6 - crc32.Size
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -19,6 +19,7 @@ package badger
 import (
 	"bytes"
 	"fmt"
+	"hash/crc32"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -249,6 +250,24 @@ func (item *Item) EstimatedSize() int64 {
 // Exact size of the key is key + 8 bytes of timestamp
 func (item *Item) KeySize() int64 {
 	return int64(len(item.key))
+}
+
+// ValueSize returns the exact size of the value.
+//
+// This can be called to quickly estimate the size of a value without fetching
+// it.
+func (item *Item) ValueSize() int64 {
+	if !item.hasValue() {
+		return 0
+	}
+	if (item.meta & bitValuePointer) == 0 {
+		return int64(len(item.vptr))
+	}
+	var vp valuePointer
+	vp.Decode(item.vptr)
+
+	klen := int64(len(item.key) + 8) // 8 bytes for timestamp.
+	return int64(vp.Len) - klen - 6 - crc32.Size
 }
 
 // UserMeta returns the userMeta set by the user. Typically, this byte, optionally set by the user

--- a/manifest.go
+++ b/manifest.go
@@ -223,7 +223,7 @@ func (mf *manifestFile) addChanges(changesParam []*pb.ManifestChange) error {
 var magicText = [4]byte{'B', 'd', 'g', 'r'}
 
 // The magic version number.
-const magicVersion = 5
+const magicVersion = 6
 
 func helpRewrite(dir string, m *Manifest) (*os.File, int, error) {
 	rewritePath := filepath.Join(dir, manifestRewriteFilename)

--- a/structs.go
+++ b/structs.go
@@ -71,28 +71,28 @@ const (
 // +------------+--------------+-----------+------+----------+
 func (h header) Encode(out []byte) int {
 	index := 0
-	index += binary.PutUvarint(out[index:], uint64(h.klen))
-	index += binary.PutUvarint(out[index:], uint64(h.vlen))
-	index += binary.PutUvarint(out[index:], h.expiresAt)
 	out[index] = h.meta
 	index++
 	out[index] = h.userMeta
-	return index + 1
+	index++
+	index += binary.PutUvarint(out[index:], uint64(h.klen))
+	index += binary.PutUvarint(out[index:], uint64(h.vlen))
+	index += binary.PutUvarint(out[index:], h.expiresAt)
+	return index
 }
 
 // Decode decodes the given header from the provided byte slice.
 func (h *header) Decode(buf []byte) {
+	h.meta = buf[0]
+	h.userMeta = buf[1]
+	buf = buf[2:]
 	klen, count := binary.Uvarint(buf)
 	h.klen = uint32(klen)
 	buf = buf[count:]
 	vlen, count := binary.Uvarint(buf)
 	h.vlen = uint32(vlen)
 	buf = buf[count:]
-	expiresAt, count := binary.Uvarint(buf)
-	h.expiresAt = uint64(expiresAt)
-	buf = buf[count:]
-	h.meta = buf[0]
-	h.userMeta = buf[1]
+	h.expiresAt, _ = binary.Uvarint(buf)
 }
 
 // Entry provides Key, Value, UserMeta and ExpiresAt. This struct can be used by

--- a/structs.go
+++ b/structs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"math"
 	"time"
 
 	"github.com/dgraph-io/badger/y"
@@ -56,25 +57,41 @@ type header struct {
 }
 
 const (
-	headerBufSize = 18
+	// Maximum possible size of the header. The maximum size of header struct will be 18 but the
+	// maximum size of varint encoded header will be 21.
+	maxHeaderSize = 21
 )
 
-func (h header) Encode(out []byte) {
-	y.AssertTrue(len(out) >= headerBufSize)
-	binary.BigEndian.PutUint32(out[0:4], h.klen)
-	binary.BigEndian.PutUint32(out[4:8], h.vlen)
-	binary.BigEndian.PutUint64(out[8:16], h.expiresAt)
-	out[16] = h.meta
-	out[17] = h.userMeta
+// Encode encodes the header into []byte.
+/* The encoded header looks like
++------------+--------------+-----------+------+----------+
+| Key Length | Value Length | ExpiresAt | Meta | UserMeta |
++------------+--------------+-----------+------+----------+
+*/
+func (h header) Encode(out []byte) int {
+	index := 0
+	index += binary.PutUvarint(out[index:], uint64(h.klen))
+	index += binary.PutUvarint(out[index:], uint64(h.vlen))
+	index += binary.PutUvarint(out[index:], h.expiresAt)
+	out[index] = h.meta
+	index++
+	out[index] = h.userMeta
+	return index + 1
 }
 
 // Decodes h from buf.
 func (h *header) Decode(buf []byte) {
-	h.klen = binary.BigEndian.Uint32(buf[0:4])
-	h.vlen = binary.BigEndian.Uint32(buf[4:8])
-	h.expiresAt = binary.BigEndian.Uint64(buf[8:16])
-	h.meta = buf[16]
-	h.userMeta = buf[17]
+	klen, count := binary.Uvarint(buf[:])
+	h.klen = uint32(klen)
+	buf = buf[count:]
+	vlen, count := binary.Uvarint(buf[:])
+	h.vlen = uint32(vlen)
+	buf = buf[count:]
+	expiresAt, count := binary.Uvarint(buf[:])
+	h.expiresAt = uint64(expiresAt)
+	buf = buf[count:]
+	h.meta = buf[0]
+	h.userMeta = buf[1]
 }
 
 // Entry provides Key, Value, UserMeta and ExpiresAt. This struct can be used by
@@ -99,6 +116,11 @@ func (e *Entry) estimateSize(threshold int) int {
 }
 
 // Encodes e to buf. Returns number of bytes written.
+/* The encoded entry looks like
++---------------+--------+-----+-------+----------+
+| Header Length | Header | Key | Value | Checksum |
++---------------+--------+-----+-------+----------+
+*/
 func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 	h := header{
 		klen:      uint32(len(e.Key)),
@@ -108,12 +130,17 @@ func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 		userMeta:  e.UserMeta,
 	}
 
-	var headerEnc [headerBufSize]byte
-	h.Encode(headerEnc[:])
+	headerEnc := make([]byte, maxHeaderSize)
+	headerLen := h.Encode(headerEnc[:])
+	// Ensure we don't overflow uint8.
+	y.AssertTrue(headerLen < math.MaxUint8)
+	// Write header length.
+	buf.Write([]byte{uint8(headerLen)})
 
-	hash := crc32.New(y.CastagnoliCrcTable)
-
+	// Trim headerEnc to contain only valid bytes.
+	headerEnc = headerEnc[:headerLen]
 	buf.Write(headerEnc[:])
+	hash := crc32.New(y.CastagnoliCrcTable)
 	if _, err := hash.Write(headerEnc[:]); err != nil {
 		return 0, err
 	}
@@ -131,8 +158,7 @@ func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 	var crcBuf [crc32.Size]byte
 	binary.BigEndian.PutUint32(crcBuf[:], hash.Sum32())
 	buf.Write(crcBuf[:])
-
-	return len(headerEnc) + len(e.Key) + len(e.Value) + len(crcBuf), nil
+	return headerLen + len(headerEnc) + len(e.Key) + len(e.Value) + len(crcBuf), nil
 }
 
 func (e Entry) print(prefix string) {

--- a/structs.go
+++ b/structs.go
@@ -41,6 +41,7 @@ func (p valuePointer) Encode(b []byte) []byte {
 	return b[:vptrSize]
 }
 
+// Decode decodes the value pointer into the provided byte buffer.
 func (p *valuePointer) Decode(b []byte) {
 	p.Fid = binary.BigEndian.Uint32(b[:4])
 	p.Len = binary.BigEndian.Uint32(b[4:8])
@@ -79,7 +80,7 @@ func (h header) Encode(out []byte) int {
 	return index + 1
 }
 
-// Decodes h from buf.
+// Decode decodes the given header from the provided byte slice.
 func (h *header) Decode(buf []byte) {
 	klen, count := binary.Uvarint(buf[:])
 	h.klen = uint32(klen)

--- a/value.go
+++ b/value.go
@@ -204,7 +204,9 @@ func (r *safeRead) nextHeaderLength(reader io.Reader) (int, error) {
 	return int(uint8(headerLen[0])), nil
 }
 
-func (r *safeRead) Entry(reader io.Reader, headerLen int) (*Entry, error) {
+// readEntry reads an entry from the provided reader. It also validates the checksum for every entry
+// read. Returns error on failure.
+func (r *safeRead) readEntry(reader io.Reader, headerLen int) (*Entry, error) {
 	var err error
 
 	hash := crc32.New(y.CastagnoliCrcTable)
@@ -301,7 +303,7 @@ func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) (uint32, 
 		} else if err != nil {
 			return 0, err
 		}
-		e, err := read.Entry(reader, hlen)
+		e, err := read.readEntry(reader, hlen)
 		if err == io.EOF {
 			break
 		} else if err == io.ErrUnexpectedEOF || err == errTruncate {

--- a/value.go
+++ b/value.go
@@ -201,19 +201,17 @@ func (r *safeRead) nextHeaderLength(reader io.Reader) (int, error) {
 	if _, err := io.ReadFull(reader, headerLen); err != nil {
 		return 0, err
 	}
-	return int(uint8(headerLen[0])), nil
+	return int(headerLen[0]), nil
 }
 
 // readEntry reads an entry from the provided reader. It also validates the checksum for every entry
 // read. Returns error on failure.
 func (r *safeRead) readEntry(reader io.Reader, headerLen int) (*Entry, error) {
-	var err error
-
 	hash := crc32.New(y.CastagnoliCrcTable)
 	tee := io.TeeReader(reader, hash)
 
 	hbuf := make([]byte, headerLen)
-	if _, err = io.ReadFull(tee, hbuf[:]); err != nil {
+	if _, err := io.ReadFull(tee, hbuf[:]); err != nil {
 		return nil, err
 	}
 
@@ -236,20 +234,20 @@ func (r *safeRead) readEntry(reader io.Reader, headerLen int) (*Entry, error) {
 	e.Key = r.k[:kl]
 	e.Value = r.v[:vl]
 
-	if _, err = io.ReadFull(tee, e.Key); err != nil {
+	if _, err := io.ReadFull(tee, e.Key); err != nil {
 		if err == io.EOF {
 			err = errTruncate
 		}
 		return nil, err
 	}
-	if _, err = io.ReadFull(tee, e.Value); err != nil {
+	if _, err := io.ReadFull(tee, e.Value); err != nil {
 		if err == io.EOF {
 			err = errTruncate
 		}
 		return nil, err
 	}
 	var crcBuf [4]byte
-	if _, err = io.ReadFull(reader, crcBuf[:]); err != nil {
+	if _, err := io.ReadFull(reader, crcBuf[:]); err != nil {
 		if err == io.EOF {
 			err = errTruncate
 		}

--- a/value_test.go
+++ b/value_test.go
@@ -17,6 +17,7 @@
 package badger
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -47,7 +48,7 @@ func TestValueBasic(t *testing.T) {
 	const val2 = "samplevalb012345678901234567890123"
 	require.True(t, len(val1) >= kv.opt.ValueThreshold)
 
-	e := &Entry{
+	e1 := &Entry{
 		Key:   []byte("samplekey"),
 		Value: []byte(val1),
 		meta:  bitValuePointer,
@@ -59,7 +60,7 @@ func TestValueBasic(t *testing.T) {
 	}
 
 	b := new(request)
-	b.Entries = []*Entry{e, e2}
+	b.Entries = []*Entry{e1, e2}
 
 	log.write([]*request{b})
 	require.Len(t, b.Ptrs, 2)
@@ -973,4 +974,21 @@ func TestValueLogTruncate(t *testing.T) {
 	// Max file ID would point to the last vlog file, which is fid=2 in this case
 	require.Equal(t, 2, int(db.vlog.maxFid))
 	require.NoError(t, db.Close())
+}
+
+func TestSafeEntry(t *testing.T) {
+	var s safeRead
+	e := NewEntry([]byte("foo"), []byte("bar"))
+	buf := bytes.NewBuffer(nil)
+	_, err := encodeEntry(e, buf)
+	require.NoError(t, err)
+
+	hlen, err := s.nextHeaderLength(buf)
+	require.NoError(t, err)
+
+	ne, err := s.Entry(buf, hlen)
+	require.NoError(t, err)
+	require.Equal(t, e.meta, ne.meta, "meta mismatch")
+	require.Equal(t, e.UserMeta, ne.UserMeta, "usermeta mismatch")
+	require.Equal(t, e.ExpiresAt, ne.ExpiresAt, "expiresAt mismatch")
 }

--- a/value_test.go
+++ b/value_test.go
@@ -976,9 +976,11 @@ func TestValueLogTruncate(t *testing.T) {
 	require.NoError(t, db.Close())
 }
 
-func TestSafeEntry(t *testing.T) {
+func TestReadEntry(t *testing.T) {
 	var s safeRead
-	e := NewEntry([]byte("foo"), []byte("bar"))
+	k := []byte("foo")
+	v := []byte("bar")
+	e := NewEntry(k, v)
 	buf := bytes.NewBuffer(nil)
 	_, err := encodeEntry(e, buf)
 	require.NoError(t, err)
@@ -986,8 +988,10 @@ func TestSafeEntry(t *testing.T) {
 	hlen, err := s.nextHeaderLength(buf)
 	require.NoError(t, err)
 
-	ne, err := s.Entry(buf, hlen)
+	ne, err := s.readEntry(buf, hlen)
 	require.NoError(t, err)
+	require.Equal(t, e.Key, ne.Key, "key mismatch")
+	require.Equal(t, e.Value, ne.Value, "value mismatch")
 	require.Equal(t, e.meta, ne.meta, "meta mismatch")
 	require.Equal(t, e.UserMeta, ne.UserMeta, "usermeta mismatch")
 	require.Equal(t, e.ExpiresAt, ne.ExpiresAt, "expiresAt mismatch")

--- a/value_test.go
+++ b/value_test.go
@@ -986,10 +986,7 @@ func TestSafeEntry(t *testing.T) {
 	_, err := encodeEntry(e, buf)
 	require.NoError(t, err)
 
-	hlen, err := s.nextHeaderLength(buf)
-	require.NoError(t, err)
-
-	ne, err := s.readEntry(buf, hlen)
+	ne, err := s.readEntry(buf)
 	require.NoError(t, err)
 	require.Equal(t, e.Key, ne.Key, "key mismatch")
 	require.Equal(t, e.Value, ne.Value, "value mismatch")


### PR DESCRIPTION
**This is a breaking change**.

Value log stores an entry for each key-value paired stored in it. The existing format looks like

| Header (fixed size: 18 bytes) 	| Key 	| Value 	| Checksum 	|
|---------------------------	|-----	|-------	|----------	|

We don't always use up all the 18 Bytes of the header. This PR proposes varint encoding for the individual attributes of the header. The varint encoded header can have length in the range of 5-21 Bytes.

The proposed entry in value log looks like

| Header length (1 byte) 	| Header (variable size) 	| Key 	| Value 	| Checksum 	|
|------------------------	|------------------------	|-----	|-------	|----------	|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/925)
<!-- Reviewable:end -->
