### PR TITLE
Acquire lock before unmapping vlog files

### DIFF
--- a/value.go
+++ b/value.go
@@ -150,7 +150,7 @@ func (lf *logFile) doneWriting(offset uint32) error {
 
 	// Unmap file before we truncate it. Windows cannot truncate a file that is mmapped.
 	if err := lf.munmap(); err != nil {
-		return errors.Wrapf(err, "failed to mumap vlog file %s", lf.fd.Name())
+		return errors.Wrapf(err, "failed to munmap vlog file %s", lf.fd.Name())
 	}
 
 	// TODO: Confirm if we need to run a file sync after truncation.

--- a/value.go
+++ b/value.go
@@ -141,6 +141,13 @@ func (lf *logFile) doneWriting(offset uint32) error {
 		return errors.Wrapf(err, "Unable to sync value log: %q", lf.path)
 	}
 
+	// Before we were acquiring a lock here on lf.lock, because we were invalidating the file
+	// descriptor due to reopening it as read-only. Now, we don't invalidate the fd, but unmap it,
+	// truncate it and remap it. That creates a window where we have segfaults because the mmap is
+	// no longer valid, while someone might be reading it. Therefore, we need a lock here again.
+	lf.lock.Lock()
+	defer lf.lock.Unlock()
+
 	// Unmap file before we truncate it. Windows cannot truncate a file that is mmapped.
 	if err := lf.munmap(); err != nil {
 		return errors.Wrapf(err, "failed to mumap vlog file %s", lf.fd.Name())


### PR DESCRIPTION
When we truncate the vlog file, we unmap and remap it. This leaves a
window for segfault. This PR reintroduces the lock that got removed in
commit https://github.com/dgraph-io/badger/commit/afa8faea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1050)
<!-- Reviewable:end -->
