### PR TITLE
should report error if fails to read the body after read header

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -366,9 +366,6 @@ func ReplayManifestFile(fp *os.File) (ret Manifest, truncOffset int64, err error
 		length := y.BytesToU32(lenCrcBuf[0:4])
 		var buf = make([]byte, length)
 		if _, err := io.ReadFull(&r, buf); err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				break
-			}
 			return Manifest{}, 0, err
 		}
 		if crc32.Checksum(buf, y.CastagnoliCrcTable) != y.BytesToU32(lenCrcBuf[4:8]) {


### PR DESCRIPTION
After reading the `lenCrcBuf` header part, should report error if fails to read the body part of `length` bytes, instead of just ignoring imcomplete data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1036)
<!-- Reviewable:end -->
