### PR TITLE
Rename WithCompressionType to WithCompression.

### DIFF
--- a/options.go
+++ b/options.go
@@ -488,11 +488,14 @@ func (opt Options) WithKeepL0InMemory(val bool) Options {
 	return opt
 }
 
-// WithCompressionType returns a new Options value with CompressionType set to the given value.
+// WithCompression returns a new Options value with Compression set to the given value.
 //
-// When compression type is set, every block will be compressed using the specified algorithm.
+// When Compression is enabled, every block will be compressed using the specified algorithm.
 // This option doesn't affect existing tables. Only the newly created tables will be compressed.
-func (opt Options) WithCompressionType(cType options.CompressionType) Options {
+//
+// The default compression algorithm used is zstd when built with Cgo. Without Cgo, the default is
+// snappy. Compression is enabled by default.
+func (opt Options) WithCompression(cType options.CompressionType) Options {
 	opt.Compression = cType
 	return opt
 }

--- a/options.go
+++ b/options.go
@@ -490,7 +490,7 @@ func (opt Options) WithKeepL0InMemory(val bool) Options {
 
 // WithCompression returns a new Options value with Compression set to the given value.
 //
-// When Compression is enabled, every block will be compressed using the specified algorithm.
+// When compression is enabled, every block will be compressed using the specified algorithm.
 // This option doesn't affect existing tables. Only the newly created tables will be compressed.
 //
 // The default compression algorithm used is zstd when built with Cgo. Without Cgo, the default is


### PR DESCRIPTION
Rename the builder method WithCompressionType to WithCompression to be
consistent with the option struct field named Compression.

Update the godoc for WithCompression with the default compression algorithm
used when Cgo is enabled (zstd) and when Cgo is disabled (snappy).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1116)
<!-- Reviewable:end -->
