### PR TITLE
Fix prefix bug in key iterator and allow all versions

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -435,6 +435,7 @@ func (txn *Txn) NewKeyIterator(key []byte, opt IteratorOptions) *Iterator {
 	}
 	opt.Prefix = key // This key must be without the timestamp.
 	opt.prefixIsKey = true
+	opt.AllVersions = true
 	return txn.NewIterator(opt)
 }
 
@@ -458,6 +459,9 @@ func (it *Iterator) Item() *Item {
 func (it *Iterator) Valid() bool {
 	if it.item == nil {
 		return false
+	}
+	if it.opt.prefixIsKey {
+		return bytes.Equal(it.item.key, it.opt.Prefix)
 	}
 	return bytes.HasPrefix(it.item.key, it.opt.Prefix)
 }


### PR DESCRIPTION
The key iterator is supposed to iterate over all versions of the same key
but the current implementation would iterate over all keys with the given prefix.
For example: A key iterator for "foo" would return true for "foo" and
"foobar". This commit fixes the issue.

This commit also sets the value of `allVersions` to true in the key iterator.
Fixes https://github.com/dgraph-io/badger/issues/943

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/950)
<!-- Reviewable:end -->
