### PR TITLE
Reduce file permissions in y.go

### DIFF
--- a/y/y.go
+++ b/y/y.go
@@ -75,7 +75,7 @@ func CreateSyncedFile(filename string, sync bool) (*os.File, error) {
 	if sync {
 		flags |= datasyncFileFlag
 	}
-	return os.OpenFile(filename, flags, 0666)
+	return os.OpenFile(filename, flags, 0600)
 }
 
 // OpenSyncedFile creates the file if one doesn't exist.
@@ -84,7 +84,7 @@ func OpenSyncedFile(filename string, sync bool) (*os.File, error) {
 	if sync {
 		flags |= datasyncFileFlag
 	}
-	return os.OpenFile(filename, flags, 0666)
+	return os.OpenFile(filename, flags, 0600)
 }
 
 // OpenTruncFile opens the file with O_RDWR | O_CREATE | O_TRUNC
@@ -93,7 +93,7 @@ func OpenTruncFile(filename string, sync bool) (*os.File, error) {
 	if sync {
 		flags |= datasyncFileFlag
 	}
-	return os.OpenFile(filename, flags, 0666)
+	return os.OpenFile(filename, flags, 0600)
 }
 
 // SafeCopy does append(a[:0], src...).


### PR DESCRIPTION
one of the issues listed in
https://deepsource.io/gh/jaipradeesh/badger/issues/ is excessive
permissions. The functions in y.go are opening files with 0666
permissions. This PR changes them to 0600 for improved security.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1056)
<!-- Reviewable:end -->
