### PR TITLE
Update iterator.go

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -523,8 +523,7 @@ func (it *Iterator) ValidForPrefix(prefix []byte) bool {
 
 // ContainForPrefix returns false when iteration is done
 // or when the current key doesn't contain the specified prefix.
-// useful in prefix scanning to match if key contains any of prefix
-// E.g, for it.Seek(prefix); it.ContainForPrefix(contain); it.Next() {
+// Useful in prefix scanning to match if other keyword should also contains in key as well, E.g is in "README.md" file
 func (it *Iterator) ContainForPrefix(prefix []byte) bool {
 	return it.Valid() && bytes.Contains(it.item.key, prefix)
 }

--- a/iterator.go
+++ b/iterator.go
@@ -523,9 +523,9 @@ func (it *Iterator) ValidForPrefix(prefix []byte) bool {
 
 // ContainForPrefix returns false when iteration is done
 // or when the current key doesn't contain the specified prefix.
-// Useful in prefix scanning to match if other keyword should also contains in key as well, E.g is in "README.md" file
-func (it *Iterator) ContainForPrefix(prefix []byte) bool {
-	return it.Valid() && bytes.Contains(it.item.key, prefix)
+// Useful in prefix scanning to match if other keyword should also contains in key as well.
+func (it *Iterator) ContainForPrefix(contain []byte) bool {
+	return it.Valid() && bytes.Contains(it.item.key, contain)
 }
 
 // Close would close the iterator. It is important to call this when you're done with iteration.

--- a/iterator.go
+++ b/iterator.go
@@ -521,6 +521,14 @@ func (it *Iterator) ValidForPrefix(prefix []byte) bool {
 	return it.Valid() && bytes.HasPrefix(it.item.key, prefix)
 }
 
+// ContainForPrefix returns false when iteration is done
+// or when the current key doesn't contain the specified prefix.
+// useful in prefix scanning to match if key contains any of prefix
+// E.g, for it.Seek(prefix); it.ContainForPrefix(contain); it.Next() {
+func (it *Iterator) ContainForPrefix(prefix []byte) bool {
+	return it.Valid() && bytes.Contains(it.item.key, prefix)
+}
+
 // Close would close the iterator. It is important to call this when you're done with iteration.
 func (it *Iterator) Close() {
 	if it.closed {

--- a/iterator.go
+++ b/iterator.go
@@ -523,7 +523,7 @@ func (it *Iterator) ValidForPrefix(prefix []byte) bool {
 
 // ContainForPrefix returns false when iteration is done
 // or when the current key doesn't contain the specified prefix.
-// Useful in prefix scanning to match if other keyword should also contains in key as well.
+// Useful in prefix scanning to match if other keyword should be contained in the key as well.
 func (it *Iterator) ContainForPrefix(contain []byte) bool {
 	return it.Valid() && bytes.Contains(it.item.key, contain)
 }


### PR DESCRIPTION
// ContainForPrefix returns false when iteration is done
// or when the current key doesn't contain the specified prefix.
// useful in prefix scanning to match if key contains any of prefix
// E.g, for it.Seek(prefix); it.ContainForPrefix(contain); it.Next() {

I needed this so badly in my situation and I believe this could be handy for others as well. Not sure, why it was not available by default.

I needed something to which I can use for a prefix with reverse as well as must contain some unique code in key in the same prefix.

Badger current only support "HasPrefix" and "HasSuffix", but there can be a situation where at some point, one may need "something in between the key".

Example added in README.md file as well here - https://github.com/dgraph-io/badger/pull/1028

```
date := "2019-09-09"
uniqueCode := "server-log-"

opts := badger.DefaultIteratorOptions
opts.PrefetchSize = 20
opts.Reverse = true
it := txn.NewIterator(opts)
defer it.Close()

// reverse prefix as per date
prefix := append([]byte("log-"+date), 0xFF)

// but should also contain this keyword in key
contain := []byte(date + "-" + uniqueCode)

// in below, I can not use "prefix" or "suffix", but I needed something like that "contains" which was present in "bytes.go" so created new function.

for it.Seek(prefix); it.ContainForPrefix(contain); it.Next() {
...
}
```

this made my reverse lookup easy, I hope this is accepted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1027)
<!-- Reviewable:end -->
