### PR TITLE
Introduce disk-less mode in badger

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -26,16 +26,12 @@ import (
 	"github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/badger/v2/y"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // Backup is a wrapper function over Stream.Backup to generate full and incremental backups of the
 // DB. For more control over how many goroutines are used to generate the backup, or if you wish to
 // backup only a certain range of keys, use Stream.Backup directly.
 func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
-	if db.opt.DiskLess {
-		return 0, errors.New("Backup cannot be used when DB is opened in diskless mode")
-	}
 	stream := db.NewStream()
 	stream.LogPrefix = "DB.Backup"
 	return stream.Backup(w, since)

--- a/backup.go
+++ b/backup.go
@@ -26,12 +26,16 @@ import (
 	"github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/badger/v2/y"
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 // Backup is a wrapper function over Stream.Backup to generate full and incremental backups of the
 // DB. For more control over how many goroutines are used to generate the backup, or if you wish to
 // backup only a certain range of keys, use Stream.Backup directly.
 func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
+	if db.opt.DiskLess {
+		return 0, errors.New("Backup cannot be used when DB is opened in diskless mode")
+	}
 	stream := db.NewStream()
 	stream.LogPrefix = "DB.Backup"
 	return stream.Backup(w, since)

--- a/backup_test.go
+++ b/backup_test.go
@@ -319,9 +319,9 @@ func TestBackup(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk less mode", func(t *testing.T) {
+	t.Run("InMemory mode", func(t *testing.T) {
 		opt := DefaultOptions("")
-		opt.DiskLess = true
+		opt.InMemory = true
 		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
 			test(t, db)
 		})

--- a/batch_test.go
+++ b/batch_test.go
@@ -71,9 +71,9 @@ func TestWriteBatch(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk less mode", func(t *testing.T) {
+	t.Run("InMemory mode", func(t *testing.T) {
 		opt := getTestOptions("")
-		opt.DiskLess = true
+		opt.InMemory = true
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)

--- a/batch_test.go
+++ b/batch_test.go
@@ -32,7 +32,7 @@ func TestWriteBatch(t *testing.T) {
 		return []byte(fmt.Sprintf("%128d", i))
 	}
 
-	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+	test := func(t *testing.T, db *DB) {
 		wb := db.NewWriteBatch()
 		defer wb.Cancel()
 
@@ -65,5 +65,18 @@ func TestWriteBatch(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
+	}
+	t.Run("disk mode", func(t *testing.T) {
+		runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+			test(t, db)
+		})
+	})
+	t.Run("disk less mode", func(t *testing.T) {
+		opt := getTestOptions("")
+		opt.DiskLess = true
+		db, err := Open(opt)
+		require.NoError(t, err)
+		test(t, db)
+		require.NoError(t, db.Close())
 	})
 }

--- a/contrib/cover.sh
+++ b/contrib/cover.sh
@@ -10,6 +10,9 @@ set -ex
 
 pushd $SRC &> /dev/null
 
+go test -v -run "Leak"
+go test -v -run "Leak" -race
+
 # create coverage output
 echo 'mode: atomic' > $OUT
 for PKG in $(go list ./...|grep -v -E 'vendor'); do
@@ -17,6 +20,7 @@ for PKG in $(go list ./...|grep -v -E 'vendor'); do
   tail -n +2 $TMP >> $OUT
 done
 
+echo "Running test with vlog_mmap false"
 # Another round of tests after turning off mmap
 go test -v -vlog_mmap=false github.com/dgraph-io/badger
 

--- a/contrib/cover.sh
+++ b/contrib/cover.sh
@@ -10,9 +10,6 @@ set -ex
 
 pushd $SRC &> /dev/null
 
-go test -v -run "Leak"
-go test -v -run "Leak" -race
-
 # create coverage output
 echo 'mode: atomic' > $OUT
 for PKG in $(go list ./...|grep -v -E 'vendor'); do

--- a/db.go
+++ b/db.go
@@ -304,7 +304,7 @@ func Open(opt Options) (db *DB, err error) {
 	}
 
 	if db.opt.DiskLess {
-		db.opt.SyncWrites = true
+		db.opt.SyncWrites = false
 		db.opt.ValueThreshold = maxValueThreshold
 	}
 	krOpt := KeyRegistryOptions{

--- a/db.go
+++ b/db.go
@@ -742,6 +742,7 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 	// Txns should not interleave among other txns or rewrites.
 	req := requestPool.Get().(*request)
 	req.Entries = entries
+	req.Ptrs = req.Ptrs[:0]
 	req.Wg = sync.WaitGroup{}
 	req.Wg.Add(1)
 	req.IncrRef()     // for db write

--- a/db.go
+++ b/db.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/binary"
 	"expvar"
-	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -1571,7 +1570,6 @@ func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList), prefixes ...[]
 	recvCh, id := db.pub.newSubscriber(c, prefixes...)
 	slurp := func(batch *pb.KVList) {
 		defer func() {
-			fmt.Println("defer called", len(batch.GetKv()))
 			if len(batch.GetKv()) > 0 {
 				cb(batch)
 			}
@@ -1600,7 +1598,6 @@ func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList), prefixes ...[]
 			// Delete the subscriber to avoid further updates.
 			return ctx.Err()
 		case batch := <-recvCh:
-			fmt.Println("slurp called")
 			slurp(batch)
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -1120,6 +1120,9 @@ func (db *DB) updateSize(lc *y.Closer) {
 // Note: Every time GC is run, it would produce a spike of activity on the LSM
 // tree.
 func (db *DB) RunValueLogGC(discardRatio float64) error {
+	if db.opt.DiskLess {
+		return errors.New("Cannot run value log GC when DB is opened in diskless mode")
+	}
 	if discardRatio >= 1.0 || discardRatio <= 0.0 {
 		return ErrInvalidRequest
 	}

--- a/db.go
+++ b/db.go
@@ -622,11 +622,11 @@ func (db *DB) updateHead(ptrs []valuePointer) {
 	db.vhead = ptr
 }
 
-var requestPool = sync.Pool{
-	New: func() interface{} {
-		return new(request)
-	},
-}
+//var requestPool = sync.Pool{
+//	New: func() interface{} {
+//		return new(request)
+//	},
+//}
 
 func (db *DB) shouldWriteValueToLSM(e Entry) bool {
 	return len(e.Value) < db.opt.ValueThreshold
@@ -734,7 +734,8 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 
 	// We can only service one request because we need each txn to be stored in a contigous section.
 	// Txns should not interleave among other txns or rewrites.
-	req := requestPool.Get().(*request)
+	//req := requestPool.Get().(*request)
+	req := new(request)
 	req.Entries = entries
 	req.Ptrs = req.Ptrs[:0]
 	req.Wg = sync.WaitGroup{}

--- a/db.go
+++ b/db.go
@@ -263,7 +263,7 @@ func Open(opt Options) (db *DB, err error) {
 		}
 	}
 
-	manifestFile, manifest, err := openOrCreateManifestFile(opt.Dir, opt.ReadOnly, opt.InMemory)
+	manifestFile, manifest, err := openOrCreateManifestFile(opt)
 	if err != nil {
 		return nil, err
 	}

--- a/db.go
+++ b/db.go
@@ -1494,9 +1494,11 @@ func (db *DB) dropAll() (func(), error) {
 	}
 	db.opt.Infof("Deleted %d SSTables. Now deleting value logs...\n", num)
 
-	num, err = db.vlog.dropAll()
-	if err != nil {
-		return resume, err
+	if !db.opt.DiskLess {
+		num, err = db.vlog.dropAll()
+		if err != nil {
+			return resume, err
+		}
 	}
 	db.vhead = valuePointer{} // Zero it out.
 	db.lc.nextFileID = 1

--- a/db.go
+++ b/db.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/binary"
 	"expvar"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -1570,6 +1571,7 @@ func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList), prefixes ...[]
 	recvCh, id := db.pub.newSubscriber(c, prefixes...)
 	slurp := func(batch *pb.KVList) {
 		defer func() {
+			fmt.Println("defer called", len(batch.GetKv()))
 			if len(batch.GetKv()) > 0 {
 				cb(batch)
 			}
@@ -1598,6 +1600,7 @@ func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList), prefixes ...[]
 			// Delete the subscriber to avoid further updates.
 			return ctx.Err()
 		case batch := <-recvCh:
+			fmt.Println("slurp called")
 			slurp(batch)
 		}
 	}

--- a/db2_test.go
+++ b/db2_test.go
@@ -395,7 +395,7 @@ func TestBigValues(t *testing.T) {
 	opts := DefaultOptions("").
 		WithValueThreshold(1 << 20).
 		WithValueLogMaxEntries(100)
-	runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
+	test := func(t *testing.T, db *DB) {
 		keyCount := 1000
 
 		data := bytes.Repeat([]byte("a"), (1 << 20)) // Valuesize 1 MB.
@@ -431,6 +431,19 @@ func TestBigValues(t *testing.T) {
 		for i := 0; i < keyCount; i++ {
 			require.NoError(t, getByKey(key(i)))
 		}
+	}
+	t.Run("disk mode", func(t *testing.T) {
+		runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
+			test(t, db)
+		})
+	})
+	t.Run("disk less mode", func(t *testing.T) {
+		opts.DiskLess = true
+		opts.Dir = ""
+		opts.ValueDir = ""
+		db, err := Open(opts)
+		require.NoError(t, err)
+		test(t, db)
 	})
 }
 

--- a/db2_test.go
+++ b/db2_test.go
@@ -444,6 +444,7 @@ func TestBigValues(t *testing.T) {
 		db, err := Open(opts)
 		require.NoError(t, err)
 		test(t, db)
+		require.NoError(t, db.Close())
 	})
 }
 

--- a/db2_test.go
+++ b/db2_test.go
@@ -437,8 +437,8 @@ func TestBigValues(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk less mode", func(t *testing.T) {
-		opts.DiskLess = true
+	t.Run("InMemory mode", func(t *testing.T) {
+		opts.InMemory = true
 		opts.Dir = ""
 		opts.ValueDir = ""
 		db, err := Open(opts)

--- a/db_test.go
+++ b/db_test.go
@@ -32,6 +32,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1633,31 +1634,33 @@ func TestGoroutineLeak(t *testing.T) {
 		t.Logf("Num go: %d", before)
 		for i := 0; i < 12; i++ {
 			runBadgerTest(t, opt, func(t *testing.T, db *DB) {
-				updated := false
-				//ctx, cancel := context.WithCancel(context.Background())
-				//var wg sync.WaitGroup
-				//wg.Add(1)
-				//var subWg sync.WaitGroup
-				//subWg.Add(1)
-				//go func() {
-				//	subWg.Done()
-				//	err := db.Subscribe(ctx, func(kvs *pb.KVList) {
-				//		require.Equal(t, []byte("value"), kvs.Kv[0].GetValue())
-				//		updated = true
-				//		wg.Done()
-				//	}, []byte("key"))
-				//	if err != nil {
-				//		require.Equal(t, err.Error(), context.Canceled.Error())
-				//	}
-				//}()
-				//subWg.Wait()
-				//err := db.Update(func(txn *Txn) error {
-				//	return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
-				//})
-				//require.NoError(t, err)
-				//wg.Wait()
-				//cancel()
-				require.Equal(t, false, updated)
+				var done uint32
+				ctx, cancel := context.WithCancel(context.Background())
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					err := db.Subscribe(ctx, func(kvs *pb.KVList) {
+						require.Equal(t, []byte("value"), kvs.Kv[0].GetValue())
+						atomic.StoreUint32(&done, 1)
+						//atomic.StoreUint32(&done, 1)
+					}, []byte("key"))
+					if err != nil {
+						require.Equal(t, err.Error(), context.Canceled.Error())
+					}
+				}()
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for atomic.LoadUint32(&done) != 1 {
+						err := db.Update(func(txn *Txn) error {
+							return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
+						})
+						require.NoError(t, err)
+					}
+					cancel()
+				}()
+				wg.Wait()
 			})
 		}
 		time.Sleep(2 * time.Second)

--- a/db_test.go
+++ b/db_test.go
@@ -1220,6 +1220,7 @@ var benchmarkData = []struct {
 }
 
 func TestLargeKeys(t *testing.T) {
+	t.Skip()
 	test := func(t *testing.T, opt Options) {
 		db, err := Open(opt)
 		require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -2054,7 +2054,7 @@ func TestWriteDiskLess(t *testing.T) {
 			item, err := txn.Get([]byte(fmt.Sprintf("key%d", j)))
 			require.NoError(t, err)
 			expected := []byte(fmt.Sprintf("val%d", j))
-			return item.Value(func(val []byte) error {
+			item.Value(func(val []byte) error {
 				require.Equal(t, expected, val,
 					"Invalid value for key %q. expected: %q, actual: %q",
 					item.Key(), expected, val)

--- a/db_test.go
+++ b/db_test.go
@@ -127,7 +127,7 @@ func runBadgerTest(t *testing.T, opts *Options, test func(t *testing.T, db *DB))
 		opts.ValueDir = dir
 	}
 
-	if opts.DiskLess {
+	if opts.InMemory {
 		opts.Dir = ""
 		opts.ValueDir = ""
 	}
@@ -283,8 +283,8 @@ func TestGet(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk-less mode", func(t *testing.T) {
-		opts := DiskLessOptions()
+	t.Run("InMemory mode", func(t *testing.T) {
+		opts := DefaultOptions("").WithInmemory(true)
 		db, err := Open(opts)
 		require.NoError(t, err)
 		test(t, db)
@@ -543,8 +543,8 @@ func TestExistsMore(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk less mode", func(t *testing.T) {
-		opt := DiskLessOptions()
+	t.Run("InMemory mode", func(t *testing.T) {
+		opt := DefaultOptions("").WithInmemory(true)
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -617,8 +617,8 @@ func TestIterate2Basic(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk less mode", func(t *testing.T) {
-		opt := DiskLessOptions()
+	t.Run("InMemory mode", func(t *testing.T) {
+		opt := DefaultOptions("").WithInmemory(true)
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -1254,8 +1254,9 @@ func TestLargeKeys(t *testing.T) {
 		opt := DefaultOptions(dir).WithValueLogFileSize(1024 * 1024 * 1024)
 		test(t, opt)
 	})
-	t.Run("disk less mode", func(t *testing.T) {
-		opt := DiskLessOptions().WithValueLogFileSize(1024 * 1024 * 1024)
+	t.Run("InMemory mode", func(t *testing.T) {
+		opt := DefaultOptions("").WithValueLogFileSize(1024 * 1024 * 1024)
+		opt.InMemory = true
 		test(t, opt)
 	})
 }
@@ -1665,8 +1666,8 @@ func TestGoroutineLeak(t *testing.T) {
 	t.Run("disk mode", func(t *testing.T) {
 		test(t, nil)
 	})
-	t.Run("disk less mode", func(t *testing.T) {
-		opt := DiskLessOptions()
+	t.Run("InMemory mode", func(t *testing.T) {
+		opt := DefaultOptions("").WithInmemory(true)
 		test(t, &opt)
 	})
 }
@@ -2036,8 +2037,8 @@ func removeDir(dir string) func() {
 	}
 }
 
-func TestWriteDiskLess(t *testing.T) {
-	opt := DiskLessOptions()
+func TestWriteInemory(t *testing.T) {
+	opt := DefaultOptions("").WithInmemory(true)
 	db, err := Open(opt)
 	require.NoError(t, err)
 	defer func() {

--- a/db_test.go
+++ b/db_test.go
@@ -284,8 +284,7 @@ func TestGet(t *testing.T) {
 		})
 	})
 	t.Run("disk-less mode", func(t *testing.T) {
-		opts := DefaultOptions("")
-		opts.DiskLess = true
+		opts := DiskLessOptions()
 		db, err := Open(opts)
 		require.NoError(t, err)
 		test(t, db)
@@ -545,8 +544,7 @@ func TestExistsMore(t *testing.T) {
 		})
 	})
 	t.Run("disk less mode", func(t *testing.T) {
-		opt := getTestOptions("")
-		opt.DiskLess = true
+		opt := DiskLessOptions()
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -620,8 +618,7 @@ func TestIterate2Basic(t *testing.T) {
 		})
 	})
 	t.Run("disk less mode", func(t *testing.T) {
-		opt := getTestOptions("")
-		opt.DiskLess = true
+		opt := DiskLessOptions()
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -1258,8 +1255,7 @@ func TestLargeKeys(t *testing.T) {
 		test(t, opt)
 	})
 	t.Run("disk less mode", func(t *testing.T) {
-		opt := DefaultOptions("").WithValueLogFileSize(1024 * 1024 * 1024)
-		opt.DiskLess = true
+		opt := DiskLessOptions().WithValueLogFileSize(1024 * 1024 * 1024)
 		test(t, opt)
 	})
 }
@@ -1670,8 +1666,7 @@ func TestGoroutineLeak(t *testing.T) {
 		test(t, nil)
 	})
 	t.Run("disk less mode", func(t *testing.T) {
-		opt := getTestOptions("")
-		opt.DiskLess = true
+		opt := DiskLessOptions()
 		test(t, &opt)
 	})
 }
@@ -2042,8 +2037,7 @@ func removeDir(dir string) func() {
 }
 
 func TestWriteDiskLess(t *testing.T) {
-	opt := DefaultOptions("")
-	opt.DiskLess = true
+	opt := DiskLessOptions()
 	db, err := Open(opt)
 	require.NoError(t, err)
 	defer func() {

--- a/db_test.go
+++ b/db_test.go
@@ -1216,11 +1216,9 @@ var benchmarkData = []struct {
 	{nil, randBytes(1000000), false},
 	{randBytes(100000), nil, false},
 	{randBytes(1000000), nil, false},
-	{randBytes(64000), randBytes(1000000), true},
 }
 
 func TestLargeKeys(t *testing.T) {
-	t.Skip()
 	test := func(t *testing.T, opt Options) {
 		db, err := Open(opt)
 		require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -1634,30 +1634,30 @@ func TestGoroutineLeak(t *testing.T) {
 		for i := 0; i < 12; i++ {
 			runBadgerTest(t, opt, func(t *testing.T, db *DB) {
 				updated := false
-				ctx, cancel := context.WithCancel(context.Background())
-				var wg sync.WaitGroup
-				wg.Add(1)
-				var subWg sync.WaitGroup
-				subWg.Add(1)
-				go func() {
-					subWg.Done()
-					err := db.Subscribe(ctx, func(kvs *pb.KVList) {
-						require.Equal(t, []byte("value"), kvs.Kv[0].GetValue())
-						updated = true
-						wg.Done()
-					}, []byte("key"))
-					if err != nil {
-						require.Equal(t, err.Error(), context.Canceled.Error())
-					}
-				}()
-				subWg.Wait()
-				err := db.Update(func(txn *Txn) error {
-					return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
-				})
-				require.NoError(t, err)
-				wg.Wait()
-				cancel()
-				require.Equal(t, true, updated)
+				//ctx, cancel := context.WithCancel(context.Background())
+				//var wg sync.WaitGroup
+				//wg.Add(1)
+				//var subWg sync.WaitGroup
+				//subWg.Add(1)
+				//go func() {
+				//	subWg.Done()
+				//	err := db.Subscribe(ctx, func(kvs *pb.KVList) {
+				//		require.Equal(t, []byte("value"), kvs.Kv[0].GetValue())
+				//		updated = true
+				//		wg.Done()
+				//	}, []byte("key"))
+				//	if err != nil {
+				//		require.Equal(t, err.Error(), context.Canceled.Error())
+				//	}
+				//}()
+				//subWg.Wait()
+				//err := db.Update(func(txn *Txn) error {
+				//	return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
+				//})
+				//require.NoError(t, err)
+				//wg.Wait()
+				//cancel()
+				require.Equal(t, false, updated)
 			})
 		}
 		time.Sleep(2 * time.Second)

--- a/db_test.go
+++ b/db_test.go
@@ -1664,40 +1664,7 @@ func TestGoroutineLeak(t *testing.T) {
 		require.Equal(t, before, runtime.NumGoroutine())
 	}
 	t.Run("disk mode", func(t *testing.T) {
-		time.Sleep(1 * time.Second)
-		before := runtime.NumGoroutine()
-		t.Logf("Num go: %d", before)
-		for i := 0; i < 12; i++ {
-			runBadgerTest(t, nil, func(t *testing.T, db *DB) {
-				updated := false
-				ctx, cancel := context.WithCancel(context.Background())
-				var wg sync.WaitGroup
-				wg.Add(1)
-				var subWg sync.WaitGroup
-				subWg.Add(1)
-				go func() {
-					subWg.Done()
-					err := db.Subscribe(ctx, func(kvs *pb.KVList) {
-						require.Equal(t, []byte("value"), kvs.Kv[0].GetValue())
-						updated = true
-						wg.Done()
-					}, []byte("key"))
-					if err != nil {
-						require.Equal(t, err.Error(), context.Canceled.Error())
-					}
-				}()
-				subWg.Wait()
-				err := db.Update(func(txn *Txn) error {
-					return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
-				})
-				require.NoError(t, err)
-				wg.Wait()
-				cancel()
-				require.Equal(t, true, updated)
-			})
-		}
-		time.Sleep(2 * time.Second)
-		require.Equal(t, before, runtime.NumGoroutine())
+		test(t, nil)
 	})
 	t.Run("disk less mode", func(t *testing.T) {
 		opt := getTestOptions("")

--- a/db_test.go
+++ b/db_test.go
@@ -2050,10 +2050,10 @@ func TestWriteDiskLess(t *testing.T) {
 		txnSet(t, db, []byte(fmt.Sprintf("key%d", i)), []byte(fmt.Sprintf("val%d", i)), 0x00)
 	}
 	err = db.View(func(txn *Txn) error {
-		for i := 0; i < 100; i++ {
-			item, err := txn.Get([]byte(fmt.Sprintf("key%d", i)))
+		for j := 0; j < 100; j++ {
+			item, err := txn.Get([]byte(fmt.Sprintf("key%d", j)))
 			require.NoError(t, err)
-			expected := []byte(fmt.Sprintf("val%d", i))
+			expected := []byte(fmt.Sprintf("val%d", j))
 			return item.Value(func(val []byte) error {
 				require.Equal(t, expected, val,
 					"Invalid value for key %q. expected: %q, actual: %q",

--- a/db_test.go
+++ b/db_test.go
@@ -1654,9 +1654,9 @@ func TestGoroutineLeak(t *testing.T) {
 				cancel()
 				require.Equal(t, true, updated)
 			})
-			time.Sleep(2 * time.Second)
-			require.Equal(t, before, runtime.NumGoroutine())
 		}
+		time.Sleep(2 * time.Second)
+		require.Equal(t, before, runtime.NumGoroutine())
 	}
 	t.Run("disk mode", func(t *testing.T) {
 		test(t, nil)

--- a/errors.go
+++ b/errors.go
@@ -122,4 +122,6 @@ var (
 
 	ErrInvalidEncryptionKey = errors.New("Encryption key's length should be" +
 		"either 16, 24, or 32 bytes")
+
+	ErrGCInMemoryMode = errors.New("Cannot run value log GC when DB is opened in InMemory mode")
 )

--- a/key_registry.go
+++ b/key_registry.go
@@ -81,6 +81,7 @@ func OpenKeyRegistry(opt KeyRegistryOptions) (*KeyRegistry, error) {
 			break
 		}
 	}
+	// If db is opened in diskless mode, we don't need to key registry on the disk.
 	if opt.DiskLess {
 		return newKeyRegistry(opt), nil
 	}
@@ -358,6 +359,7 @@ func (kr *KeyRegistry) latestDataKey() (*pb.DataKey, error) {
 		CreatedAt: time.Now().Unix(),
 		Iv:        iv,
 	}
+	// Don't store the datakey on file if badger is running in diskless mode.
 	if !kr.opt.DiskLess {
 		// Store the datekey.
 		buf := &bytes.Buffer{}

--- a/key_registry.go
+++ b/key_registry.go
@@ -81,7 +81,7 @@ func OpenKeyRegistry(opt KeyRegistryOptions) (*KeyRegistry, error) {
 			break
 		}
 	}
-	// If db is opened in InMemory mode, we don't need to key registry on the disk.
+	// If db is opened in InMemory mode, we don't need to write key registry to the disk.
 	if opt.InMemory {
 		return newKeyRegistry(opt), nil
 	}

--- a/key_registry_test.go
+++ b/key_registry_test.go
@@ -132,3 +132,25 @@ func TestEncryptionAndDecryption(t *testing.T) {
 	require.Equal(t, dk.Data, dk1.Data)
 	require.NoError(t, kr.Close())
 }
+
+func TestKeyRegistryDiskLess(t *testing.T) {
+	encryptionKey := make([]byte, 32)
+	_, err := rand.Read(encryptionKey)
+	require.NoError(t, err)
+
+	opt := getRegistryTestOptions("", encryptionKey)
+	opt.DiskLess = true
+
+	kr, err := OpenKeyRegistry(opt)
+	require.NoError(t, err)
+	_, err = kr.latestDataKey()
+	require.NoError(t, err)
+	// We're resetting the last created timestamp. So, it creates
+	// new datakey.
+	kr.lastCreated = 0
+	_, err = kr.latestDataKey()
+	// We generated two key. So, checking the length.
+	require.Equal(t, 2, len(kr.dataKeys))
+	require.NoError(t, err)
+	require.NoError(t, kr.Close())
+}

--- a/key_registry_test.go
+++ b/key_registry_test.go
@@ -133,13 +133,13 @@ func TestEncryptionAndDecryption(t *testing.T) {
 	require.NoError(t, kr.Close())
 }
 
-func TestKeyRegistryDiskLess(t *testing.T) {
+func TestKeyRegistryInMemory(t *testing.T) {
 	encryptionKey := make([]byte, 32)
 	_, err := rand.Read(encryptionKey)
 	require.NoError(t, err)
 
 	opt := getRegistryTestOptions("", encryptionKey)
-	opt.DiskLess = true
+	opt.InMemory = true
 
 	kr, err := OpenKeyRegistry(opt)
 	require.NoError(t, err)

--- a/levels.go
+++ b/levels.go
@@ -827,13 +827,10 @@ func (s *levelsController) runCompactDef(l int, cd compactDef) (err error) {
 		}
 	}()
 
-	// Skip writing to manifest file if db is opened in InMemory mode.
-	if !s.kv.opt.InMemory {
-		changeSet := buildChangeSet(&cd, newTables)
-		// We write to the manifest _before_ we delete files (and after we created files)
-		if err := s.kv.manifest.addChanges(changeSet.Changes); err != nil {
-			return err
-		}
+	changeSet := buildChangeSet(&cd, newTables)
+	// We write to the manifest _before_ we delete files (and after we created files)
+	if err := s.kv.manifest.addChanges(changeSet.Changes); err != nil {
+		return err
 	}
 
 	// See comment earlier in this function about the ordering of these ops, and the order in which

--- a/levels.go
+++ b/levels.go
@@ -242,21 +242,19 @@ func (s *levelsController) dropTree() (int, error) {
 		return 0, nil
 	}
 
-	// Skip writing changes to the manifest file if DB is opened in disk less mode.
-	if !s.kv.opt.InMemory {
-		// Generate the manifest changes.
-		changes := []*pb.ManifestChange{}
-		for _, table := range all {
-			// Add a delete change only if the table is not in memory.
-			if !table.IsInmemory {
-				changes = append(changes, newDeleteChange(table.ID()))
-			}
-		}
-		changeSet := pb.ManifestChangeSet{Changes: changes}
-		if err := s.kv.manifest.addChanges(changeSet.Changes); err != nil {
-			return 0, err
+	// Generate the manifest changes.
+	changes := []*pb.ManifestChange{}
+	for _, table := range all {
+		// Add a delete change only if the table is not in memory.
+		if !table.IsInmemory {
+			changes = append(changes, newDeleteChange(table.ID()))
 		}
 	}
+	changeSet := pb.ManifestChangeSet{Changes: changes}
+	if err := s.kv.manifest.addChanges(changeSet.Changes); err != nil {
+		return 0, err
+	}
+
 	// Now that manifest has been successfully written, we can delete the tables.
 	for _, l := range s.levels {
 		l.Lock()

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -142,6 +142,9 @@ func TestDropAllTwice(t *testing.T) {
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
+	opts.DiskLess = true
+	opts.Dir = ""
+	opts.ValueDir = ""
 	db, err := Open(opts)
 	require.NoError(t, err)
 	defer func() {
@@ -152,7 +155,7 @@ func TestDropAllTwice(t *testing.T) {
 	populate := func(db *DB) {
 		writer := db.NewWriteBatch()
 		for i := uint64(0); i < N; i++ {
-			require.NoError(t, writer.Set([]byte(key("key", int(i))), val(true)))
+			require.NoError(t, writer.Set([]byte(key("key", int(i))), val(false)))
 		}
 		require.NoError(t, writer.Flush())
 	}

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -142,7 +142,7 @@ func TestDropAllTwice(t *testing.T) {
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
 	opts.ValueLogFileSize = 5 << 20
-	opts.DiskLess = true
+	opts.InMemory = true
 	opts.Dir = ""
 	opts.ValueDir = ""
 	db, err := Open(opts)

--- a/manifest.go
+++ b/manifest.go
@@ -122,7 +122,9 @@ func (m *Manifest) clone() Manifest {
 func openOrCreateManifestFile(dir string, readOnly bool, inMemory bool) (
 	ret *manifestFile, result Manifest, err error) {
 	if inMemory {
-		return &manifestFile{}, Manifest{}, nil
+		return &manifestFile{
+			inMemory: true,
+		}, Manifest{}, nil
 	}
 	return helpOpenOrCreateManifestFile(dir, readOnly, manifestDeletionsRewriteThreshold)
 }

--- a/manifest.go
+++ b/manifest.go
@@ -122,9 +122,7 @@ func (m *Manifest) clone() Manifest {
 func openOrCreateManifestFile(dir string, readOnly bool, inMemory bool) (
 	ret *manifestFile, result Manifest, err error) {
 	if inMemory {
-		return &manifestFile{
-			inMemory: true,
-		}, Manifest{}, nil
+		return &manifestFile{inMemory: true}, Manifest{}, nil
 	}
 	return helpOpenOrCreateManifestFile(dir, readOnly, manifestDeletionsRewriteThreshold)
 }

--- a/manifest.go
+++ b/manifest.go
@@ -117,14 +117,14 @@ func (m *Manifest) clone() Manifest {
 	return ret
 }
 
-// openOrCreateManifestFile opens a Badger manifest file if it exists, or creates on if
-// one doesn’t.
-func openOrCreateManifestFile(dir string, readOnly bool, inMemory bool) (
+// openOrCreateManifestFile opens a Badger manifest file if it exists, or creates one if
+// doesn’t exists.
+func openOrCreateManifestFile(opt Options) (
 	ret *manifestFile, result Manifest, err error) {
-	if inMemory {
+	if opt.InMemory {
 		return &manifestFile{inMemory: true}, Manifest{}, nil
 	}
-	return helpOpenOrCreateManifestFile(dir, readOnly, manifestDeletionsRewriteThreshold)
+	return helpOpenOrCreateManifestFile(opt.Dir, opt.ReadOnly, manifestDeletionsRewriteThreshold)
 }
 
 func helpOpenOrCreateManifestFile(dir string, readOnly bool, deletionsThreshold int) (

--- a/options.go
+++ b/options.go
@@ -519,3 +519,12 @@ func (opt Options) WithMaxCacheSize(size int64) Options {
 	opt.MaxCacheSize = size
 	return opt
 }
+
+// WithDiskLess returns a new Options value with DiskLess set to the given value.
+//
+// When badger is running in diskless mode, everything is stored in memory. No value/sst files are
+// created. In case of a crash all data will be lost.
+func (opt Options) WithDiskLess(b bool) Options {
+	opt.DiskLess = b
+	return opt
+}

--- a/options.go
+++ b/options.go
@@ -50,6 +50,7 @@ type Options struct {
 	Logger              Logger
 	Compression         options.CompressionType
 	EventLogging        bool
+	DiskLess            bool
 
 	// Fine tuning options.
 

--- a/options.go
+++ b/options.go
@@ -146,6 +146,15 @@ func DefaultOptions(path string) Options {
 	}
 }
 
+// DiskLessOptions retuns badger options for diskless mode along with other recommended options
+// for good performance.
+// Feel free to modify these to suit your needs with the WithX methods.
+func DiskLessOptions() Options {
+	opt := DefaultOptions("")
+	opt.DiskLess = true
+	return opt
+}
+
 func buildTableOptions(opt Options) table.Options {
 	return table.Options{
 		BlockSize:          opt.BlockSize,

--- a/options.go
+++ b/options.go
@@ -50,7 +50,7 @@ type Options struct {
 	Logger              Logger
 	Compression         options.CompressionType
 	EventLogging        bool
-	DiskLess            bool
+	InMemory            bool
 
 	// Fine tuning options.
 
@@ -144,15 +144,6 @@ func DefaultOptions(path string) Options {
 		EncryptionKey:                 []byte{},
 		EncryptionKeyRotationDuration: 10 * 24 * time.Hour, // Default 10 days.
 	}
-}
-
-// DiskLessOptions retuns badger options for diskless mode along with other recommended options
-// for good performance.
-// Feel free to modify these to suit your needs with the WithX methods.
-func DiskLessOptions() Options {
-	opt := DefaultOptions("")
-	opt.DiskLess = true
-	return opt
 }
 
 func buildTableOptions(opt Options) table.Options {
@@ -543,11 +534,11 @@ func (opt Options) WithMaxCacheSize(size int64) Options {
 	return opt
 }
 
-// WithDiskLess returns a new Options value with DiskLess set to the given value.
+// WithInMemory returns a new Options value with Inmemory mode set to the given value.
 //
-// When badger is running in diskless mode, everything is stored in memory. No value/sst files are
+// When badger is running in InMemory mode, everything is stored in memory. No value/sst files are
 // created. In case of a crash all data will be lost.
-func (opt Options) WithDiskLess(b bool) Options {
-	opt.DiskLess = b
+func (opt Options) WithInmemory(b bool) Options {
+	opt.InMemory = b
 	return opt
 }

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -297,7 +297,7 @@ func (w *sortedWriter) handleRequests() {
 
 	process := func(req *request) {
 		for i, e := range req.Entries {
-			// If badger is running in diskless mode, req.Ptrs == 0.
+			// If badger is running in InMemory mode, req.Ptrs == 0.
 			if i < len(req.Ptrs) {
 				vptr := req.Ptrs[i]
 				if !vptr.IsZero() {
@@ -408,7 +408,7 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 	opts.DataKey = builder.DataKey()
 	opts.Cache = w.db.blockCache
 	var tbl *table.Table
-	if w.db.opt.DiskLess {
+	if w.db.opt.InMemory {
 		var err error
 		if tbl, err = table.OpenInMemoryTable(data, fileID, &opts); err != nil {
 			return err
@@ -449,8 +449,8 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 		// other keys to avoid an overlap.
 		lhandler = lc.levels[0]
 	}
-	// Don't create a change if bader is running in diskless mode.
-	if !w.db.opt.DiskLess {
+	// Don't create a change if bader is running in InMemory mode.
+	if !w.db.opt.InMemory {
 		// Now that table can be opened successfully, let's add this to the MANIFEST.
 		change := &pb.ManifestChange{
 			Id:          tbl.ID(),

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -244,13 +244,13 @@ func (sw *StreamWriter) Flush() error {
 	}
 
 	// Now sync the directories, so all the files are registered.
-	if !sw.db.opt.DiskLess && (sw.db.opt.ValueDir != sw.db.opt.Dir) {
-		if err := syncDir(sw.db.opt.ValueDir); err != nil {
+	if sw.db.opt.ValueDir != sw.db.opt.Dir {
+		if err := sw.db.syncDir(sw.db.opt.ValueDir); err != nil {
 			return err
 		}
-		if err := syncDir(sw.db.opt.Dir); err != nil {
-			return err
-		}
+	}
+	if err := sw.db.syncDir(sw.db.opt.Dir); err != nil {
+		return err
 	}
 	return sw.db.lc.validate()
 }

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -297,7 +297,7 @@ func (w *sortedWriter) handleRequests() {
 
 	process := func(req *request) {
 		for i, e := range req.Entries {
-			// If badger is running in InMemory mode, req.Ptrs == 0.
+			// If badger is running in InMemory mode, len(req.Ptrs) == 0.
 			if i < len(req.Ptrs) {
 				vptr := req.Ptrs[i]
 				if !vptr.IsZero() {
@@ -449,18 +449,15 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 		// other keys to avoid an overlap.
 		lhandler = lc.levels[0]
 	}
-	// Don't create a change if bader is running in InMemory mode.
-	if !w.db.opt.InMemory {
-		// Now that table can be opened successfully, let's add this to the MANIFEST.
-		change := &pb.ManifestChange{
-			Id:          tbl.ID(),
-			Op:          pb.ManifestChange_CREATE,
-			Level:       uint32(lhandler.level),
-			Compression: uint32(tbl.CompressionType()),
-		}
-		if err := w.db.manifest.addChanges([]*pb.ManifestChange{change}); err != nil {
-			return err
-		}
+	// Now that table can be opened successfully, let's add this to the MANIFEST.
+	change := &pb.ManifestChange{
+		Id:          tbl.ID(),
+		Op:          pb.ManifestChange_CREATE,
+		Level:       uint32(lhandler.level),
+		Compression: uint32(tbl.CompressionType()),
+	}
+	if err := w.db.manifest.addChanges([]*pb.ManifestChange{change}); err != nil {
+		return err
 	}
 	if err := lhandler.replaceTables([]*table.Table{}, []*table.Table{tbl}); err != nil {
 		return err

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -51,14 +51,7 @@ func getSortedKVList(valueSize, listSize int) *pb.KVList {
 
 // check if we can read values after writing using stream writer
 func TestStreamWriter1(t *testing.T) {
-	normalModeOpts := getTestOptions("")
-	managedModeOpts := getTestOptions("")
-	managedModeOpts.managedTxns = true
-
-	diskLessModeOpts := getTestOptions("")
-	diskLessModeOpts.DiskLess = true
-
-	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts, &diskLessModeOpts} {
+	test := func(t *testing.T, opts *Options) {
 		runBadgerTest(t, opts, func(t *testing.T, db *DB) {
 			// write entries using stream writer
 			noOfKeys := 1000
@@ -91,18 +84,25 @@ func TestStreamWriter1(t *testing.T) {
 			require.NoError(t, err, "error while retrieving key")
 		})
 	}
+	t.Run("Normal mode", func(t *testing.T) {
+		normalModeOpts := getTestOptions("")
+		test(t, &normalModeOpts)
+	})
+	t.Run("Managed mode", func(t *testing.T) {
+		managedModeOpts := getTestOptions("")
+		managedModeOpts.managedTxns = true
+		test(t, &managedModeOpts)
+	})
+	t.Run("DiskLess mode", func(t *testing.T) {
+		diskLessModeOpts := getTestOptions("")
+		diskLessModeOpts.DiskLess = true
+		test(t, &diskLessModeOpts)
+	})
 }
 
 // write more keys to db after writing keys using stream writer
 func TestStreamWriter2(t *testing.T) {
-	normalModeOpts := getTestOptions("")
-	managedModeOpts := getTestOptions("")
-	managedModeOpts.managedTxns = true
-
-	diskLessModeOpts := getTestOptions("")
-	diskLessModeOpts.DiskLess = true
-
-	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts, &diskLessModeOpts} {
+	test := func(t *testing.T, opts *Options) {
 		runBadgerTest(t, opts, func(t *testing.T, db *DB) {
 			// write entries using stream writer
 			noOfKeys := 1000
@@ -147,17 +147,24 @@ func TestStreamWriter2(t *testing.T) {
 			require.Nil(t, err, "error should be nil while iterating")
 		})
 	}
+	t.Run("Normal mode", func(t *testing.T) {
+		normalModeOpts := getTestOptions("")
+		test(t, &normalModeOpts)
+	})
+	t.Run("Managed mode", func(t *testing.T) {
+		managedModeOpts := getTestOptions("")
+		managedModeOpts.managedTxns = true
+		test(t, &managedModeOpts)
+	})
+	t.Run("DiskLess mode", func(t *testing.T) {
+		diskLessModeOpts := getTestOptions("")
+		diskLessModeOpts.DiskLess = true
+		test(t, &diskLessModeOpts)
+	})
 }
 
 func TestStreamWriter3(t *testing.T) {
-	normalModeOpts := getTestOptions("")
-	managedModeOpts := getTestOptions("")
-	managedModeOpts.managedTxns = true
-
-	diskLessModeOpts := getTestOptions("")
-	diskLessModeOpts.DiskLess = true
-
-	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts, &diskLessModeOpts} {
+	test := func(t *testing.T, opts *Options) {
 		runBadgerTest(t, opts, func(t *testing.T, db *DB) {
 			// write entries using stream writer
 			noOfKeys := 1000
@@ -229,6 +236,20 @@ func TestStreamWriter3(t *testing.T) {
 			require.Nil(t, err, "error should be nil while iterating")
 		})
 	}
+	t.Run("Normal mode", func(t *testing.T) {
+		normalModeOpts := getTestOptions("")
+		test(t, &normalModeOpts)
+	})
+	t.Run("Managed mode", func(t *testing.T) {
+		managedModeOpts := getTestOptions("")
+		managedModeOpts.managedTxns = true
+		test(t, &managedModeOpts)
+	})
+	t.Run("DiskLess mode", func(t *testing.T) {
+		diskLessModeOpts := getTestOptions("")
+		diskLessModeOpts.DiskLess = true
+		test(t, &diskLessModeOpts)
+	})
 }
 
 // After inserting all data from streams, StreamWriter reinitializes Oracle and updates its nextTs

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -55,7 +55,10 @@ func TestStreamWriter1(t *testing.T) {
 	managedModeOpts := getTestOptions("")
 	managedModeOpts.managedTxns = true
 
-	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts} {
+	diskLessModeOpts := getTestOptions("")
+	diskLessModeOpts.DiskLess = true
+
+	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts, &diskLessModeOpts} {
 		runBadgerTest(t, opts, func(t *testing.T, db *DB) {
 			// write entries using stream writer
 			noOfKeys := 1000
@@ -96,7 +99,10 @@ func TestStreamWriter2(t *testing.T) {
 	managedModeOpts := getTestOptions("")
 	managedModeOpts.managedTxns = true
 
-	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts} {
+	diskLessModeOpts := getTestOptions("")
+	diskLessModeOpts.DiskLess = true
+
+	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts, &diskLessModeOpts} {
 		runBadgerTest(t, opts, func(t *testing.T, db *DB) {
 			// write entries using stream writer
 			noOfKeys := 1000
@@ -148,7 +154,10 @@ func TestStreamWriter3(t *testing.T) {
 	managedModeOpts := getTestOptions("")
 	managedModeOpts.managedTxns = true
 
-	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts} {
+	diskLessModeOpts := getTestOptions("")
+	diskLessModeOpts.DiskLess = true
+
+	for _, opts := range []*Options{&normalModeOpts, &managedModeOpts, &diskLessModeOpts} {
 		runBadgerTest(t, opts, func(t *testing.T, db *DB) {
 			// write entries using stream writer
 			noOfKeys := 1000

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -93,9 +93,9 @@ func TestStreamWriter1(t *testing.T) {
 		managedModeOpts.managedTxns = true
 		test(t, &managedModeOpts)
 	})
-	t.Run("DiskLess mode", func(t *testing.T) {
+	t.Run("InMemory mode", func(t *testing.T) {
 		diskLessModeOpts := getTestOptions("")
-		diskLessModeOpts.DiskLess = true
+		diskLessModeOpts.InMemory = true
 		test(t, &diskLessModeOpts)
 	})
 }
@@ -156,9 +156,9 @@ func TestStreamWriter2(t *testing.T) {
 		managedModeOpts.managedTxns = true
 		test(t, &managedModeOpts)
 	})
-	t.Run("DiskLess mode", func(t *testing.T) {
+	t.Run("InMemory mode", func(t *testing.T) {
 		diskLessModeOpts := getTestOptions("")
-		diskLessModeOpts.DiskLess = true
+		diskLessModeOpts.InMemory = true
 		test(t, &diskLessModeOpts)
 	})
 }
@@ -245,9 +245,9 @@ func TestStreamWriter3(t *testing.T) {
 		managedModeOpts.managedTxns = true
 		test(t, &managedModeOpts)
 	})
-	t.Run("DiskLess mode", func(t *testing.T) {
+	t.Run("InMemory mode", func(t *testing.T) {
 		diskLessModeOpts := getTestOptions("")
-		diskLessModeOpts.DiskLess = true
+		diskLessModeOpts.InMemory = true
 		test(t, &diskLessModeOpts)
 	})
 }

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+go version
+
 # Ensure that we can compile the binary.
 pushd badger
 go build -v .

--- a/txn.go
+++ b/txn.go
@@ -294,16 +294,8 @@ func (txn *Txn) newPendingWritesIterator(reversed bool) *pendingWritesIterator {
 
 func (txn *Txn) checkSize(e *Entry) error {
 	count := txn.count + 1
-	var size int64
-	// If badger is opened in InMemory mode, the size of transaction should include
-	// the actual size of the value.
-	if txn.db.opt.InMemory {
-		size = txn.size + int64(len(e.Key)) + int64(len(e.Value)) + 2 /* Meta and user meta */
-	} else {
-		size = txn.size + int64(e.estimateSize(txn.db.opt.ValueThreshold))
-	}
 	// Extra bytes for the version in key.
-	size += 10
+	size := txn.size + int64(e.estimateSize(txn.db.opt.ValueThreshold)) + 10
 	if count >= txn.db.opt.maxBatchCount || size >= txn.db.opt.maxBatchSize {
 		return ErrTxnTooBig
 	}

--- a/txn.go
+++ b/txn.go
@@ -295,9 +295,9 @@ func (txn *Txn) newPendingWritesIterator(reversed bool) *pendingWritesIterator {
 func (txn *Txn) checkSize(e *Entry) error {
 	count := txn.count + 1
 	var size int64
-	// If badger is opened in diskless mode, the size of transaction should include
+	// If badger is opened in InMemory mode, the size of transaction should include
 	// the actual size of the value.
-	if txn.db.opt.DiskLess {
+	if txn.db.opt.InMemory {
 		size = txn.size + int64(len(e.Key)) + int64(len(e.Value)) + 2 /* Meta and user meta */
 	} else {
 		size = txn.size + int64(e.estimateSize(txn.db.opt.ValueThreshold))

--- a/txn.go
+++ b/txn.go
@@ -294,8 +294,14 @@ func (txn *Txn) newPendingWritesIterator(reversed bool) *pendingWritesIterator {
 
 func (txn *Txn) checkSize(e *Entry) error {
 	count := txn.count + 1
+	var size int64
+	if txn.db.opt.DiskLess {
+		size = txn.size + int64(len(e.Key)) + int64(len(e.Value)) + 2 /* Meta and user meta */
+	} else {
+		size = txn.size + int64(e.estimateSize(txn.db.opt.ValueThreshold))
+	}
 	// Extra bytes for version in key.
-	size := txn.size + int64(e.estimateSize(txn.db.opt.ValueThreshold)) + 10
+	size += 10
 	if count >= txn.db.opt.maxBatchCount || size >= txn.db.opt.maxBatchSize {
 		return ErrTxnTooBig
 	}

--- a/txn.go
+++ b/txn.go
@@ -295,12 +295,14 @@ func (txn *Txn) newPendingWritesIterator(reversed bool) *pendingWritesIterator {
 func (txn *Txn) checkSize(e *Entry) error {
 	count := txn.count + 1
 	var size int64
+	// If badger is opened in diskless mode, the size of transaction should include
+	// the actual size of the value.
 	if txn.db.opt.DiskLess {
 		size = txn.size + int64(len(e.Key)) + int64(len(e.Value)) + 2 /* Meta and user meta */
 	} else {
 		size = txn.size + int64(e.estimateSize(txn.db.opt.ValueThreshold))
 	}
-	// Extra bytes for version in key.
+	// Extra bytes for the version in key.
 	size += 10
 	if count >= txn.db.opt.maxBatchCount || size >= txn.db.opt.maxBatchSize {
 		return ErrTxnTooBig

--- a/txn_test.go
+++ b/txn_test.go
@@ -91,6 +91,7 @@ func TestTxnReadAfterWrite(t *testing.T) {
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
+		require.NoError(t, db.Close())
 	})
 }
 

--- a/txn_test.go
+++ b/txn_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestTxnSimple(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
-
 		txn := db.NewTransaction(true)
 
 		for i := 0; i < 10; i++ {
@@ -56,7 +55,7 @@ func TestTxnSimple(t *testing.T) {
 }
 
 func TestTxnReadAfterWrite(t *testing.T) {
-	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+	test := func(t *testing.T, db *DB) {
 		var wg sync.WaitGroup
 		N := 100
 		wg.Add(N)
@@ -80,6 +79,18 @@ func TestTxnReadAfterWrite(t *testing.T) {
 			}(i)
 		}
 		wg.Wait()
+	}
+	t.Run("disk mode", func(t *testing.T) {
+		runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+			test(t, db)
+		})
+	})
+	t.Run("disk less mode", func(t *testing.T) {
+		opt := getTestOptions("")
+		opt.DiskLess = true
+		db, err := Open(opt)
+		require.NoError(t, err)
+		test(t, db)
 	})
 }
 
@@ -615,7 +626,7 @@ func TestTxnIterationEdgeCase3(t *testing.T) {
 }
 
 func TestIteratorAllVersionsWithDeleted(t *testing.T) {
-	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+	test := func(t *testing.T, db *DB) {
 		// Write two keys
 		err := db.Update(func(txn *Txn) error {
 			require.NoError(t, txn.SetEntry(NewEntry([]byte("answer1"), []byte("42"))))
@@ -661,6 +672,19 @@ func TestIteratorAllVersionsWithDeleted(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
+	}
+	t.Run("disk mode", func(t *testing.T) {
+		runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+			test(t, db)
+		})
+	})
+	t.Run("disk less mode", func(t *testing.T) {
+		opt := getTestOptions("")
+		opt.DiskLess = true
+		db, err := Open(opt)
+		require.NoError(t, err)
+		test(t, db)
+		require.NoError(t, db.Close())
 	})
 }
 
@@ -713,86 +737,101 @@ func TestManagedDB(t *testing.T) {
 
 	opt := getTestOptions(dir)
 	opt.managedTxns = true
-	db, err := Open(opt)
-	require.NoError(t, err)
-	defer db.Close()
 
-	key := func(i int) []byte {
-		return []byte(fmt.Sprintf("key-%02d", i))
-	}
-
-	val := func(i int) []byte {
-		return []byte(fmt.Sprintf("val-%d", i))
-	}
-
-	require.Panics(t, func() {
-		db.Update(func(tx *Txn) error { return nil })
-	})
-
-	err = db.View(func(tx *Txn) error { return nil })
-	require.NoError(t, err)
-
-	// Write data at t=3.
-	txn := db.NewTransactionAt(3, true)
-	for i := 0; i <= 3; i++ {
-		require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
-	}
-	require.Panics(t, func() { txn.Commit() })
-	require.NoError(t, txn.CommitAt(3, nil))
-
-	// Read data at t=2.
-	txn = db.NewTransactionAt(2, false)
-	for i := 0; i <= 3; i++ {
-		_, err := txn.Get(key(i))
-		require.Equal(t, ErrKeyNotFound, err)
-	}
-	txn.Discard()
-
-	// Read data at t=3.
-	txn = db.NewTransactionAt(3, false)
-	for i := 0; i <= 3; i++ {
-		item, err := txn.Get(key(i))
-		require.NoError(t, err)
-		require.Equal(t, uint64(3), item.Version())
-		v, err := item.ValueCopy(nil)
-		require.NoError(t, err)
-		require.Equal(t, val(i), v)
-	}
-	txn.Discard()
-
-	// Write data at t=7.
-	txn = db.NewTransactionAt(6, true)
-	for i := 0; i <= 7; i++ {
-		_, err := txn.Get(key(i))
-		if err == nil {
-			continue // Don't overwrite existing keys.
+	test := func(t *testing.T, db *DB) {
+		key := func(i int) []byte {
+			return []byte(fmt.Sprintf("key-%02d", i))
 		}
-		require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
-	}
-	require.NoError(t, txn.CommitAt(7, nil))
 
-	// Read data at t=9.
-	txn = db.NewTransactionAt(9, false)
-	for i := 0; i <= 9; i++ {
-		item, err := txn.Get(key(i))
-		if i <= 7 {
-			require.NoError(t, err)
-		} else {
+		val := func(i int) []byte {
+			return []byte(fmt.Sprintf("val-%d", i))
+		}
+
+		require.Panics(t, func() {
+			db.Update(func(tx *Txn) error { return nil })
+		})
+
+		err = db.View(func(tx *Txn) error { return nil })
+		require.NoError(t, err)
+
+		// Write data at t=3.
+		txn := db.NewTransactionAt(3, true)
+		for i := 0; i <= 3; i++ {
+			require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
+		}
+		require.Panics(t, func() { txn.Commit() })
+		require.NoError(t, txn.CommitAt(3, nil))
+
+		// Read data at t=2.
+		txn = db.NewTransactionAt(2, false)
+		for i := 0; i <= 3; i++ {
+			_, err := txn.Get(key(i))
 			require.Equal(t, ErrKeyNotFound, err)
 		}
+		txn.Discard()
 
-		if i <= 3 {
+		// Read data at t=3.
+		txn = db.NewTransactionAt(3, false)
+		for i := 0; i <= 3; i++ {
+			item, err := txn.Get(key(i))
+			require.NoError(t, err)
 			require.Equal(t, uint64(3), item.Version())
-		} else if i <= 7 {
-			require.Equal(t, uint64(7), item.Version())
-		}
-		if i <= 7 {
 			v, err := item.ValueCopy(nil)
 			require.NoError(t, err)
 			require.Equal(t, val(i), v)
 		}
+		txn.Discard()
+
+		// Write data at t=7.
+		txn = db.NewTransactionAt(6, true)
+		for i := 0; i <= 7; i++ {
+			_, err := txn.Get(key(i))
+			if err == nil {
+				continue // Don't overwrite existing keys.
+			}
+			require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
+		}
+		require.NoError(t, txn.CommitAt(7, nil))
+
+		// Read data at t=9.
+		txn = db.NewTransactionAt(9, false)
+		for i := 0; i <= 9; i++ {
+			item, err := txn.Get(key(i))
+			if i <= 7 {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, ErrKeyNotFound, err)
+			}
+
+			if i <= 3 {
+				require.Equal(t, uint64(3), item.Version())
+			} else if i <= 7 {
+				require.Equal(t, uint64(7), item.Version())
+			}
+			if i <= 7 {
+				v, err := item.ValueCopy(nil)
+				require.NoError(t, err)
+				require.Equal(t, val(i), v)
+			}
+		}
+		txn.Discard()
 	}
-	txn.Discard()
+	t.Run("disk mode", func(t *testing.T) {
+		db, err := Open(opt)
+		require.NoError(t, err)
+		test(t, db)
+		require.NoError(t, db.Close())
+	})
+	t.Run("disk less mode", func(t *testing.T) {
+		opt.DiskLess = true
+		opt.Dir = ""
+		opt.ValueDir = ""
+		db, err := Open(opt)
+		require.NoError(t, err)
+		test(t, db)
+		require.NoError(t, db.Close())
+	})
+
 }
 
 func TestArmV7Issue311Fix(t *testing.T) {

--- a/txn_test.go
+++ b/txn_test.go
@@ -85,9 +85,9 @@ func TestTxnReadAfterWrite(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk less mode", func(t *testing.T) {
+	t.Run("InMemory mode", func(t *testing.T) {
 		opt := getTestOptions("")
-		opt.DiskLess = true
+		opt.InMemory = true
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -679,9 +679,9 @@ func TestIteratorAllVersionsWithDeleted(t *testing.T) {
 			test(t, db)
 		})
 	})
-	t.Run("disk less mode", func(t *testing.T) {
+	t.Run("InMemory mode", func(t *testing.T) {
 		opt := getTestOptions("")
-		opt.DiskLess = true
+		opt.InMemory = true
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -823,8 +823,8 @@ func TestManagedDB(t *testing.T) {
 		test(t, db)
 		require.NoError(t, db.Close())
 	})
-	t.Run("disk less mode", func(t *testing.T) {
-		opt.DiskLess = true
+	t.Run("InMemory mode", func(t *testing.T) {
+		opt.InMemory = true
 		opt.Dir = ""
 		opt.ValueDir = ""
 		db, err := Open(opt)

--- a/value.go
+++ b/value.go
@@ -732,6 +732,9 @@ func (vlog *valueLog) deleteLogFile(lf *logFile) error {
 }
 
 func (vlog *valueLog) dropAll() (int, error) {
+	if vlog.db.opt.DiskLess {
+		return 0, nil
+	}
 	// We don't want to block dropAll on any pending transactions. So, don't worry about iterator
 	// count.
 	var count int

--- a/value.go
+++ b/value.go
@@ -1708,6 +1708,10 @@ func (vlog *valueLog) runGC(discardRatio float64, head valuePointer) error {
 }
 
 func (vlog *valueLog) updateDiscardStats(stats map[uint32]int64) {
+	if vlog.opt.InMemory {
+		return
+	}
+
 	select {
 	case vlog.lfDiscardStats.flushChan <- stats:
 	default:

--- a/value.go
+++ b/value.go
@@ -1218,7 +1218,7 @@ func (req *request) DecrRef() {
 		return
 	}
 	req.Entries = nil
-	requestPool.Put(req)
+	//requestPool.Put(req)
 }
 
 func (req *request) Wait() error {


### PR DESCRIPTION
This PR introduces disk-less mode in badger. The disk-less mode can be enabled by setting `options.DiskLess = true`. When badger is running in disk-less mode no files are created and everything is stored in memory.

On DB close, all stored data is lost.

NOTE - An existing DB cannot be opened in diskless mode.

Fixes https://github.com/dgraph-io/badger/issues/1001
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1113)
<!-- Reviewable:end -->
