### PR TITLE
Prevent unnecessary safecopy in iterator parseKV

### DIFF
--- a/table/iterator.go
+++ b/table/iterator.go
@@ -164,7 +164,7 @@ func (itr *blockIterator) parseKV(h header) {
 			itr.pos, h.klen, h.vlen, len(itr.data), h)
 		return
 	}
-	itr.val = y.SafeCopy(itr.val, itr.data[itr.pos:itr.pos+uint32(h.vlen)])
+	itr.val = itr.data[itr.pos : itr.pos+uint32(h.vlen)]
 	itr.pos += uint32(h.vlen)
 }
 

--- a/txn.go
+++ b/txn.go
@@ -420,7 +420,7 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 	item.meta = vs.Meta
 	item.userMeta = vs.UserMeta
 	item.db = txn.db
-	item.vptr = vs.Value // TODO: Do we need to copy this over?
+	item.vptr = y.SafeCopy(item.vptr, vs.Value)
 	item.txn = txn
 	item.expiresAt = vs.ExpiresAt
 	return item, nil


### PR DESCRIPTION
The previous implementation of parseKV would copy over the value slice
every time, which is not necessary. The value slice should be copied only
when we return the result of point lookups. The proposed patch remove
safecopy call from the iterator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/971)
<!-- Reviewable:end -->
