### PR TITLE
Set datakey for first table in stream writer

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -216,7 +216,7 @@ type sortedWriter struct {
 func (sw *StreamWriter) newWriter(streamID uint32) (*sortedWriter, error) {
 	dk, err := sw.db.registry.latestDataKey()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create new writer")
+		return nil, err
 	}
 
 	bopts := table.Options{

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -292,7 +292,6 @@ func TestStreamWriter5(t *testing.T) {
 // if those are going to same table.
 func TestStreamWriter6(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
-		fmt.Println(db.opt.Dir)
 		list := &pb.KVList{}
 		str := []string{"a", "a", "b", "b", "c", "c"}
 		ver := 1


### PR DESCRIPTION
If encryption is enabled on a DB and stream writer is used then the
first file SST would not be encrypted, only the SSTs after the first one
would be encrypted. This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1054)
<!-- Reviewable:end -->
