### PR TITLE
Adding encrption support to the table and table builder.

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -153,6 +153,7 @@ func (b *Builder) finishBlock() {
 		block := b.buf.Bytes()[b.baseOffset:]
 		eBlock, err := b.encrypt(block)
 		y.Check(y.Wrapf(err, "Error while encrypting block in table builder."))
+		// We're rewriting the block, after encrypting.
 		b.buf.Truncate(int(b.baseOffset))
 		b.buf.Write(eBlock)
 	}

--- a/table/builder.go
+++ b/table/builder.go
@@ -141,8 +141,7 @@ Structure of Block.
 | to perform binary search in the block)  | (4 Bytes)          | Checksum     | (4 Bytes)        |
 +-----------------------------------------+--------------------+--------------+------------------+
 */
-// The structure of the block will remain same while encrypting. But we store the above
-// data in the encrypted format and also append IV at the end of the block.
+// In case the data is encrypted, the "IV" is added to the end of the block.
 func (b *Builder) finishBlock() {
 	b.buf.Write(y.U32SliceToBytes(b.entryOffsets))
 	b.buf.Write(y.U32ToBytes(uint32(len(b.entryOffsets))))
@@ -238,9 +237,7 @@ The table structure looks like
 | Index   | Index Size | Checksum  | Checksum Size |
 +---------+------------+-----------+---------------+
 */
-// The table structure remains same while encrypting. The only
-// diffrence is that, we store encrypted data. The index will
-// have additional IV while on the disk.
+// In case the data is encrypted, the "IV" is added to the end of the index.
 func (b *Builder) Finish() []byte {
 	bf := z.NewBloomFilter(float64(len(b.keyHashes)), b.opt.BloomFalsePostive)
 	for _, h := range b.keyHashes {
@@ -303,9 +300,8 @@ func (b *Builder) DataKey() *pb.DataKey {
 	return b.opt.DataKey
 }
 
-// encrypt will encrypt the give data and appends
-// IV to the end of the encrypted data. It should be called
-// only after checking shouldEncrypt method.
+// encrypt will encrypt the given data and appends IV to the end of the encrypted data.
+// This should be only called only after checking shouldEncrypt method.
 func (b *Builder) encrypt(data []byte) ([]byte, error) {
 	iv, err := y.GenerateIV()
 	if err != nil {

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/badger/options"
+	"github.com/dgraph-io/badger/pb"
 	"github.com/dgraph-io/badger/y"
 )
 
@@ -41,38 +42,49 @@ func TestTableIndex(t *testing.T) {
 	})
 
 	t.Run("multiple keys", func(t *testing.T) {
-		keysCount := 10000
-		opts := Options{BlockSize: 4 * 1024, BloomFalsePostive: 0.01}
-		builder := NewTableBuilder(opts)
-		filename := fmt.Sprintf("%s%c%d.sst", os.TempDir(), os.PathSeparator, rand.Int63())
-		f, err := y.OpenSyncedFile(filename, true)
+		opts := []Options{}
+		// Normal mode.
+		opts = append(opts, Options{BlockSize: 4 * 1024, BloomFalsePostive: 0.01})
+		// Encryption mode.
+		key := make([]byte, 32)
+		_, err := rand.Read(key)
 		require.NoError(t, err)
+		opts = append(opts, Options{BlockSize: 4 * 1024, BloomFalsePostive: 0.01,
+			DataKey: &pb.DataKey{Data: key}})
+		keysCount := 10000
+		for _, opt := range opts {
+			builder := NewTableBuilder(opt)
+			filename := fmt.Sprintf("%s%c%d.sst", os.TempDir(), os.PathSeparator, rand.Int63())
+			f, err := y.OpenSyncedFile(filename, true)
+			require.NoError(t, err)
 
-		blockFirstKeys := make([][]byte, 0)
-		blockCount := 0
-		for i := 0; i < keysCount; i++ {
-			k := []byte(fmt.Sprintf("%016x", i))
-			v := fmt.Sprintf("%d", i)
-			vs := y.ValueStruct{Value: []byte(v)}
-			if i == 0 { // This is first key for first block.
-				blockFirstKeys = append(blockFirstKeys, k)
-				blockCount = 1
-			} else if builder.shouldFinishBlock(k, vs) {
-				blockCount++
-				blockFirstKeys = append(blockFirstKeys, k)
+			blockFirstKeys := make([][]byte, 0)
+			blockCount := 0
+			for i := 0; i < keysCount; i++ {
+				k := []byte(fmt.Sprintf("%016x", i))
+				v := fmt.Sprintf("%d", i)
+				vs := y.ValueStruct{Value: []byte(v)}
+				if i == 0 { // This is first key for first block.
+					blockFirstKeys = append(blockFirstKeys, k)
+					blockCount = 1
+				} else if builder.shouldFinishBlock(k, vs) {
+					blockCount++
+					blockFirstKeys = append(blockFirstKeys, k)
+				}
+				builder.Add(k, vs)
 			}
-			builder.Add(k, vs)
-		}
-		f.Write(builder.Finish())
+			f.Write(builder.Finish())
 
-		opts = Options{LoadingMode: options.LoadToRAM, ChkMode: options.OnTableAndBlockRead}
-		tbl, err := OpenTable(f, opts)
-		require.NoError(t, err, "unable to open table")
+			topt := Options{LoadingMode: options.LoadToRAM, ChkMode: options.OnTableAndBlockRead,
+				DataKey: opt.DataKey}
+			tbl, err := OpenTable(f, topt)
+			require.NoError(t, err, "unable to open table")
 
-		// Ensure index is built correctly
-		require.Equal(t, blockCount, len(tbl.blockIndex))
-		for i, ko := range tbl.blockIndex {
-			require.Equal(t, ko.Key, blockFirstKeys[i])
+			// Ensure index is built correctly
+			require.Equal(t, blockCount, len(tbl.blockIndex))
+			for i, ko := range tbl.blockIndex {
+				require.Equal(t, ko.Key, blockFirstKeys[i])
+			}
 		}
 	})
 }


### PR DESCRIPTION
This PR is the follow up of the registry PR #975 .

In this PR, support for encryption added to the table.

Implementation details.

The data format on disk will be the same as before, except we'll add IV to the end of the data block, which we are encrypting.

We'll decide whether to decrypt or encrypt based on the datakey. If datakey present, we'll encrypt or decrypt. Otherwise, we don't do anything.

We'll encrypt while storing to the disk.(table builder)
We'll decrypt while reading the data. (table)
Signed-off-by: பாலாஜி ஜின்னா <balaji@dgraph.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/991)
<!-- Reviewable:end -->
