### PR TITLE
Change badger version in manifest version FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,7 +862,7 @@ you're trying to open in a newer version of badger. The underlying data format c
 badger versions and users will have to migrate their data directory.
 Badger data can be migrated from version X of badger to version Y of badger by following the steps
 listed below.
-Assume you were on badger v1.6.0 and you wish to migrate to v2.0.0 version
+Assume you were on badger v1.6.0 and you wish to migrate to v2.0.0 version.
 1. Install badger version v1.6.0
     - `cd $GOPATH/src/github.com/dgraph-io/badger`
     - `git checkout v1.6.0`

--- a/README.md
+++ b/README.md
@@ -862,10 +862,10 @@ you're trying to open in a newer version of badger. The underlying data format c
 badger versions and users will have to migrate their data directory.
 Badger data can be migrated from version X of badger to version Y of badger by following the steps
 listed below.
-Assume you were on badger v1.5.5 and you wish to migrate to v2.0.0 version
-1. Install badger version v1.5.5.
+Assume you were on badger v1.6.0 and you wish to migrate to v2.0.0 version
+1. Install badger version v1.6.0
     - `cd $GOPATH/src/github.com/dgraph-io/badger`
-    - `git checkout v1.5.5`
+    - `git checkout v1.6.0`
     - `cd badger && go install`
 
       This should install the old badger binary in your $GOBIN.


### PR DESCRIPTION
The badger version mentioned in manifest version mismatch FAQ has an unsupported backup format. This commit changes the badger version in the FAQ from `v1.5.5` to `v1.6.0`. `v1.6.0` has the new backup format.

The backup format was changed in https://github.com/dgraph-io/badger/commit/4e5cbcc8574b8258c0146d4d01539b6d48212f4a commit.

Fixes https://github.com/dgraph-io/badger/issues/1063

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1074)
<!-- Reviewable:end -->
