### PR TITLE
Run travis build for all go version for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ go:
     - "1.11"
     - "1.12"
 
-matrix:
-  include:
-    - os: osx
+os:
+    - linux
+    - osx
+
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ go:
     - "1.12"
 
 os:
-    - linux
     - osx
 
 notifications:


### PR DESCRIPTION
Currently, tests are only run for Go1.11 on OSX in Travis build. This PR fixes it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/998)
<!-- Reviewable:end -->
