### PR TITLE
Making the stream writer APIs goroutine-safe

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -79,7 +79,8 @@ func (sw *StreamWriter) Prepare() error {
 }
 
 // Write writes KVList to DB. Each KV within the list contains the stream id which StreamWriter
-// would use to demux the writes. Write is not thread safe and it should NOT be called concurrently.
+// would use to demux the writes. Write is thread safe and can be called concurrently by mulitple
+// goroutines.
 func (sw *StreamWriter) Write(kvs *pb.KVList) error {
 	if len(kvs.GetKv()) == 0 {
 		return nil

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -41,7 +41,7 @@ const headStreamId uint32 = math.MaxUint32
 // StreamWriter should not be called on in-use DB instances. It is designed only to bootstrap new
 // DBs.
 type StreamWriter struct {
-	writeLock sync.Mutex
+	writeLock  sync.Mutex
 	db         *DB
 	done       func()
 	throttle   *y.Throttle


### PR DESCRIPTION
Adding locks around the StreamWriter APIs so that multiple go routines can call the APIs simultaneously without race conditions.
I've verified this change in bulk loader, which used to have RACE condition warnings reported by the race detector. With this change, those warnings are no longer showing up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/959)
<!-- Reviewable:end -->
