### PR TITLE
Limit manifest's change set size

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -375,7 +375,7 @@ func ReplayManifestFile(fp *os.File) (Manifest, int64, error) {
 		if length > uint32(stat.Size()) {
 			return Manifest{}, 0, errors.Errorf(
 				"Buffer length: %d greater than file size: %d. Manifest file might be corrupted",
-			)
+				length, stat.Size())
 		}
 		var buf = make([]byte, length)
 		if _, err := io.ReadFull(&r, buf); err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -353,6 +353,11 @@ func ReplayManifestFile(fp *os.File) (Manifest, int64, error) {
 				version, magicVersion)
 	}
 
+	stat, err := fp.Stat()
+	if err != nil {
+		return Manifest{}, 0, err
+	}
+
 	build := createManifest()
 	var offset int64
 	for {
@@ -366,6 +371,12 @@ func ReplayManifestFile(fp *os.File) (Manifest, int64, error) {
 			return Manifest{}, 0, err
 		}
 		length := y.BytesToU32(lenCrcBuf[0:4])
+		// Sanity check to ensure we don't over-allocate memory.
+		if length > uint32(stat.Size()) {
+			return Manifest{}, 0, errors.Errorf(
+				"Buffer length: %d greater than file size: %d. Manifest file might be corrupted",
+			)
+		}
 		var buf = make([]byte, length)
 		if _, err := io.ReadFull(&r, buf); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {


### PR DESCRIPTION
This PR limits the amount of memory we allocated for reading the manifest changes set's size.
When a manifest file is corrupted, in worst case we might end up allocating more than 4GB in the following make call https://github.com/dgraph-io/badger/blob/eef7c122607e5c2cc60e14eb20c883efa3e6855b/manifest.go#L368-L369

This PR ensures we don't over-allocate the byte slice.
Fixes https://github.com/dgraph-io/badger/issues/490

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1119)
<!-- Reviewable:end -->
