### PR TITLE
Use standard proto functions for Marshal/Unmarshal and Size

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dgraph-io/badger/pb"
 	"github.com/dgraph-io/badger/y"
+	"github.com/golang/protobuf/proto"
 )
 
 // Backup is a wrapper function over Stream.Backup to generate full and incremental backups of the
@@ -119,7 +120,7 @@ func writeTo(list *pb.KVList, w io.Writer) error {
 	if err := binary.Write(w, binary.LittleEndian, uint64(list.Size())); err != nil {
 		return err
 	}
-	buf, err := list.Marshal()
+	buf, err := proto.Marshal(list)
 	if err != nil {
 		return err
 	}
@@ -228,7 +229,7 @@ func (db *DB) Load(r io.Reader, maxPendingWrites int) error {
 		}
 
 		list := &pb.KVList{}
-		if err := list.Unmarshal(unmarshalBuf[:sz]); err != nil {
+		if err := proto.Unmarshal(unmarshalBuf[:sz], list); err != nil {
 			return err
 		}
 

--- a/backup.go
+++ b/backup.go
@@ -117,7 +117,7 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 }
 
 func writeTo(list *pb.KVList, w io.Writer) error {
-	if err := binary.Write(w, binary.LittleEndian, uint64(list.Size())); err != nil {
+	if err := binary.Write(w, binary.LittleEndian, uint64(proto.Size(list))); err != nil {
 		return err
 	}
 	buf, err := proto.Marshal(list)

--- a/manifest.go
+++ b/manifest.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/dgraph-io/badger/pb"
 	"github.com/dgraph-io/badger/y"
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -186,7 +187,7 @@ func (mf *manifestFile) close() error {
 // the wrong time.)
 func (mf *manifestFile) addChanges(changesParam []*pb.ManifestChange) error {
 	changes := pb.ManifestChangeSet{Changes: changesParam}
-	buf, err := changes.Marshal()
+	buf, err := proto.Marshal(&changes)
 	if err != nil {
 		return err
 	}
@@ -241,7 +242,7 @@ func helpRewrite(dir string, m *Manifest) (*os.File, int, error) {
 	changes := m.asChanges()
 	set := pb.ManifestChangeSet{Changes: changes}
 
-	changeBuf, err := set.Marshal()
+	changeBuf, err := proto.Marshal(&set)
 	if err != nil {
 		fp.Close()
 		return nil, 0, err
@@ -371,7 +372,7 @@ func ReplayManifestFile(fp *os.File) (ret Manifest, truncOffset int64, err error
 		}
 
 		var changeSet pb.ManifestChangeSet
-		if err := changeSet.Unmarshal(buf); err != nil {
+		if err := proto.Unmarshal(buf, &changeSet); err != nil {
 			return Manifest{}, 0, err
 		}
 

--- a/stream.go
+++ b/stream.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dgraph-io/badger/pb"
 	"github.com/dgraph-io/badger/y"
 	humanize "github.com/dustin/go-humanize"
+	"github.com/golang/protobuf/proto"
 )
 
 const pageSize = 4 << 20 // 4MB
@@ -195,7 +196,7 @@ func (st *Stream) produceKVs(ctx context.Context) error {
 				continue
 			}
 			outList.Kv = append(outList.Kv, list.Kv...)
-			size += list.Size()
+			size += proto.Size(list)
 			if size >= pageSize {
 				for _, kv := range outList.Kv {
 					kv.StreamId = streamId
@@ -260,7 +261,7 @@ func (st *Stream) streamKVs(ctx context.Context) error {
 				break loop
 			}
 		}
-		sz := uint64(batch.Size())
+		sz := uint64(proto.Size(batch))
 		bytesSent += sz
 		count += len(batch.Kv)
 		t := time.Now()

--- a/table/builder.go
+++ b/table/builder.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/dgryski/go-farm"
+	"github.com/golang/protobuf/proto"
 
 	"github.com/dgraph-io/badger/pb"
 	"github.com/dgraph-io/badger/y"
@@ -232,7 +233,7 @@ func (b *Builder) Finish() []byte {
 
 	b.finishBlock() // This will never start a new block.
 
-	index, err := b.tableIndex.Marshal()
+	index, err := proto.Marshal(b.tableIndex)
 	y.Check(err)
 	// Write index the file.
 	n, err := b.buf.Write(index)
@@ -263,7 +264,7 @@ func (b *Builder) writeChecksum(data []byte) {
 	}
 
 	// Write checksum to the file.
-	chksum, err := checksum.Marshal()
+	chksum, err := proto.Marshal(&checksum)
 	y.Check(err)
 	n, err := b.buf.Write(chksum)
 	y.Check(err)

--- a/table/table.go
+++ b/table/table.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 
 	"github.com/dgryski/go-farm"
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/badger/options"
@@ -130,7 +131,7 @@ type block struct {
 
 func (b block) verifyCheckSum() error {
 	cs := &pb.Checksum{}
-	if err := cs.Unmarshal(b.checksum); err != nil {
+	if err := proto.Unmarshal(b.checksum, cs); err != nil {
 		return y.Wrapf(err, "unable to unmarshal checksum for block")
 	}
 	return y.VerifyChecksum(b.data, cs)
@@ -264,7 +265,7 @@ func (t *Table) readIndex() error {
 	expectedChk := &pb.Checksum{}
 	readPos -= checksumLen
 	buf = t.readNoFail(readPos, checksumLen)
-	if err := expectedChk.Unmarshal(buf); err != nil {
+	if err := proto.Unmarshal(buf, expectedChk); err != nil {
 		return err
 	}
 
@@ -281,7 +282,7 @@ func (t *Table) readIndex() error {
 	}
 
 	index := pb.TableIndex{}
-	err := index.Unmarshal(data)
+	err := proto.Unmarshal(data, &index)
 	y.Check(err)
 
 	t.bf = z.JSONUnmarshal(index.BloomFilter)


### PR DESCRIPTION
Some of the code interacting with protobufs was calling functions emitted by the proto compiler directly on the protobuf structs;  `proto_obj.Marshal`, `proto_obj.Unmarshal`, proto_obj.Size`.

These functions are no longer emitted by the upstream protobuf compiler, only by gogo/protobuf.

Users who don't use the pregenerated `pb.pb.go`, but instead recompile the proto files using the upstream compiler will encounter compilations failures.  (I hit this because that's the default mode for importing go projects using bazel and gazelle).

These commits change any code that was using these functions to use the standard proto library functions: `proto.Marshal`, `proto.Unmarshal`, and `proto.Size`.

These changes shouldn't cause any performance effects --- the implementations of each of these functions call out, directly or indirectly, to the directly-attached functions, if they exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/994)
<!-- Reviewable:end -->
