### PR TITLE
Cast idx to uint32 to fix compilation on i386

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -432,7 +432,7 @@ func (t *Table) block(idx int) (*block, error) {
 
 func (t *Table) blockCacheKey(idx int) uint64 {
 	y.AssertTrue(t.ID() < math.MaxUint32)
-	y.AssertTrue(idx < math.MaxUint32)
+	y.AssertTrue(uint64(idx) < math.MaxUint32)
 	return (t.ID() << 32) | uint64(idx)
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -432,7 +432,7 @@ func (t *Table) block(idx int) (*block, error) {
 
 func (t *Table) blockCacheKey(idx int) uint64 {
 	y.AssertTrue(t.ID() < math.MaxUint32)
-	y.AssertTrue(uint64(idx) < math.MaxUint32)
+	y.AssertTrue(uint32(idx) < math.MaxUint32)
 	return (t.ID() << 32) | uint64(idx)
 }
 


### PR DESCRIPTION
`env GOOS=linux GOARCH=386 go build` no longer complains about integer overflow.

See https://github.com/dgraph-io/badger/issues/953#issuecomment-552241033

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1118)
<!-- Reviewable:end -->
