### PR TITLE
Optimise createTable in stream_writer.go

### DIFF
--- a/level_handler.go
+++ b/level_handler.go
@@ -140,7 +140,12 @@ func (s *levelHandler) replaceTables(toDel, toAdd []*table.Table) error {
 	return decrRefs(toDel)
 }
 
-func (s *levelHandler) addTables(toAdd []*table.Table) error {
+// addTable adds toAdd tables to levelHandler. Normally when we add tables to levelHandler, we sort
+// tables based on table.Smallest. This is required for correctness of the system. But in some cases
+// this can be avoided(such as stream writer). We can just add tables to levelHandler's table list
+// and after all addTables calls, we can sort table list(check sortTable method).
+// NOTE: addTables and sortTables duplicate some code from replaceTables().
+func (s *levelHandler) addTables(toAdd []*table.Table) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -150,10 +155,9 @@ func (s *levelHandler) addTables(toAdd []*table.Table) error {
 		t.IncrRef()
 		s.tables = append(s.tables, t)
 	}
-
-	return nil
 }
 
+// sortTables sorts tables of levelHandler based on table.Smallest.
 func (s *levelHandler) sortTables() {
 	s.RLock()
 	defer s.RUnlock()

--- a/level_handler.go
+++ b/level_handler.go
@@ -140,24 +140,22 @@ func (s *levelHandler) replaceTables(toDel, toAdd []*table.Table) error {
 	return decrRefs(toDel)
 }
 
-// addTable adds toAdd tables to levelHandler. Normally when we add tables to levelHandler, we sort
-// tables based on table.Smallest. This is required for correctness of the system. But in some cases
-// this can be avoided(such as stream writer). We can just add tables to levelHandler's table list
-// and after all addTables calls, we can sort table list(check sortTable method).
-// NOTE: addTables and sortTables duplicate some code from replaceTables().
-func (s *levelHandler) addTables(toAdd []*table.Table) {
+// addTable adds toAdd table to levelHandler. Normally when we add tables to levelHandler, we sort
+// tables based on table.Smallest. This is required for correctness of the system. But in case of
+// stream writer this can be avoided. We can just add tables to levelHandler's table list
+// and after all addTable calls, we can sort table list(check sortTable method).
+// NOTE: levelHandler.sortTables() should be called after call addTable calls are done.
+func (s *levelHandler) addTable(t *table.Table) {
 	s.Lock()
 	defer s.Unlock()
 
-	// Increase totalSize first.
-	for _, t := range toAdd {
-		s.totalSize += t.Size()
-		t.IncrRef()
-		s.tables = append(s.tables, t)
-	}
+	s.totalSize += t.Size() // Increase totalSize first.
+	t.IncrRef()
+	s.tables = append(s.tables, t)
 }
 
 // sortTables sorts tables of levelHandler based on table.Smallest.
+// Normally it should be called after all addTable calls.
 func (s *levelHandler) sortTables() {
 	s.RLock()
 	defer s.RUnlock()

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -454,9 +454,11 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 	if err := w.db.manifest.addChanges([]*pb.ManifestChange{change}); err != nil {
 		return err
 	}
-	if err := lhandler.addTables([]*table.Table{tbl}); err != nil {
-		return err
-	}
+
+	// We are not calling lhandler.replaceTables() here, as it sorts tables on every addition.
+	// We can sort all tables only once during Flush() call.
+	lhandler.addTables([]*table.Table{tbl})
+
 	// Release the ref held by OpenTable.
 	_ = tbl.DecrRef()
 	w.db.opt.Infof("Table created: %d at level: %d for stream: %d. Size: %s\n",

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -457,7 +457,7 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 
 	// We are not calling lhandler.replaceTables() here, as it sorts tables on every addition.
 	// We can sort all tables only once during Flush() call.
-	lhandler.addTables([]*table.Table{tbl})
+	lhandler.addTable(tbl)
 
 	// Release the ref held by OpenTable.
 	_ = tbl.DecrRef()

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -243,6 +243,11 @@ func (sw *StreamWriter) Flush() error {
 		return err
 	}
 
+	// Sort tables at the end.
+	for _, l := range sw.db.lc.levels {
+		l.sortTables()
+	}
+
 	// Now sync the directories, so all the files are registered.
 	if sw.db.opt.ValueDir != sw.db.opt.Dir {
 		if err := syncDir(sw.db.opt.ValueDir); err != nil {
@@ -449,7 +454,7 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 	if err := w.db.manifest.addChanges([]*pb.ManifestChange{change}); err != nil {
 		return err
 	}
-	if err := lhandler.replaceTables([]*table.Table{}, []*table.Table{tbl}); err != nil {
+	if err := lhandler.addTables([]*table.Table{tbl}); err != nil {
 		return err
 	}
 	// Release the ref held by OpenTable.


### PR DESCRIPTION
Found out this while running dgraph bulk loader.

```go
(pprof) top --cum
Showing nodes accounting for 20.62s, 65.09% of 31.68s total
Dropped 113 nodes (cum <= 0.16s)
Showing top 10 nodes out of 45
      flat  flat%   sum%        cum   cum%
         0     0%     0%     28.62s 90.34%  github.com/dgraph-io/badger/v2.(*sortedWriter).createTable
         0     0%     0%     28.62s 90.34%  github.com/dgraph-io/badger/v2.(*sortedWriter).send.func1
     0.84s  2.65%  2.65%     28.61s 90.31%  github.com/dgraph-io/badger/v2.(*levelHandler).replaceTables
         0     0%  2.65%     27.50s 86.81%  sort.Slice
     0.07s  0.22%  2.87%     27.50s 86.81%  sort.quickSort_func
     1.30s  4.10%  6.98%     26.78s 84.53%  sort.doPivot_func
     1.24s  3.91% 10.89%     25.86s 81.63%  github.com/dgraph-io/badger/v2.(*levelHandler).replaceTables.func1
     1.60s  5.05% 15.94%     17.55s 55.40%  github.com/dgraph-io/badger/v2/y.CompareKeys
     0.19s   0.6% 16.54%     15.95s 50.35%  bytes.Compare
    15.38s 48.55% 65.09%     15.38s 48.55%  cmpbody
```

In `createTable` method of `StreamWriter` we are calling `levelHandler.replaceTables` method. This method adds table to `leveHandler` tables and sorts table based on `table.Smallest`. This sorting is required if we are adding tables and also querying `Badger`. In StreamWriter we just write data and hence we can avoid sorting on every addition of table. After we are done adding all tables, we can sort tables on all levels based on `table.Smallest`.

Ran below program on `master` and `This PR`.

```go
package main

import (
	"fmt"
	"io/ioutil"
	"os"

	badger "github.com/dgraph-io/badger"
	"github.com/dgraph-io/badger/pb"
)

func insert(sw *badger.StreamWriter) {
	var val [10]byte
	list := &pb.KVList{}
	for i := 0; i < 100000; i++ {
		list.Kv = list.Kv[:0]
		kv1 := &pb.KV{
			Key:      []byte(fmt.Sprintf("%4d", i)),
			Value:    val[:],
			Version:  1,
			StreamId: uint32(i),
		}
		kv2 := &pb.KV{
			StreamId:   uint32(i),
			StreamDone: true,
		}
		list.Kv = append(list.Kv, kv1, kv2)
		if err := sw.Write(list); err != nil {
			panic("sw.Write() failed " + err.Error())
		}

	}
}

func main() {
	dir, err := ioutil.TempDir(".", "badger-test")
	if err != nil {
		panic(err)
	}
	defer func() {
		if err := os.RemoveAll(dir); err != nil {
			panic(err)
		}
	}()
	opts := badger.DefaultOptions(dir)
	db, err := badger.Open(opts)
	if err != nil {
		panic("unable to open db " + err.Error())
	}
	defer func() {
		if err := db.Close(); err != nil {
			panic("unable to close db " + err.Error())
		}
	}()

	sw := db.NewStreamWriter()
	if err := sw.Prepare(); err != nil {
		panic("sw.Prepare() failed " + err.Error())
	}

	insert(sw)

	if err := sw.Flush(); err != nil {
		panic("sw.Flush() failed " + err.Error())
	}
}
```

Time to run:
**Master**: `2143.86s user 25.89s system 107% cpu 33:47.75 total`
**This PR**: `63.28s user 22.79s system 23% cpu 6:13.93 total`

**Note: Time difference to complete above program will increase more between `master` and `This PR` with increase in number of streams.**

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1132)
<!-- Reviewable:end -->
