### PR TITLE
Fix TestGoroutineLeak and Example_subscribe test

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1581,10 +1581,7 @@ func TestGoroutineLeak(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			var wg sync.WaitGroup
 			wg.Add(1)
-			var subWg sync.WaitGroup
-			subWg.Add(1)
 			go func() {
-				subWg.Done()
 				err := db.Subscribe(ctx, func(kvs *pb.KVList) {
 					require.Equal(t, []byte("value"), kvs.Kv[0].GetValue())
 					updated = true
@@ -1594,7 +1591,8 @@ func TestGoroutineLeak(t *testing.T) {
 					require.Equal(t, err.Error(), context.Canceled.Error())
 				}
 			}()
-			subWg.Wait()
+			// Wait for the go routine to be scheduled.
+			time.Sleep(time.Second)
 			err := db.Update(func(txn *Txn) error {
 				return txn.SetEntry(NewEntry([]byte("key"), []byte("value")))
 			})
@@ -1947,6 +1945,8 @@ func ExampleDB_Subscribe() {
 		log.Printf("subscription closed")
 	}()
 
+	// Wait for the above go routine to be scheduled.
+	time.Sleep(time.Second)
 	// Write both keys, but only one should be printed in the Output.
 	err = db.Update(func(txn *Txn) error { return txn.Set(aKey, aValue) })
 	if err != nil {


### PR DESCRIPTION
Both the test use subscription and there was a race condition which
would cause the builds to fail at times. This commit fixes it.


Fixes https://github.com/dgraph-io/badger/issues/1122 and https://github.com/dgraph-io/badger/issues/1087

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1123)
<!-- Reviewable:end -->
