### PR TITLE
Change zstd compression algorithm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/valyala/gozstd v1.6.2 // indirect
+	github.com/valyala/gozstd v1.6.2
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/dgraph-io/badger
 go 1.12
 
 require (
-	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
 	github.com/cespare/xxhash/v2 v2.1.0 // indirect
 	github.com/dgraph-io/ristretto v0.0.0-20190916120426-cd2835491e0e
@@ -16,6 +15,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
+	github.com/valyala/gozstd v1.6.2 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
-github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/VictoriaMetrics/fastcache v1.5.1/go.mod h1:+jv9Ckb+za/P1ZRg/sulP5Ni1v49daAVERr0H3CuscE=
@@ -64,6 +62,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/valyala/gozstd v1.6.2 h1:MgBfNm0I8IKm51LUTTKfO9vi4BtmoH7kBXeUvgaiZVU=
+github.com/valyala/gozstd v1.6.2/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/table/builder.go
+++ b/table/builder.go
@@ -22,11 +22,11 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/DataDog/zstd"
 	"github.com/dgryski/go-farm"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
+	"github.com/valyala/gozstd"
 
 	"github.com/dgraph-io/badger/options"
 	"github.com/dgraph-io/badger/pb"
@@ -347,7 +347,7 @@ func (b *Builder) compressData(data []byte) ([]byte, error) {
 	case options.Snappy:
 		return snappy.Encode(nil, data), nil
 	case options.ZSTD:
-		return zstd.Compress(nil, data)
+		return gozstd.Compress(nil, data)
 	}
 	return nil, errors.New("Unsupported compression type")
 }

--- a/table/builder.go
+++ b/table/builder.go
@@ -347,7 +347,7 @@ func (b *Builder) compressData(data []byte) ([]byte, error) {
 	case options.Snappy:
 		return snappy.Encode(nil, data), nil
 	case options.ZSTD:
-		return gozstd.Compress(nil, data)
+		return gozstd.Compress(nil, data), nil
 	}
 	return nil, errors.New("Unsupported compression type")
 }

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -125,7 +125,7 @@ func BenchmarkBuilder(b *testing.B) {
 
 	keysCount := 1300000 // This number of entries consumes ~64MB of memory.
 	for i := 0; i < b.N; i++ {
-		opts := Options{BlockSize: 4 * 1024, BloomFalsePositive: 0.01}
+		opts := Options{Compression: options.ZSTD, BlockSize: 4 * 1024, BloomFalsePositive: 0.01}
 		builder := NewTableBuilder(opts)
 
 		for i := 0; i < keysCount; i++ {

--- a/table/table.go
+++ b/table/table.go
@@ -28,10 +28,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/DataDog/zstd"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
+	"github.com/valyala/gozstd"
 
 	"github.com/dgraph-io/badger/options"
 	"github.com/dgraph-io/badger/pb"
@@ -512,7 +512,7 @@ func (t *Table) decompressData(data []byte) ([]byte, error) {
 	case options.Snappy:
 		return snappy.Decode(nil, data)
 	case options.ZSTD:
-		return zstd.Decompress(nil, data)
+		return gozstd.Decompress(nil, data)
 	}
 	return nil, errors.New("Unsupported compression type")
 }


### PR DESCRIPTION
Currently, we use https://github.com/DataDog/zstd implementation for ZSTD compression and https://github.com/valyala/gozstd seems to be faster than https://github.com/DataDog/zstd . This PR 
proposes use of `valyala/gozstd` instead of `DataDog/zstd`.

```
benchstat zstd.txt gozstd.txt 
name                       old time/op  new time/op  delta
Compression/compress-16     213ms ± 6%   116ms ± 3%  -45.79%  (p=0.000 n=9+10)
Compression/decompress-16  48.5ms ± 3%  45.0ms ± 1%   -7.30%  (p=0.000 n=10+10)
```

The following script was used for benchmarking
```go
var a []byte
func BenchmarkCompression(b *testing.B) {
	opts := Options{BlockSize: 4 * 1024, BloomFalsePositive: 0.01}
	count := uint64(1e6)
	builder := NewTableBuilder(opts)
	// Approx 64 MB table size
	for i := uint64(0); i < count*2; i++ {
		k := fmt.Sprintf("%016x", i)
		v := fmt.Sprintf("%016d", i)
		builder.Add([]byte(k), y.ValueStruct{Value: []byte(v)})
	}
	// Build a dummy table so that we can use the same buffer for benchmarks
	buf := builder.Finish()

	var x []byte
	var err error
	// Used for decompression benchmarks
	// cbuf, err := zstd.Compress(nil, buf) 	// Use this buffer for zstd.
	// require.NoError(b, err)
	cbuf1 := gozstd.Compress(nil, buf)

	fmt.Println("len of buf", humanize.Bytes(uint64(len(buf))))
	b.ResetTimer()
	b.Run("compress", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			x = gozstd.Compress(nil, buf) // change this for zstd.
		}
		a = x
	})
	b.Run("decompress", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			x, err = gozstd.Decompress(nil, cbuf1) // change this for zstd.
			if err != nil {
				panic(err)
			}
		}
		a = x
	})
}
```

The following is the benchmark of time taken to build a table in badger (https://github.com/dgraph-io/badger/blob/f50343ff404d8198df6dc83755ec2eab863d5ff2/table/builder_test.go#L116)
```
benchstat master-builder.txt new-builder.txt                       
name        old time/op  new time/op  delta
Builder-16   1.02s ± 1%   0.73s ± 2%  -27.77%  (p=0.000 n=9+10)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1069)
<!-- Reviewable:end -->
