### PR TITLE
Fix race condition in updateDiscardStats

### DIFF
--- a/value.go
+++ b/value.go
@@ -1384,11 +1384,12 @@ func (vlog *valueLog) runGC(discardRatio float64, head valuePointer) error {
 
 func (vlog *valueLog) updateDiscardStats(stats map[uint32]int64) error {
 	vlog.lfDiscardStats.Lock()
+	defer vlog.lfDiscardStats.Unlock()
+
 	for fid, sz := range stats {
 		vlog.lfDiscardStats.m[fid] += sz
 		vlog.lfDiscardStats.updatesSinceFlush++
 	}
-	vlog.lfDiscardStats.Unlock()
 	if vlog.lfDiscardStats.updatesSinceFlush > discardStatsFlushThreshold {
 		if err := vlog.flushDiscardStats(); err != nil {
 			return err


### PR DESCRIPTION
The TestGetMore test fails with race condition in updateDiscardStats
function.
See https://teamcity.dgraph.io/viewLog.html?buildId=19032&buildTypeId=Badger_UnitTests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/973)
<!-- Reviewable:end -->
