### PR TITLE
Fix request increment ref bug

### DIFF
--- a/db.go
+++ b/db.go
@@ -726,11 +726,10 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 	// We can only service one request because we need each txn to be stored in a contigous section.
 	// Txns should not interleave among other txns or rewrites.
 	req := requestPool.Get().(*request)
+	req.reset()
 	req.Entries = entries
-	req.Wg = sync.WaitGroup{}
 	req.Wg.Add(1)
 	req.IncrRef()     // for db write
-	req.IncrRef()     // for publisher updates
 	db.writeCh <- req // Handled in doWrites.
 	y.NumPuts.Add(int64(len(entries)))
 

--- a/publisher.go
+++ b/publisher.go
@@ -52,7 +52,7 @@ func (p *publisher) listenForUpdates(c *y.Closer) {
 		p.cleanSubscribers()
 		c.Done()
 	}()
-	slurp := func(batch []*request) {
+	slurp := func(batch requests) {
 		for {
 			select {
 			case reqs := <-p.pubCh:
@@ -150,8 +150,9 @@ func (p *publisher) deleteSubscriber(id uint64) {
 	delete(p.subscribers, id)
 }
 
-func (p *publisher) sendUpdates(reqs []*request) {
+func (p *publisher) sendUpdates(reqs requests) {
 	if p.noOfSubscribers() != 0 {
+		reqs.IncrRef()
 		p.pubCh <- reqs
 	}
 }

--- a/value.go
+++ b/value.go
@@ -1197,6 +1197,14 @@ type request struct {
 	ref  int32
 }
 
+func (req *request) reset() {
+	req.Entries = req.Entries[:0]
+	req.Ptrs = req.Ptrs[:0]
+	req.Wg = sync.WaitGroup{}
+	req.Err = nil
+	req.ref = 0
+}
+
 func (req *request) IncrRef() {
 	atomic.AddInt32(&req.ref, 1)
 }
@@ -1222,6 +1230,12 @@ type requests []*request
 func (reqs requests) DecrRef() {
 	for _, req := range reqs {
 		req.DecrRef()
+	}
+}
+
+func (reqs requests) IncrRef() {
+	for _, req := range reqs {
+		req.IncrRef()
 	}
 }
 


### PR DESCRIPTION
The `sendToWriteCh()` method would increment the `ref` of a request by 2
(one for the write and another for the publisher). The `ref` value was
always decremented by the `doWrite()` function but the publisher would
decrement it only if there were any subscribers.

This would mean that we `ALWAYS` create new `request` object in the `requestPool` but never put them back into the pool.
https://github.com/dgraph-io/badger/blob/eef7c122607e5c2cc60e14eb20c883efa3e6855b/value.go#L1204-L1211

With this commit, we increment the request `ref` for the publisher only if
there are any actual subscribers.


The adding `print` statements around the `requestPool.Get()` and `requestPool.Put()` functions shows the request object were never being added to the pool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1121)
<!-- Reviewable:end -->
