### PR TITLE
Set move key's expiresAt for keys with TTL

### DIFF
--- a/value.go
+++ b/value.go
@@ -383,6 +383,7 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 			ne := new(Entry)
 			ne.meta = 0 // Remove all bits. Different keyspace doesn't need these bits.
 			ne.UserMeta = e.UserMeta
+			ne.ExpiresAt = e.ExpiresAt
 
 			// Create a new key in a separate keyspace, prefixed by moveKey. We are not
 			// allowed to rewrite an older version of key in the LSM tree, because then this older


### PR DESCRIPTION
The value log GC moves keys from one value log file to another. The
current implementation of vlog GC  would not copy the TTL from the
original entry to the new move key. This commit fixes that.

Without this change, the move keys were not being removed as seen in
issue https://github.com/dgraph-io/badger/issues/974.
With this commit, the move keys are being removed.


This script (https://gist.github.com/kung-foo/66317e4b274ec456a92270e32d692ff7) was used to generate the results shown below.

**Move keys being removed because of this Patch** (internal keys == move keys)
![Move Keys - New Patch (2)](https://user-images.githubusercontent.com/12949454/63633024-f4ee6380-c65e-11e9-967f-59922bd38bc3.png)


**Move keys not being removed in master**
![63579935-52c47200-c5b1-11e9-99c3-4bbb8659dd00](https://user-images.githubusercontent.com/12949454/63632992-b789d600-c65e-11e9-954f-0546084926f0.png)

Fixes: https://github.com/dgraph-io/badger/issues/974

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1006)
<!-- Reviewable:end -->
