### PR TITLE
Fix VerifyValueChecksum checks

### DIFF
--- a/value.go
+++ b/value.go
@@ -1418,7 +1418,7 @@ func (vlog *valueLog) Read(vp valuePointer, s *y.Slice) ([]byte, func(), error) 
 
 	if vlog.opt.VerifyValueChecksum {
 		hash := crc32.New(y.CastagnoliCrcTable)
-		if _, err := hash.Write(buf); err != nil {
+		if _, err := hash.Write(buf[:len(buf)-crc32.Size]); err != nil {
 			runCallback(cb)
 			return nil, nil, errors.Wrapf(err, "failed to write hash for vp %+v", vp)
 		}


### PR DESCRIPTION
Fixes #1127 

Issue was that crc32 value read from log was included when recomputing hash value for verification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1138)
<!-- Reviewable:end -->
