### PR TITLE
Fix discard stats moved by GC bug

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/trace"
 
 	"github.com/dgraph-io/badger/options"
 	"github.com/dgraph-io/badger/pb"
@@ -1893,4 +1894,55 @@ func ExampleDB_Subscribe() {
 	wg.Wait()
 	// Output:
 	// a-key is now set to a-value
+}
+
+// Regression test for https://github.com/dgraph-io/badger/issues/926
+func TestDiscardStatsMove(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger-test")
+	require.NoError(t, err)
+	ops := getTestOptions(dir)
+	ops.ValueLogMaxEntries = 1
+	db, err := Open(ops)
+	require.NoError(t, err)
+
+	stat := make(map[uint32]int64, ops.ValueThreshold+10)
+	for i := uint32(0); i < uint32(ops.ValueThreshold+10); i++ {
+		stat[i] = 0
+	}
+
+	// Set discard stat.
+	db.vlog.lfDiscardStats = &lfDiscardStats{
+		m: stat,
+	}
+	entries := []*Entry{{
+		Key: y.KeyWithTs(lfDiscardStatsKey, 1),
+		// The discard stat value is more than value threshold.
+		Value: db.vlog.encodedDiscardStats(),
+	}}
+	// Push discard stats entry to write channel
+	req, err := db.sendToWriteCh(entries)
+	require.NoError(t, err)
+	req.Wait()
+
+	// Push more entries so that we get more than 1 value log files.
+	require.NoError(t, db.Update(func(txn *Txn) error {
+		e := NewEntry([]byte("f"), []byte("1"))
+		return txn.SetEntry(e)
+	}))
+	require.NoError(t, db.Update(func(txn *Txn) error {
+		e := NewEntry([]byte("ff"), []byte("1"))
+		return txn.SetEntry(e)
+
+	}))
+
+	tr := trace.New("Badger.ValueLog", "GC")
+	// Use first value log file for GC. This value log file contains the discard stats.
+	lf := db.vlog.filesMap[0]
+	require.NoError(t, db.vlog.rewrite(lf, tr))
+	require.NoError(t, db.Close())
+
+	db, err = Open(ops)
+	require.NoError(t, err)
+	require.Equal(t, stat, db.vlog.lfDiscardStats.m)
+	require.NoError(t, db.Close())
 }

--- a/value.go
+++ b/value.go
@@ -1455,12 +1455,16 @@ func (vlog *valueLog) populateDiscardStats() error {
 		defer runCallback(cb)
 		val = make([]byte, len(result))
 		copy(val, result)
+		// The result is stored in val. We can break the loop from here.
 		if err == nil {
 			break
 		}
 		if err != ErrRetry {
 			return err
 		}
+		// If we're at this point it means we haven't found the value yet and if the current key has
+		// badger move prefix, we should break from here since we've already tried the original key
+		// and the key with move prefix. "val" would be empty since we haven't found the value yet.
 		if bytes.HasPrefix(newKey, badgerMove) {
 			break
 		}

--- a/value.go
+++ b/value.go
@@ -1427,34 +1427,50 @@ func (vlog *valueLog) encodedDiscardStats() []byte {
 // populateDiscardStats populates vlog.lfDiscardStats
 // This function will be called while initializing valueLog
 func (vlog *valueLog) populateDiscardStats() error {
-	discardStatsKey := y.KeyWithTs(lfDiscardStatsKey, math.MaxUint64)
-	vs, err := vlog.db.get(discardStatsKey)
-	if err != nil {
-		return err
-	}
-
-	// check if value is Empty
-	if vs.Value == nil || len(vs.Value) == 0 {
-		return nil
-	}
-
+	key := y.KeyWithTs(lfDiscardStatsKey, math.MaxUint64)
+	newKey := make([]byte, len(key))
+	copy(newKey, key)
 	var statsMap map[uint32]int64
-	// discard map is stored in the vlog file.
-	if vs.Meta&bitValuePointer > 0 {
-		var vp valuePointer
-		vp.Decode(vs.Value)
-		result, cb, err := vlog.Read(vp, new(y.Slice))
+	var val []byte
+	var vp valuePointer
+	for {
+		vs, err := vlog.db.get(newKey)
 		if err != nil {
-			return errors.Wrapf(err, "failed to read value pointer from vlog file: %+v", vp)
+			return err
 		}
+		// Vlaue doesn't exist.
+		if vs.Meta == 0 && len(vs.Value) == 0 {
+			vs.Value = []byte{}
+			break
+		}
+		vp.Decode(vs.Value)
+		// Entry stored in LSM tree.
+		if vs.Meta&bitValuePointer == 0 {
+			val = make([]byte, len(vs.Value))
+			copy(val, vs.Value)
+			break
+		}
+		// Read entry from value log.
+		result, cb, err := vlog.Read(vp, new(y.Slice))
+		val = make([]byte, len(result))
+		copy(val, result)
 		defer runCallback(cb)
-		if err := json.Unmarshal(result, &statsMap); err != nil {
-			return errors.Wrapf(err, "failed to unmarshal discard stats")
+		if err != ErrRetry {
+			break
 		}
-	} else {
-		if err := json.Unmarshal(vs.Value, &statsMap); err != nil {
-			return errors.Wrapf(err, "failed to unmarshal discard stats")
+		if bytes.HasPrefix(newKey, badgerMove) {
+			vs.Value = []byte{}
+			break
 		}
+		// If we're at this point it means the discard stats key was moved by the GC and the actual
+		// entry is the one prefixed by badger move key.
+		newKey = make([]byte, len(badgerMove)+len(key))
+		// Prepend existing key with badger move and search for the key.
+		n := copy(newKey, badgerMove)
+		copy(newKey[n:], key)
+	}
+	if err := json.Unmarshal(val, &statsMap); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal discard stats")
 	}
 	vlog.opt.Debugf("Value Log Discard stats: %v", statsMap)
 	vlog.lfDiscardStats = &lfDiscardStats{m: statsMap}

--- a/value.go
+++ b/value.go
@@ -1456,11 +1456,10 @@ func (vlog *valueLog) populateDiscardStats() error {
 		copy(val, result)
 		defer runCallback(cb)
 		if err != ErrRetry {
-			break
+			return err
 		}
 		if bytes.HasPrefix(newKey, badgerMove) {
-			vs.Value = []byte{}
-			break
+			return nil
 		}
 		// If we're at this point it means the discard stats key was moved by the GC and the actual
 		// entry is the one prefixed by badger move key.

--- a/value.go
+++ b/value.go
@@ -1438,10 +1438,10 @@ func (vlog *valueLog) populateDiscardStats() error {
 		if err != nil {
 			return err
 		}
-		// Vlaue doesn't exist.
+		// Value doesn't exist.
 		if vs.Meta == 0 && len(vs.Value) == 0 {
-			vs.Value = []byte{}
-			break
+			vlog.opt.Debugf("Value log discard stats empty")
+			return nil
 		}
 		vp.Decode(vs.Value)
 		// Entry stored in LSM tree.

--- a/value_test.go
+++ b/value_test.go
@@ -974,3 +974,59 @@ func TestValueLogTruncate(t *testing.T) {
 	require.Equal(t, 2, int(db.vlog.maxFid))
 	require.NoError(t, db.Close())
 }
+
+// Regression test for https://github.com/dgraph-io/badger/issues/926
+func TestDiscardStatsMove(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger-test")
+	require.NoError(t, err)
+	ops := getTestOptions(dir)
+	ops.ValueLogMaxEntries = 1
+	db, err := Open(ops)
+	require.NoError(t, err)
+
+	stat := make(map[uint32]int64, ops.ValueThreshold+10)
+	for i := uint32(0); i < uint32(ops.ValueThreshold+10); i++ {
+		stat[i] = 0
+	}
+
+	// Set discard stat.
+	db.vlog.lfDiscardStats = &lfDiscardStats{
+		m: stat,
+	}
+	entries := []*Entry{{
+		Key: y.KeyWithTs(lfDiscardStatsKey, 1),
+		// The discard stat value is more than value threshold.
+		Value: db.vlog.encodedDiscardStats(),
+	}}
+	// Push discard stats entry to write channel
+	req, err := db.sendToWriteCh(entries)
+	require.NoError(t, err)
+	req.Wait()
+
+	// Unset discard stats. We've already pushed the stats. If we don't unset it then it will be
+	// pushed again on DB close. Also, the first insertion was in vlog file 1, this insertion would
+	// be in value log file 3.
+	db.vlog.lfDiscardStats.m = nil
+
+	// Push more entries so that we get more than 1 value log files.
+	require.NoError(t, db.Update(func(txn *Txn) error {
+		e := NewEntry([]byte("f"), []byte("1"))
+		return txn.SetEntry(e)
+	}))
+	require.NoError(t, db.Update(func(txn *Txn) error {
+		e := NewEntry([]byte("ff"), []byte("1"))
+		return txn.SetEntry(e)
+
+	}))
+
+	tr := trace.New("Badger.ValueLog", "GC")
+	// Use first value log file for GC. This value log file contains the discard stats.
+	lf := db.vlog.filesMap[0]
+	require.NoError(t, db.vlog.rewrite(lf, tr))
+	require.NoError(t, db.Close())
+
+	db, err = Open(ops)
+	require.NoError(t, err)
+	require.Equal(t, stat, db.vlog.lfDiscardStats.m)
+	require.NoError(t, db.Close())
+}

--- a/value_test.go
+++ b/value_test.go
@@ -1026,7 +1026,7 @@ func TestDiscardStatsMove(t *testing.T) {
 		stat[i] = 0
 	}
 
-	// Set discard stat.
+	// Set discard stats.
 	db.vlog.lfDiscardStats = &lfDiscardStats{
 		m: stat,
 	}
@@ -1035,7 +1035,7 @@ func TestDiscardStatsMove(t *testing.T) {
 		// The discard stat value is more than value threshold.
 		Value: db.vlog.encodedDiscardStats(),
 	}}
-	// Push discard stats entry to write channel
+	// Push discard stats entry to the write channel.
 	req, err := db.sendToWriteCh(entries)
 	require.NoError(t, err)
 	req.Wait()


### PR DESCRIPTION
The discard stats are stored like normal keys in badger, which means if
the size of the value of discard stats key is greater the value threshold it
will be stored in the value log. When value log GC happens, we insert
the same key in badger with a !badger!move prefix which points to the
new value log file. So when searching for the value of a key, if the value
points to a value log file which doesn't exist, we search for the same
key with `!badger!move` prefix.

The above logic was missing from the populateDiscardStats function. The
earlier implementation would never search for the key with `!badger!move`
prefix. It would return error on the first attempt to find the key. This
commit ensures we search for a key with prefix badger move if the value
for the existing key pointed to a value log file that no longer exists.

Fixes - https://github.com/dgraph-io/badger/issues/926

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/929)
<!-- Reviewable:end -->
