### PR TITLE
Remove unnecessary param from vlog.open in tests

### DIFF
--- a/value_test.go
+++ b/value_test.go
@@ -406,7 +406,7 @@ func TestValueGC4(t *testing.T) {
 	err = kv.vlog.Close()
 	require.NoError(t, err)
 
-	err = kv.vlog.open(kv, valuePointer{Fid: 2}, kv.replayFunction(), true)
+	err = kv.vlog.open(kv, valuePointer{Fid: 2}, kv.replayFunction())
 	require.NoError(t, err)
 
 	for i := 0; i < 8; i++ {
@@ -629,7 +629,7 @@ func TestPartialAppendToValueLog(t *testing.T) {
 	// Replay value log from beginning, badger head is past k2.
 	require.NoError(t, kv.vlog.Close())
 	require.NoError(t,
-		kv.vlog.open(kv, valuePointer{Fid: 0}, kv.replayFunction(), true))
+		kv.vlog.open(kv, valuePointer{Fid: 0}, kv.replayFunction()))
 	require.NoError(t, kv.Close())
 }
 


### PR DESCRIPTION
The vlog.open had an unnecessary param. This PR removes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1043)
<!-- Reviewable:end -->
