### PR TITLE
Optimize compareKeys function

### DIFF
--- a/y/y.go
+++ b/y/y.go
@@ -121,16 +121,18 @@ func ParseTs(key []byte) uint64 {
 	return math.MaxUint64 - binary.BigEndian.Uint64(key[len(key)-8:])
 }
 
-// CompareKeys checks the key without timestamp and checks the timestamp if keyNoTs
-// is same.
-// a<timestamp> would be sorted higher than aa<timestamp> if we use bytes.compare
-// All keys should have timestamp.
-func CompareKeys(key1, key2 []byte) int {
-	AssertTrue(len(key1) > 8 && len(key2) > 8)
-	if cmp := bytes.Compare(key1[:len(key1)-8], key2[:len(key2)-8]); cmp != 0 {
-		return cmp
+// CompareKeys checks the key with timestamp if the lengths are equal, otherwise checks only the
+// keys.
+// a<timestamp> would be sorted higher than aa<timestamp>
+func CompareKeys(key1 []byte, key2 []byte) int {
+	if len(key1) == len(key2) {
+		return bytes.Compare(key1, key2)
 	}
-	return bytes.Compare(key1[len(key1)-8:], key2[len(key2)-8:])
+	origKey1Len := len(key1) - 8
+	origkey2Len := len(key2) - 8
+	// If the lengths are different, we don't need to compare the
+	// timestamps since the keys itself are different.
+	return bytes.Compare(key1[:origKey1Len], key2[:origkey2Len])
 }
 
 // ParseKey parses the actual key from the key bytes.


### PR DESCRIPTION
The existing implementation would perform two comparisons if the keys
differed only in timestamps. The proposed implementation performs only
one comparison even if the keys are different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/937)
<!-- Reviewable:end -->
