### PR TITLE
Use max compression level in ZSTD

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -346,7 +346,7 @@ func (b *Builder) compressData(data []byte) ([]byte, error) {
 	case options.Snappy:
 		return snappy.Encode(nil, data), nil
 	case options.ZSTD:
-		return y.ZSTDCompress(nil, data)
+		return y.ZSTDCompress(nil, data, b.opt.ZSTDCompressionLevel)
 	}
 	return nil, errors.New("Unsupported compression type")
 }

--- a/table/table.go
+++ b/table/table.go
@@ -69,6 +69,9 @@ type Options struct {
 	Compression options.CompressionType
 
 	Cache *ristretto.Cache
+
+	// ZSTDCompressionLevel is the ZSTD compression level used for compressing blocks.
+	ZSTDCompressionLevel int
 }
 
 // TableInterface is useful for testing.

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -46,10 +46,11 @@ func key(prefix string, i int) string {
 
 func getTestTableOptions() Options {
 	return Options{
-		Compression:        options.ZSTD,
-		LoadingMode:        options.LoadToRAM,
-		BlockSize:          4 * 1024,
-		BloomFalsePositive: 0.01,
+		Compression:          options.ZSTD,
+		ZSTDCompressionLevel: 15,
+		LoadingMode:          options.LoadToRAM,
+		BlockSize:            4 * 1024,
+		BloomFalsePositive:   0.01,
 	}
 
 }

--- a/y/zstd_cgo.go
+++ b/y/zstd_cgo.go
@@ -32,5 +32,5 @@ func ZSTDDecompress(dst, src []byte) ([]byte, error) {
 
 // ZSTDCompress compresses a block using ZSTD algorithm.
 func ZSTDCompress(dst, src []byte) ([]byte, error) {
-	return zstd.Compress(dst, src)
+	return zstd.CompressLevel(dst, src, zstd.BestCompression)
 }

--- a/y/zstd_cgo.go
+++ b/y/zstd_cgo.go
@@ -31,6 +31,6 @@ func ZSTDDecompress(dst, src []byte) ([]byte, error) {
 }
 
 // ZSTDCompress compresses a block using ZSTD algorithm.
-func ZSTDCompress(dst, src []byte) ([]byte, error) {
-	return zstd.CompressLevel(dst, src, zstd.BestCompression)
+func ZSTDCompress(dst, src []byte, compressionLevel int) ([]byte, error) {
+	return zstd.CompressLevel(dst, src, compressionLevel)
 }

--- a/y/zstd_nocgo.go
+++ b/y/zstd_nocgo.go
@@ -33,6 +33,6 @@ func ZSTDDecompress(dst, src []byte) ([]byte, error) {
 }
 
 // ZSTDCompress compresses a block using ZSTD algorithm.
-func ZSTDCompress(dst, src []byte) ([]byte, error) {
+func ZSTDCompress(dst, src []byte, compressionLevel int) ([]byte, error) {
 	return nil, errZstdCgo
 }


### PR DESCRIPTION
The default level is `5`. This PR sets the compression level to 15 which gives the best speed vs compression ratio trade-off.

| Level | Compression Ratio | Time Taken (Data Dog) (in n/s) |
|:-----:|:-----------------:|-------------------------------|
| 1     | 2.932754881       | 21152                         |
| 2     | 2.753564155       | 21752                         |
| 3     | 2.729475101       | 24112                         |
| 4     | 2.816666667       | 38338                         |
| 5     | 2.897142857       | 46792                         |
| 6     | 2.954115076       | 69259                         |
| 7     | 2.954115076       | 94859                         |
| 8     | 2.954115076       | 122494                        |
| 9     | 2.954115076       | 76904                         |
| 10    | 2.954115076       | 75655                         |
| 11    | 2.870488323       | 178359                        |
| 12    | 3.09382151        | 418902                        |
| 13    | 4.384864865       | 244562                        |
| 14    | 4.384864865       | 242424                        |
| 15    | 4.384864865       | 239042                        |
| 16    | 4.38961039        | 471493                        |
| 17    | 4.38961039        | 470330                        |
| 18    | 4.38961039        | 472117                        |
| 19    | 4.38961039        | 471703                        |
| 20    | 4.38961039        | 474596                        |

![Compression Ratio and Time Taken (Data Dog) (in n_s)](https://user-images.githubusercontent.com/12949454/68406202-67bfa300-01a7-11ea-8d1b-193a456602b5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1111)
<!-- Reviewable:end -->
