### PR TITLE
Minor optimizations

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -25,10 +25,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgryski/go-farm"
-
 	"github.com/dgraph-io/badger/options"
 	"github.com/dgraph-io/badger/table"
+	"github.com/dgryski/go-farm"
 
 	"github.com/dgraph-io/badger/y"
 )
@@ -363,7 +362,7 @@ func (opt *IteratorOptions) pickTable(t table.TableInterface) bool {
 	}
 	// Bloom filter lookup would only work if opt.Prefix does NOT have the read
 	// timestamp as part of the key.
-	if opt.prefixIsKey && t.DoesNotHaveHash(farm.Fingerprint64(opt.Prefix)) {
+	if opt.prefixIsKey && t.DoesNotHave(farm.Fingerprint64(opt.Prefix)) {
 		return false
 	}
 	return true
@@ -405,7 +404,7 @@ func (opt *IteratorOptions) pickTables(all []*table.Table) []*table.Table {
 		}
 		// opt.Prefix is actually the key. So, we can run bloom filter checks
 		// as well.
-		if t.DoesNotHaveHash(hash) {
+		if t.DoesNotHave(hash) {
 			continue
 		}
 		out = append(out, t)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -36,9 +36,9 @@ type tableMock struct {
 	left, right []byte
 }
 
-func (tm *tableMock) Smallest() []byte                 { return tm.left }
-func (tm *tableMock) Biggest() []byte                  { return tm.right }
-func (tm *tableMock) DoesNotHaveHash(hash uint64) bool { return false }
+func (tm *tableMock) Smallest() []byte             { return tm.left }
+func (tm *tableMock) Biggest() []byte              { return tm.right }
+func (tm *tableMock) DoesNotHave(hash uint64) bool { return false }
 
 func TestPickTables(t *testing.T) {
 	opt := DefaultIteratorOptions

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -36,9 +36,9 @@ type tableMock struct {
 	left, right []byte
 }
 
-func (tm *tableMock) Smallest() []byte            { return tm.left }
-func (tm *tableMock) Biggest() []byte             { return tm.right }
-func (tm *tableMock) DoesNotHave(key []byte) bool { return false }
+func (tm *tableMock) Smallest() []byte                 { return tm.left }
+func (tm *tableMock) Biggest() []byte                  { return tm.right }
+func (tm *tableMock) DoesNotHaveHash(hash uint64) bool { return false }
 
 func TestPickTables(t *testing.T) {
 	opt := DefaultIteratorOptions

--- a/level_handler.go
+++ b/level_handler.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/dgryski/go-farm"
+
 	"github.com/dgraph-io/badger/table"
 	"github.com/dgraph-io/badger/y"
 	"github.com/pkg/errors"
@@ -231,9 +233,10 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 	tables, decr := s.getTableForKey(key)
 	keyNoTs := y.ParseKey(key)
 
+	hash := farm.Fingerprint64(keyNoTs)
 	var maxVs y.ValueStruct
 	for _, th := range tables {
-		if th.DoesNotHave(keyNoTs) {
+		if th.DoesNotHaveHash(hash) {
 			y.NumLSMBloomHits.Add(s.strLevel, 1)
 			continue
 		}

--- a/level_handler.go
+++ b/level_handler.go
@@ -236,7 +236,7 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 	hash := farm.Fingerprint64(keyNoTs)
 	var maxVs y.ValueStruct
 	for _, th := range tables {
-		if th.DoesNotHaveHash(hash) {
+		if th.DoesNotHave(hash) {
 			y.NumLSMBloomHits.Add(s.strLevel, 1)
 			continue
 		}

--- a/table/table.go
+++ b/table/table.go
@@ -61,7 +61,7 @@ type Options struct {
 type TableInterface interface {
 	Smallest() []byte
 	Biggest() []byte
-	DoesNotHaveHash(hash uint64) bool
+	DoesNotHave(hash uint64) bool
 }
 
 // Table represents a loaded table file with the info we have about it
@@ -347,9 +347,9 @@ func (t *Table) Filename() string { return t.fd.Name() }
 // ID is the table's ID number (used to make the file name).
 func (t *Table) ID() uint64 { return t.id }
 
-// DoesNotHaveHash returns true if (but not "only if") the table does not have the key hash.
+// DoesNotHave returns true if (but not "only if") the table does not have the key hash.
 // It does a bloom filter lookup.
-func (t *Table) DoesNotHaveHash(hash uint64) bool { return !t.bf.Has(hash) }
+func (t *Table) DoesNotHave(hash uint64) bool { return !t.bf.Has(hash) }
 
 // VerifyChecksum verifies checksum for all blocks of table. This function is called by
 // OpenTable() function. This function is also called inside levelsController.VerifyChecksum().

--- a/table/table.go
+++ b/table/table.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/dgryski/go-farm"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
@@ -62,7 +61,7 @@ type Options struct {
 type TableInterface interface {
 	Smallest() []byte
 	Biggest() []byte
-	DoesNotHave(key []byte) bool
+	DoesNotHaveHash(hash uint64) bool
 }
 
 // Table represents a loaded table file with the info we have about it
@@ -348,9 +347,9 @@ func (t *Table) Filename() string { return t.fd.Name() }
 // ID is the table's ID number (used to make the file name).
 func (t *Table) ID() uint64 { return t.id }
 
-// DoesNotHave returns true if (but not "only if") the table does not have the key.  It does a
-// bloom filter lookup.
-func (t *Table) DoesNotHave(key []byte) bool { return !t.bf.Has(farm.Fingerprint64(key)) }
+// DoesNotHaveHash returns true if (but not "only if") the table does not have the key hash.
+// It does a bloom filter lookup.
+func (t *Table) DoesNotHaveHash(hash uint64) bool { return !t.bf.Has(hash) }
 
 // VerifyChecksum verifies checksum for all blocks of table. This function is called by
 // OpenTable() function. This function is also called inside levelsController.VerifyChecksum().

--- a/y/y.go
+++ b/y/y.go
@@ -128,7 +128,6 @@ func ParseTs(key []byte) uint64 {
 // a<timestamp> would be sorted higher than aa<timestamp> if we use bytes.compare
 // All keys should have timestamp.
 func CompareKeys(key1, key2 []byte) int {
-	AssertTrue(len(key1) > 8 && len(key2) > 8)
 	if cmp := bytes.Compare(key1[:len(key1)-8], key2[:len(key2)-8]); cmp != 0 {
 		return cmp
 	}
@@ -141,7 +140,6 @@ func ParseKey(key []byte) []byte {
 		return nil
 	}
 
-	AssertTrue(len(key) > 8)
 	return key[:len(key)-8]
 }
 


### PR DESCRIPTION
- Use precalculated hash for bloom filter test.
- Remove assertTrue from y.CompareKeys and y.ParseKeys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1017)
<!-- Reviewable:end -->
