### PR TITLE
Fix race condition on db.orc.nextTxnTs

### DIFF
--- a/db.go
+++ b/db.go
@@ -121,10 +121,11 @@ func (db *DB) replayFunction() func(Entry, valuePointer) error {
 			db.elog.Printf("First key=%q\n", e.Key)
 		}
 		first = false
-
+		db.orc.Lock()
 		if db.orc.nextTxnTs < y.ParseTs(e.Key) {
 			db.orc.nextTxnTs = y.ParseTs(e.Key)
 		}
+		db.orc.Unlock()
 
 		nk := make([]byte, len(e.Key))
 		copy(nk, e.Key)

--- a/db2_test.go
+++ b/db2_test.go
@@ -597,8 +597,8 @@ func TestL0GCBug(t *testing.T) {
 
 	// Do not change any of the options below unless it's necessary.
 	opts := getTestOptions(dir)
-	opts.MaxTableSize = 1920
-	opts.NumMemtables = 1
+	opts.NumLevelZeroTables = 50
+	opts.NumLevelZeroTablesStall = 51
 	opts.ValueLogMaxEntries = 2
 	opts.ValueThreshold = 2
 	opts.KeepL0InMemory = true


### PR DESCRIPTION
This PR acquires a lock before updating the `db.orc.nextTxnTs` value which prevents the race condition.
See https://github.com/dgraph-io/badger/issues/1100 for details of race condition.

Fixes https://github.com/dgraph-io/badger/issues/1100.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1101)
<!-- Reviewable:end -->
