### PR TITLE
Drop discard stats if we can't unmarshal it

### DIFF
--- a/value.go
+++ b/value.go
@@ -800,7 +800,9 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 		return errFile(err, last.path, "Map log file")
 	}
 	if err := vlog.populateDiscardStats(); err != nil {
-		return err
+		// Print the error and continue. We don't want to prevent value log open if there's an error
+		// with the fetching discards stats.
+		db.opt.Infof("Failed to populate discard stats: %s", err)
 	}
 	return nil
 }

--- a/value.go
+++ b/value.go
@@ -802,7 +802,7 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 	if err := vlog.populateDiscardStats(); err != nil {
 		// Print the error and continue. We don't want to prevent value log open if there's an error
 		// with the fetching discards stats.
-		db.opt.Infof("Failed to populate discard stats: %s", err)
+		db.opt.Errorf("Failed to populate discard stats: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
We don't want to prevent badger from starting if we can't read/unmarshal
discard stats.

Fixes https://github.com/dgraph-io/dgraph/issues/3669

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/936)
<!-- Reviewable:end -->
