### PR TITLE
Reuse block iterator inside table iterator

### DIFF
--- a/table/iterator.go
+++ b/table/iterator.go
@@ -299,7 +299,7 @@ func (itr *Iterator) seekToFirst() {
 		return
 	}
 
-	block.ResetIterator(itr.bi)
+	block.resetIterator(itr.bi)
 	itr.bi.SeekToFirst()
 	itr.err = itr.bi.Error()
 }
@@ -317,7 +317,7 @@ func (itr *Iterator) seekToLast() {
 		return
 	}
 
-	block.ResetIterator(itr.bi)
+	block.resetIterator(itr.bi)
 	itr.bi.SeekToLast()
 	itr.err = itr.bi.Error()
 }
@@ -330,7 +330,7 @@ func (itr *Iterator) seekHelper(blockIdx int, key []byte) {
 		return
 	}
 
-	block.ResetIterator(itr.bi)
+	block.resetIterator(itr.bi)
 	itr.bi.Seek(key, origin)
 	itr.err = itr.bi.Error()
 }
@@ -404,7 +404,7 @@ func (itr *Iterator) next() {
 			return
 		}
 
-		block.ResetIterator(itr.bi)
+		block.resetIterator(itr.bi)
 		itr.bi.SeekToFirst()
 		itr.err = itr.bi.Error()
 		return
@@ -433,7 +433,7 @@ func (itr *Iterator) prev() {
 			return
 		}
 
-		block.ResetIterator(itr.bi)
+		block.resetIterator(itr.bi)
 		itr.bi.SeekToLast()
 		itr.err = itr.bi.Error()
 		return

--- a/table/table.go
+++ b/table/table.go
@@ -143,14 +143,12 @@ func (b *block) verifyCheckSum() error {
 	return y.VerifyChecksum(b.data[:readPos], cs)
 }
 
-func (b *block) NewIterator() *blockIterator {
-	bi := &blockIterator{
-		data:              b.data,
-		numEntries:        b.numEntries,
-		entriesIndexStart: b.entriesIndexStart,
-	}
+func (b *block) ResetIterator(bi *blockIterator) {
+	bi.data = b.data
+	bi.numEntries = b.numEntries
+	bi.entriesIndexStart = b.entriesIndexStart
 
-	return bi
+	bi.Reset()
 }
 
 // OpenTable assumes file has only one table and opens it. Takes ownership of fd upon function

--- a/table/table.go
+++ b/table/table.go
@@ -144,11 +144,11 @@ func (b *block) verifyCheckSum() error {
 }
 
 func (b *block) ResetIterator(bi *blockIterator) {
+	bi.Reset()
+
 	bi.data = b.data
 	bi.numEntries = b.numEntries
 	bi.entriesIndexStart = b.entriesIndexStart
-
-	bi.Reset()
 }
 
 // OpenTable assumes file has only one table and opens it. Takes ownership of fd upon function

--- a/table/table.go
+++ b/table/table.go
@@ -128,7 +128,7 @@ type block struct {
 	chkLen            int // checksum length
 }
 
-func (b block) verifyCheckSum() error {
+func (b *block) verifyCheckSum() error {
 	readPos := len(b.data) - 4 - b.chkLen
 	if readPos < 0 {
 		// This should be rare, hence can create a error instead of having global error.
@@ -143,7 +143,7 @@ func (b block) verifyCheckSum() error {
 	return y.VerifyChecksum(b.data[:readPos], cs)
 }
 
-func (b block) NewIterator() *blockIterator {
+func (b *block) NewIterator() *blockIterator {
 	bi := &blockIterator{
 		data:              b.data,
 		numEntries:        b.numEntries,

--- a/table/table.go
+++ b/table/table.go
@@ -143,7 +143,7 @@ func (b *block) verifyCheckSum() error {
 	return y.VerifyChecksum(b.data[:readPos], cs)
 }
 
-func (b *block) ResetIterator(bi *blockIterator) {
+func (b *block) resetIterator(bi *blockIterator) {
 	bi.Reset()
 
 	bi.data = b.data


### PR DESCRIPTION
Idea is to minimise allocations for block iterators by allocating block iterator only once and then reusing the same, inside table iterator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/972)
<!-- Reviewable:end -->
