### PR TITLE
Handle nil memtable gracefully on Close

### DIFF
--- a/db.go
+++ b/db.go
@@ -492,6 +492,10 @@ func (db *DB) getMemTables() ([]*skl.Skiplist, func()) {
 
 	tables := make([]*skl.Skiplist, len(db.imm)+1)
 
+	if db.mt == nil {
+		return nil, nil
+	}
+
 	// Get mutable memtable.
 	tables[0] = db.mt
 	tables[0].IncrRef()
@@ -527,6 +531,9 @@ func (db *DB) getMemTables() ([]*skl.Skiplist, func()) {
 // to ensure that we pick the highest version of the movekey present.
 func (db *DB) get(key []byte) (y.ValueStruct, error) {
 	tables, decr := db.getMemTables() // Lock should be released.
+	if len(tables) == 0 {
+		return y.ValueStruct{}, errors.New("No tables found. DB may be closed")
+	}
 	defer decr()
 
 	var maxVs *y.ValueStruct


### PR DESCRIPTION
This is related to crashes on Close. I think it's a fair expectation that if you have multiple goroutines reading/writing a call to Close (on a sigterm for example) will not cause a panic. This fixes an issue where the memtable is nil on Close. This will cause Get's to return errors and not panic


This is an example of the panic
```
goroutine 85845 [running]:
github.com/dgraph-io/badger/skl.(*Skiplist).IncrRef(...)
	skl/skl.go:86
github.com/dgraph-io/badger.(*DB).getMemTables(0xc000491c00, 0x0, 0x0, 0x0, 0x0)
	db.go:484 +0xd7
github.com/dgraph-io/badger.(*DB).get(0xc000491c00, 0xc015c7c3c0, 0x38, 0x38, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	db.go:516 +0x66
github.com/dgraph-io/badger.(*Txn).Get(0xc00dfc5500, 0xc013083da0, 0x30, 0x30, 0x24, 0x30, 0xc017628378)
	txn.go:407 +0xe7
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1034)
<!-- Reviewable:end -->
