### PR TITLE
DefaultOptions: Set SyncWrites to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,11 +815,11 @@ workloads, you should be using the `Transaction` API.
 
 - **I don't see any disk write. Why?**
 
-If you're using Badger with `SyncWrites=false`, then your writes might not be written to value log
-and won't get synced to disk immediately. Writes to LSM tree are done inmemory first, before they
+By default, the `SyncWrites` option is set to `false` in badger. This means that the entries written to the files won't get synced to the disk immediately. Writes to LSM tree are done inmemory first, before they
 get compacted to disk. The compaction would only happen once `MaxTableSize` has been reached. So, if
 you're doing a few writes and then checking, you might not see anything on disk. Once you `Close`
-the database, you'll see these writes on disk.
+the database, you'll see these writes on disk. Set `SyncWrites=true` if you wish to have files
+opened in the sync mode.
 
 - **Reverse iteration doesn't give me the right results.**
 

--- a/options.go
+++ b/options.go
@@ -97,7 +97,7 @@ func DefaultOptions(path string) Options {
 		NumLevelZeroTables:      5,
 		NumLevelZeroTablesStall: 10,
 		NumMemtables:            5,
-		SyncWrites:              true,
+		SyncWrites:              false,
 		NumVersionsToKeep:       1,
 		CompactL0OnClose:        true,
 		// Nothing to read/write value log using standard File I/O


### PR DESCRIPTION
This commit sets `SyncWrites` to `false` in the `DefaultOptions`. We found out
that there was a significant performance improvement in serial writes if
`SyncWrites` is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/931)
<!-- Reviewable:end -->
