### PR TITLE
Do not return error from builder.Add method

### DIFF
--- a/db.go
+++ b/db.go
@@ -858,9 +858,7 @@ func writeLevel0Table(ft flushTask, f io.Writer) error {
 		if len(ft.dropPrefix) > 0 && bytes.HasPrefix(iter.Key(), ft.dropPrefix) {
 			continue
 		}
-		if err := b.Add(iter.Key(), iter.Value()); err != nil {
-			return err
-		}
+		b.Add(iter.Key(), iter.Value())
 	}
 	_, err := f.Write(b.Finish())
 	return err

--- a/db2_test.go
+++ b/db2_test.go
@@ -523,7 +523,7 @@ func createTableWithRange(t *testing.T, db *DB, start, end int) *table.Table {
 		binary.BigEndian.PutUint64(key[:], uint64(i))
 		key = y.KeyWithTs(key, uint64(0))
 		val := y.ValueStruct{Value: []byte(fmt.Sprintf("%d", i))}
-		require.NoError(t, b.Add(key, val))
+		b.Add(key, val)
 	}
 
 	fileID := db.lc.reserveFileID()

--- a/levels.go
+++ b/levels.go
@@ -556,7 +556,7 @@ func (s *levelsController) compactBuildTables(
 				}
 			}
 			numKeys++
-			y.Check(builder.Add(it.Key(), it.Value()))
+			builder.Add(it.Key(), it.Value())
 		}
 		// It was true that it.Valid() at least once in the loop above, which means we
 		// called Add() at least once, and builder is not Empty().

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -148,11 +148,6 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 			Meta:     'A',
 			UserMeta: 0,
 		})
-		if t != nil {
-			require.NoError(t, err)
-		} else {
-			y.Check(err)
-		}
 	}
 	f.Write(b.Finish())
 	f.Close()

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -143,7 +143,7 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 	})
 	for _, kv := range keyValues {
 		y.AssertTrue(len(kv) == 2)
-		err := b.Add(y.KeyWithTs([]byte(kv[0]), 10), y.ValueStruct{
+		b.Add(y.KeyWithTs([]byte(kv[0]), 10), y.ValueStruct{
 			Value:    []byte(kv[1]),
 			Meta:     'A',
 			UserMeta: 0,

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -274,7 +274,8 @@ func (w *sortedWriter) Add(key []byte, vs y.ValueStruct) error {
 	}
 
 	w.lastKey = y.SafeCopy(w.lastKey, key)
-	return w.builder.Add(key, vs)
+	w.builder.Add(key, vs)
+	return nil
 }
 
 func (w *sortedWriter) send() error {

--- a/table/builder.go
+++ b/table/builder.go
@@ -196,7 +196,7 @@ func (b *Builder) shouldFinishBlock(key []byte, value y.ValueStruct) bool {
 }
 
 // Add adds a key-value pair to the block.
-func (b *Builder) Add(key []byte, value y.ValueStruct) error {
+func (b *Builder) Add(key []byte, value y.ValueStruct) {
 	if b.shouldFinishBlock(key, value) {
 		b.finishBlock()
 		// Start a new block. Initialize the block.
@@ -206,7 +206,6 @@ func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 		b.entryOffsets = b.entryOffsets[:0]
 	}
 	b.addHelper(key, value)
-	return nil // Currently, there is no meaningful error.
 }
 
 // TODO: vvv this was the comment on ReachedCapacity.

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -59,7 +59,7 @@ func TestTableIndex(t *testing.T) {
 				blockCount++
 				blockFirstKeys = append(blockFirstKeys, k)
 			}
-			y.Check(builder.Add(k, vs))
+			builder.Add(k, vs)
 		}
 		f.Write(builder.Finish())
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -74,12 +74,7 @@ func buildTable(t *testing.T, keyValues [][]string) *os.File {
 	})
 	for _, kv := range keyValues {
 		y.AssertTrue(len(kv) == 2)
-		err := b.Add(y.KeyWithTs([]byte(kv[0]), 0), y.ValueStruct{Value: []byte(kv[1]), Meta: 'A', UserMeta: 0})
-		if t != nil {
-			require.NoError(t, err)
-		} else {
-			y.Check(err)
-		}
+		b.Add(y.KeyWithTs([]byte(kv[0]), 0), y.ValueStruct{Value: []byte(kv[1]), Meta: 'A', UserMeta: 0})
 	}
 	f.Write(b.Finish())
 	f.Close()
@@ -649,7 +644,7 @@ func TestTableBigValues(t *testing.T) {
 	for i := 0; i < n; i++ {
 		key := y.KeyWithTs([]byte(key("", i)), 0)
 		vs := y.ValueStruct{Value: value(i)}
-		require.NoError(t, builder.Add(key, vs))
+		builder.Add(key, vs)
 	}
 
 	f.Write(builder.Finish())
@@ -741,7 +736,7 @@ func BenchmarkReadMerged(b *testing.B) {
 			// id := i*tableSize+j (not interleaved)
 			k := fmt.Sprintf("%016x", id)
 			v := fmt.Sprintf("%d", id)
-			y.Check(builder.Add([]byte(k), y.ValueStruct{Value: []byte(v), Meta: 123, UserMeta: 0}))
+			builder.Add([]byte(k), y.ValueStruct{Value: []byte(v), Meta: 123, UserMeta: 0})
 		}
 		f.Write(builder.Finish())
 		tbl, err := OpenTable(f, options.LoadToRAM, options.OnTableAndBlockRead)
@@ -824,7 +819,7 @@ func getTableForBenchmarks(b *testing.B, count int) *Table {
 	for i := 0; i < count; i++ {
 		k := fmt.Sprintf("%016x", i)
 		v := fmt.Sprintf("%d", i)
-		y.Check(builder.Add([]byte(k), y.ValueStruct{Value: []byte(v)}))
+		builder.Add([]byte(k), y.ValueStruct{Value: []byte(v)})
 	}
 
 	f.Write(builder.Finish())


### PR DESCRIPTION
The builder.Add method doesn't need to return an error. We always return
nil and it has to be handled everywhere. This commit removes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/958)
<!-- Reviewable:end -->
