### PR TITLE
Fix value log `dropAll` race condition

### DIFF
--- a/value.go
+++ b/value.go
@@ -756,10 +756,10 @@ func (vlog *valueLog) dropAll() (int, error) {
 	}
 
 	vlog.db.opt.Infof("Value logs deleted. Creating value log file: 0")
+	atomic.StoreUint32(&vlog.maxFid, 0)
 	if _, err := vlog.createVlogFile(0); err != nil {
 		return count, err
 	}
-	atomic.StoreUint32(&vlog.maxFid, 0)
 	return count, nil
 }
 


### PR DESCRIPTION
Fixes #1131

After reading #1136, I spend a fair bit of time tracing the locking/unlocking and I was convinced nothing is wrong with it (although I might very well have missed something). That's when I reread the error in #1131 and noticed that the fault is a `SIGBUS`, not `SIGSEGV`. 

On the man page of `mmap`, it says that `SIGBUS` may occur when accessing `a portion of the buffer that does not correspond to the file (for example, beyond the end of the file, including the case where another process has truncated the file).` Interestingly, in Go, slicing the `[]byte` returned by `unix.Mmap` beyond the end of the backing file will be completely fine, but attempting to read from that slice would cause the `SIGBUS` exception to be thrown. Here's a minimal example that demonstrates this behaviour.

Code:
```go
func main() {
	f, _ := os.Open("example") // this is a 0-length file
	mtype := unix.PROT_READ
	buf, _ := unix.Mmap(int(f.Fd()), 0, int(2048), mtype, unix.MAP_SHARED)
	slice := buf[10:20]
	fmt.Println("sliced", len(slice))
	fmt.Println(slice[0])
}
```
Output:
```
sliced 10
unexpected fault address 0x7f645d87300a
fatal error: fault
[signal SIGBUS: bus error code=0x2 addr=0x7f645d87300a pc=0x48e0de]
```

Here's what I think leads to the error in the test. 

At the end of `vlog.dropAll()`, `createLogFile(0)` is called. The following steps are performed:
 
1. A `logFile` is created with minimal size (I believe it only contains the `vlog header`).
1. This log file is `mmap`-ed with the following statement `lf.mmap(2 * vlog.opt.ValueLogFileSize)`. 
1. `vlog.writableLogOffset` is set. 
1. Log file `0` is added to `vlog.filesMap`.
1. `vlog.maxFid` is set. 

Between steps 4 and 5, there is a narrow window where a reader can call `vlog.Read` on to access log file `0` with an invalid offset if the previous value of `vlog.maxFid` is not `0`. Since `vlog.maxFid` has not been updated, `vp.Fid == maxFid && vp.Offset >= vlog.woffset()` evaluates to false. `readValueBytes` executes without error since `lf.read` only slices `lf.fmap`. Finally, `h.Decode` triggers the `SIGBUS`.

The fix in this PR is the minimal change that I believe is necessary to resolve the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1140)
<!-- Reviewable:end -->
