### PR TITLE
Lock log file before munmap

### DIFF
--- a/value.go
+++ b/value.go
@@ -570,6 +570,9 @@ func (vlog *valueLog) deleteLogFile(lf *logFile) error {
 	if lf == nil {
 		return nil
 	}
+	lf.lock.Lock()
+	defer lf.lock.Unlock()
+
 	path := vlog.fpath(lf.fid)
 	if err := lf.munmap(); err != nil {
 		_ = lf.fd.Close()


### PR DESCRIPTION
Per the comments in the struct, the logFile should be write-locked when closing or unmapping. There is a potential race condition where an iterator could be reading a value and be holding the RLock but the memory will be unmapped via a call to deleteLogFile(lf *logFile)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/949)
<!-- Reviewable:end -->
