### PR TITLE
Fix table.Smallest/Biggest and iterator Prefix bug

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -349,10 +349,10 @@ func (opt *IteratorOptions) pickTable(t table.TableInterface) bool {
 		}
 		return key
 	}
-	if bytes.Compare(trim(t.Smallest()), opt.Prefix) > 0 {
+	if bytes.Compare(trim(y.ParseKey(t.Smallest())), opt.Prefix) > 0 {
 		return false
 	}
-	if bytes.Compare(trim(t.Biggest()), opt.Prefix) < 0 {
+	if bytes.Compare(trim(y.ParseKey(t.Biggest())), opt.Prefix) < 0 {
 		return false
 	}
 	// Bloom filter lookup would only work if opt.Prefix does NOT have the read

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -44,12 +44,14 @@ func TestPickTables(t *testing.T) {
 
 	within := func(prefix, left, right string) {
 		opt.Prefix = []byte(prefix)
-		tm := &tableMock{left: []byte(left), right: []byte(right)}
+		// PickTable expects smallest and biggest to contain timestamps.
+		tm := &tableMock{left: y.KeyWithTs([]byte(left), 1), right: y.KeyWithTs([]byte(right), 1)}
 		require.True(t, opt.pickTable(tm))
 	}
 	outside := func(prefix, left, right string) {
 		opt.Prefix = []byte(prefix)
-		tm := &tableMock{left: []byte(left), right: []byte(right)}
+		// PickTable expects smallest and biggest to contain timestamps.
+		tm := &tableMock{left: y.KeyWithTs([]byte(left), 1), right: y.KeyWithTs([]byte(right), 1)}
 		require.False(t, opt.pickTable(tm))
 	}
 	within("abc", "ab", "ad")

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -42,23 +42,25 @@ func (tm *tableMock) DoesNotHave(key []byte) bool { return false }
 func TestPickTables(t *testing.T) {
 	opt := DefaultIteratorOptions
 
-	within := func(prefix, left, right string) {
-		opt.Prefix = []byte(prefix)
+	within := func(prefix, left, right []byte) {
+		opt.Prefix = prefix
 		// PickTable expects smallest and biggest to contain timestamps.
-		tm := &tableMock{left: y.KeyWithTs([]byte(left), 1), right: y.KeyWithTs([]byte(right), 1)}
-		require.True(t, opt.pickTable(tm))
+		tm := &tableMock{left: y.KeyWithTs(left, 1), right: y.KeyWithTs(right, 1)}
+		require.True(t, opt.pickTable(tm), "within failed for %b %b %b\n", prefix, left, right)
 	}
 	outside := func(prefix, left, right string) {
 		opt.Prefix = []byte(prefix)
 		// PickTable expects smallest and biggest to contain timestamps.
 		tm := &tableMock{left: y.KeyWithTs([]byte(left), 1), right: y.KeyWithTs([]byte(right), 1)}
-		require.False(t, opt.pickTable(tm))
+		require.False(t, opt.pickTable(tm), "outside failed for %b %b %b", prefix, left, right)
 	}
-	within("abc", "ab", "ad")
-	within("abc", "abc", "ad")
-	within("abc", "abb123", "ad")
-	within("abc", "abc123", "abd234")
-	within("abc", "abc123", "abc456")
+	within([]byte("abc"), []byte("ab"), []byte("ad"))
+	within([]byte("abc"), []byte("abc"), []byte("ad"))
+	within([]byte("abc"), []byte("abb123"), []byte("ad"))
+	within([]byte("abc"), []byte("abc123"), []byte("abd234"))
+	within([]byte("abc"), []byte("abc123"), []byte("abc456"))
+	// Regression test for https://github.com/dgraph-io/badger/issues/992
+	within([]byte{0, 0, 1}, []byte{0}, []byte{0, 0, 1})
 
 	outside("abd", "abe", "ad")
 	outside("abd", "ac", "ad")

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -35,7 +35,7 @@ type blockIterator struct {
 	entryOffsets []uint32
 
 	// prevOverlap stores the overlap of the previous key with the base key.
-	// This avoids unnecssary copy of base key when the overlap is same for multiple keys.
+	// This avoids unnecessary copy of base key when the overlap is same for multiple keys.
 	prevOverlap uint16
 }
 
@@ -341,7 +341,8 @@ func (itr *Iterator) prev() {
 	}
 }
 
-// Key follows the y.Iterator interface
+// Key follows the y.Iterator interface.
+// Returns the key with timestamp.
 func (itr *Iterator) Key() []byte {
 	return itr.bi.key
 }

--- a/table/table.go
+++ b/table/table.go
@@ -77,7 +77,7 @@ type Table struct {
 	mmap []byte // Memory mapped.
 
 	// The following are initialized once and const.
-	smallest, biggest []byte // Smallest and largest keys.
+	smallest, biggest []byte // Smallest and largest keys (with timestamps).
 	id                uint64 // file id, part of filename
 
 	bf       *z.Bloom


### PR DESCRIPTION
The pick table compares the smallest and biggest key of each table
against the iteratorOptions.Prefix. The smallest and biggest key contain
timestamps while the prefix does not contain a timestamp. So pickTable
would return not return the correct tables.

For example
Table has Smallest [0 255 255... ] and prefix [0, 0, 1], the comparison
of these two values would return true implying that the smallest is
greater than the prefix which is incorrect because prefix doesn't
contains a timestamp and smallest does.

With this commit, we compare the smallest/biggest keys without
timestamps to the opt.Prefix.

Fixes https://github.com/dgraph-io/badger/issues/992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/997)
<!-- Reviewable:end -->
