### PR TITLE
Fix flaky TestTableChecksum test

### DIFF
--- a/table/table_test.go
+++ b/table/table_test.go
@@ -720,7 +720,7 @@ func TestTableBigValues(t *testing.T) {
 func TestTableChecksum(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 	// we are going to write random byte at random location in table file.
-	rb := make([]byte, 1)
+	rb := make([]byte, 100)
 	rand.Read(rb)
 	opts := getTestTableOptions()
 	f := buildTestTable(t, "k", 10000, opts)
@@ -732,6 +732,7 @@ func TestTableChecksum(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatal("Test should have been failed with checksum mismatch error")
 	}
+	require.NoError(t, os.Remove(f.Name()))
 }
 
 func BenchmarkRead(b *testing.B) {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -732,7 +732,6 @@ func TestTableChecksum(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatal("Test should have been failed with checksum mismatch error")
 	}
-	require.NoError(t, os.Remove(f.Name()))
 }
 
 func BenchmarkRead(b *testing.B) {


### PR DESCRIPTION
The `TestTableChecksum` test fails at times because we were replacing only a single byte and it is possible that the new byte is equal to the old one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1086)
<!-- Reviewable:end -->
