### PR TITLE
Use removeDir instead of defer os.Remove

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -35,7 +35,7 @@ import (
 func TestBackupRestore1(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	db, err := Open(getTestOptions(dir))
 	require.NoError(t, err)
 
@@ -73,7 +73,7 @@ func TestBackupRestore1(t *testing.T) {
 	// Use different directory.
 	dir, err = ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	bak, err := ioutil.TempFile(dir, "badgerbak")
 	require.NoError(t, err)
 	_, err = db.Backup(bak, 0)
@@ -119,9 +119,7 @@ func TestBackupRestore2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		os.RemoveAll(tmpdir)
-	}()
+	defer removeDir(tmpdir)
 
 	s1Path := filepath.Join(tmpdir, "test1")
 	s2Path := filepath.Join(tmpdir, "test2")
@@ -284,7 +282,7 @@ func TestBackup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpdir)
+	defer removeDir(tmpdir)
 
 	db1, err := Open(DefaultOptions(filepath.Join(tmpdir, "backup0")))
 	if err != nil {
@@ -329,7 +327,7 @@ func TestBackupRestore3(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpdir)
+	defer removeDir(tmpdir)
 
 	N := 1000
 	entries := createEntries(N)
@@ -387,7 +385,7 @@ func TestBackupLoadIncremental(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpdir)
+	defer removeDir(tmpdir)
 
 	N := 100
 	entries := createEntries(N)

--- a/db2_test.go
+++ b/db2_test.go
@@ -49,7 +49,7 @@ func TestTruncateVlogWithClose(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
 	opt.SyncWrites = true
@@ -366,7 +366,7 @@ func TestDiscardMapTooBig(t *testing.T) {
 	}
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	db, err := Open(DefaultOptions(dir))
 	require.NoError(t, err, "error while openning db")
@@ -442,7 +442,7 @@ func TestBigValues(t *testing.T) {
 func TestCompactionFilePicking(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	db, err := Open(DefaultOptions(dir).WithTableLoadingMode(options.LoadToRAM))
 	require.NoError(t, err, "error while opening db")
@@ -538,11 +538,6 @@ func createTableWithRange(t *testing.T, db *DB, start, end int) *table.Table {
 	tab, err := table.OpenTable(fd, bopts)
 	require.NoError(t, err)
 	return tab
-}
-func deferRemoveDir(t *testing.T, dir string) func() {
-	return func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}
 }
 
 func TestReadSameVlog(t *testing.T) {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -236,7 +236,7 @@ func TestIteratePrefix(t *testing.T) {
 func BenchmarkIteratePrefixSingleKey(b *testing.B) {
 	dir, err := ioutil.TempDir(".", "badger-test")
 	y.Check(err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.TableLoadingMode = options.LoadToRAM
 	db, err := Open(opts)

--- a/key_registry_test.go
+++ b/key_registry_test.go
@@ -18,7 +18,6 @@ package badger
 import (
 	"io/ioutil"
 	"math/rand"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,9 +34,7 @@ func TestBuildRegistry(t *testing.T) {
 	encryptionKey := make([]byte, 32)
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	_, err = rand.Read(encryptionKey)
 	require.NoError(t, err)
 	opt := getRegistryTestOptions(dir, encryptionKey)
@@ -66,9 +63,7 @@ func TestRewriteRegistry(t *testing.T) {
 	encryptionKey := make([]byte, 32)
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	_, err = rand.Read(encryptionKey)
 	require.NoError(t, err)
 	opt := getRegistryTestOptions(dir, encryptionKey)
@@ -94,9 +89,7 @@ func TestMismatch(t *testing.T) {
 	encryptionKey := make([]byte, 32)
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	_, err = rand.Read(encryptionKey)
 	require.NoError(t, err)
 	opt := getRegistryTestOptions(dir, encryptionKey)
@@ -121,9 +114,7 @@ func TestEncryptionAndDecryption(t *testing.T) {
 	encryptionKey := make([]byte, 32)
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	_, err = rand.Read(encryptionKey)
 	require.NoError(t, err)
 	opt := getRegistryTestOptions(dir, encryptionKey)

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"math"
 	"math/rand"
-	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -59,9 +58,7 @@ func numKeysManaged(db *DB, readTs uint64) int {
 func TestDropAllManaged(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.managedTxns = true
 	opts.ValueLogFileSize = 5 << 20
@@ -106,9 +103,7 @@ func TestDropAllManaged(t *testing.T) {
 func TestDropAll(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -144,9 +139,7 @@ func TestDropAll(t *testing.T) {
 func TestDropAllTwice(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -177,9 +170,7 @@ func TestDropAllTwice(t *testing.T) {
 func TestDropAllWithPendingTxn(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -250,9 +241,7 @@ func TestDropAllWithPendingTxn(t *testing.T) {
 func TestDropReadOnly(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -284,9 +273,7 @@ func TestDropReadOnly(t *testing.T) {
 func TestWriteAfterClose(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -312,9 +299,7 @@ func TestWriteAfterClose(t *testing.T) {
 func TestDropAllRace(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.managedTxns = true
 	db, err := Open(opts)
@@ -378,9 +363,7 @@ func TestDropAllRace(t *testing.T) {
 func TestDropPrefix(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -431,9 +414,7 @@ func TestDropPrefix(t *testing.T) {
 func TestDropPrefixWithPendingTxn(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -505,9 +486,7 @@ func TestDropPrefixWithPendingTxn(t *testing.T) {
 func TestDropPrefixReadOnly(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
 	db, err := Open(opts)
@@ -539,9 +518,7 @@ func TestDropPrefixReadOnly(t *testing.T) {
 func TestDropPrefixRace(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.managedTxns = true
 	db, err := Open(opts)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -37,7 +37,7 @@ import (
 func TestManifestBasic(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
 	{
@@ -72,7 +72,7 @@ func TestManifestBasic(t *testing.T) {
 func helpTestManifestFileCorruption(t *testing.T, off int64, errorContent string) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
 	{
@@ -165,7 +165,7 @@ func buildTable(t *testing.T, keyValues [][]string, bopts table.Options) *os.Fil
 func TestOverlappingKeyRangeError(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	kv, err := Open(DefaultOptions(dir))
 	require.NoError(t, err)
 
@@ -212,7 +212,7 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 func TestManifestRewrite(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	deletionsThreshold := 10
 	mf, m, err := helpOpenOrCreateManifestFile(dir, false, deletionsThreshold)
 	defer func() {

--- a/merge_test.go
+++ b/merge_test.go
@@ -19,7 +19,6 @@ package badger
 import (
 	"encoding/binary"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -114,7 +113,7 @@ func TestGetMergeOperator(t *testing.T) {
 	t.Run("Old keys should be removed after compaction", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "badger-test")
 		require.NoError(t, err)
-		defer os.RemoveAll(dir)
+		defer removeDir(dir)
 
 		opts := getTestOptions(dir)
 		db, err := Open(opts)

--- a/stream_test.go
+++ b/stream_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -60,7 +59,7 @@ var ctxb = context.Background()
 func TestStream(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	db, err := OpenManaged(DefaultOptions(dir))
 	require.NoError(t, err)

--- a/stream_test.go
+++ b/stream_test.go
@@ -157,4 +157,5 @@ func TestStream(t *testing.T) {
 	for pred, count := range m {
 		require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
 	}
+	require.NoError(t, db.Close())
 }

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -92,7 +92,7 @@ func TestTableIndex(t *testing.T) {
 				require.Equal(t, ko.Key, blockFirstKeys[i])
 			}
 			f.Close()
-			os.RemoveAll(filename)
+			require.NoError(t, os.RemoveAll(filename))
 		}
 	})
 }

--- a/txn_test.go
+++ b/txn_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -710,7 +709,7 @@ func TestIteratorAllVersionsWithDeleted2(t *testing.T) {
 func TestManagedDB(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
 	opt.managedTxns = true
@@ -801,7 +800,7 @@ func TestArmV7Issue311Fix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	db, err := Open(DefaultOptions(dir).
 		WithTableLoadingMode(options.MemoryMap).

--- a/value_test.go
+++ b/value_test.go
@@ -38,7 +38,7 @@ import (
 func TestValueBasic(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	y.Check(err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	kv, _ := Open(getTestOptions(dir))
 	defer kv.Close()
@@ -99,7 +99,7 @@ func TestValueBasic(t *testing.T) {
 func TestValueGCManaged(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	N := 10000
 	opt := getTestOptions(dir)
@@ -158,7 +158,7 @@ func TestValueGCManaged(t *testing.T) {
 func TestValueGC(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	opt := getTestOptions(dir)
 	opt.ValueLogFileSize = 1 << 20
 
@@ -211,7 +211,7 @@ func TestValueGC(t *testing.T) {
 func TestValueGC2(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	opt := getTestOptions(dir)
 	opt.ValueLogFileSize = 1 << 20
 
@@ -287,7 +287,7 @@ func TestValueGC2(t *testing.T) {
 func TestValueGC3(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	opt := getTestOptions(dir)
 	opt.ValueLogFileSize = 1 << 20
 
@@ -362,7 +362,7 @@ func TestValueGC3(t *testing.T) {
 func TestValueGC4(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	opt := getTestOptions(dir)
 	opt.ValueLogFileSize = 1 << 20
 	opt.Truncate = true
@@ -438,7 +438,7 @@ func TestValueGC4(t *testing.T) {
 func TestPersistLFDiscardStats(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	opt := getTestOptions(dir)
 	opt.ValueLogFileSize = 1 << 20
 	opt.Truncate = true
@@ -492,7 +492,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 func TestChecksums(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	// Set up SST with K1=V1
 	opts := getTestOptions(dir)
@@ -575,7 +575,7 @@ func TestChecksums(t *testing.T) {
 func TestPartialAppendToValueLog(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	// Create skeleton files.
 	opts := getTestOptions(dir)
@@ -641,7 +641,7 @@ func TestPartialAppendToValueLog(t *testing.T) {
 func TestReadOnlyOpenWithPartialAppendToValueLog(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	// Create skeleton files.
 	opts := getTestOptions(dir)
@@ -680,7 +680,7 @@ func TestValueLogTrigger(t *testing.T) {
 	t.Skip("Difficult to trigger compaction, so skipping. Re-enable after fixing #226")
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
 	opt.ValueLogFileSize = 1 << 20
@@ -716,7 +716,7 @@ func TestValueLogTrigger(t *testing.T) {
 func createVlog(t *testing.T, entries []*Entry) []byte {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 100 * 1024 * 1024 // 100Mb
@@ -740,7 +740,7 @@ func createVlog(t *testing.T, entries []*Entry) []byte {
 func TestPenultimateLogCorruption(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 	opt := getTestOptions(dir)
 	opt.ValueLogLoadingMode = options.FileIO
 	// Each txn generates at least two entries. 3 txns will fit each file.
@@ -849,7 +849,7 @@ func (th *testHelper) readRange(from, to int) {
 func TestBug578(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	y.Check(err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	db, err := Open(DefaultOptions(dir).
 		WithValueLogMaxEntries(64).
@@ -889,7 +889,7 @@ func BenchmarkReadWrite(b *testing.B) {
 			b.Run(fmt.Sprintf("%3.1f,%04d", rw, vsz), func(b *testing.B) {
 				dir, err := ioutil.TempDir("", "vlog-benchmark")
 				y.Check(err)
-				defer os.RemoveAll(dir)
+				defer removeDir(dir)
 
 				db, err := Open(getTestOptions(dir))
 				y.Check(err)
@@ -945,7 +945,7 @@ func BenchmarkReadWrite(b *testing.B) {
 func TestValueLogTruncate(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer removeDir(dir)
 
 	db, err := Open(DefaultOptions(dir).WithTruncate(true))
 	require.NoError(t, err)
@@ -1140,7 +1140,7 @@ func TestBlockedDiscardStatsOnClose(t *testing.T) {
 func TestValueEntryCorruption(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
-	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
 	opt.VerifyValueChecksum = true


### PR DESCRIPTION
This commit adds `removeDir` function that removes dir and handles
returned error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1085)
<!-- Reviewable:end -->
