### PR TITLE
Fix boundaries on GC batch size

### DIFF
--- a/value.go
+++ b/value.go
@@ -400,8 +400,8 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 			ne.Value = append([]byte{}, e.Value...)
 			es := int64(ne.estimateSize(vlog.opt.ValueThreshold))
 			// Ensure length and size of wb is within transaction limits.
-			if int64(len(wb)+1) > vlog.opt.maxBatchCount ||
-				size+es > vlog.opt.maxBatchSize {
+			if int64(len(wb)+1) >= vlog.opt.maxBatchCount ||
+				size+es >= vlog.opt.maxBatchSize {
 				tr.LazyPrintf("request has %d entries, size %d", len(wb), size)
 				if err := vlog.db.batchSet(wb); err != nil {
 					return err


### PR DESCRIPTION
In the value log rewrite, the check to determine if the commit was going to be within transaction limits only checked if the value would be `>` than the max count. However, the check within the transaction is:

```
   if count >= db.opt.maxBatchCount || size >= db.opt.maxBatchSize {
        return nil, ErrTxnTooBig
    }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/987)
<!-- Reviewable:end -->
