### PR TITLE
Add readTs in WriteBatch

### DIFF
--- a/managed_db.go
+++ b/managed_db.go
@@ -40,16 +40,19 @@ func (db *DB) NewTransactionAt(readTs uint64, update bool) *Txn {
 	return txn
 }
 
-// NewWriteBatchAt is similar to NewWriteBatch but it allows user to set the commit timestamp.
+// NewWriteBatchAt is similar to NewWriteBatch but it allows user to set the read and commit
+// timestamp for all transactions in WriteBatch.
 // NewWriteBatchAt is supposed to be used only in the managed mode.
-func (db *DB) NewWriteBatchAt(commitTs uint64) *WriteBatch {
+func (db *DB) NewWriteBatchAt(readTs, commitTs uint64) *WriteBatch {
 	if !db.opt.managedTxns {
 		panic("cannot use NewWriteBatchAt with managedDB=false. Use NewWriteBatch instead")
 	}
 
 	wb := db.newWriteBatch()
 	wb.commitTs = commitTs
+	wb.readTs = readTs
 	wb.txn.commitTs = commitTs
+	wb.txn.readTs = readTs
 	return wb
 }
 

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -582,7 +582,7 @@ func TestWriteBatchManagedMode(t *testing.T) {
 	opt.managedTxns = true
 	opt.MaxTableSize = 1 << 15 // This would create multiple transactions in write batch.
 	runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
-		wb := db.NewWriteBatchAt(1)
+		wb := db.NewWriteBatchAt(math.MaxUint64, 1)
 		defer wb.Cancel()
 
 		N, M := 50000, 1000


### PR DESCRIPTION
WriteBatch can be used in managed and non managed mode. In managed
mode, commitTs for all transactions in WriteBatch is passed via
NewWriteBatchAt method. readTs for transactions is currently 0.
readTs for transactions is set explicitly(as done in NewTransactionAt)
in managed mode.
This PR allows, setting readTs for transactions in WB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1033)
<!-- Reviewable:end -->
