### PR TITLE
Fixed Txn size calculation and ensure write after first Set call in case of ErrTxnTooBig

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -161,10 +161,10 @@ func (l *KVLoader) Set(kv *pb.KV) error {
 		ExpiresAt: kv.ExpiresAt,
 		meta:      meta,
 	}
-	estimatedSize := int64(e.estimateSize(l.db.opt.ValueThreshold))
+	estimatedSize := int64(e.estimateSize())
 	// Flush entries if inserting the next entry would overflow the transactional limits.
 	if int64(len(l.entries))+1 >= l.db.opt.maxBatchCount ||
-		l.entriesSize+estimatedSize >= l.db.opt.maxBatchSize {
+		l.entriesSize+estimatedSize >= l.db.opt.MaxBatchSize {
 		if err := l.send(); err != nil {
 			return err
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -1547,14 +1547,6 @@ func TestLSMOnly(t *testing.T) {
 	_, err = Open(dopts)
 	require.Contains(t, err.Error(), "Invalid ValueThreshold")
 
-	// Also test for error, when ValueThresholdSize is greater than maxBatchSize.
-	dopts.ValueThreshold = LSMOnlyOptions(dir).ValueThreshold
-	// maxBatchSize is calculated from MaxTableSize.
-	dopts.MaxTableSize = int64(LSMOnlyOptions(dir).ValueThreshold)
-	_, err = Open(dopts)
-	require.Error(t, err, "db creation should have been failed")
-	require.Contains(t, err.Error(), "Valuethreshold greater than max batch size")
-
 	opts.ValueLogMaxEntries = 100
 	db, err := Open(opts)
 	require.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -55,6 +55,7 @@ type Options struct {
 	// Fine tuning options.
 
 	MaxTableSize        int64
+	MaxBatchSize        int64
 	LevelSizeMultiplier int
 	MaxLevels           int
 	ValueThreshold      int
@@ -96,7 +97,6 @@ type Options struct {
 	// 4. Flags for testing purposes
 	// ------------------------------
 	maxBatchCount int64 // max entries in batch
-	maxBatchSize  int64 // max batch size in bytes
 }
 
 // DefaultOptions sets a list of recommended options for good performance.
@@ -153,6 +153,7 @@ func DefaultOptions(path string) Options {
 		EventLogging:                  true,
 		EncryptionKey:                 []byte{},
 		EncryptionKeyRotationDuration: 10 * 24 * time.Hour, // Default 10 days.
+		MaxBatchSize:                  500 << (10 * 2),     // Default 500MB
 	}
 }
 
@@ -563,5 +564,15 @@ func (opt Options) WithInmemory(b bool) Options {
 // The default value of ZSTDCompressionLevel is 15.
 func (opt Options) WithZSTDCompressionLevel(cLevel int) Options {
 	opt.ZSTDCompressionLevel = cLevel
+	return opt
+}
+
+// WithMaxBatchSize returns a new Options value with MaxBatchSize set
+// to the given value.
+//
+// This value specifies the maximum number of bytes that can being written in
+// a single Transaction.
+func (opt Options) WithMaxBatchSize(size int64) Options {
+	opt.MaxBatchSize = size
 	return opt
 }

--- a/structs.go
+++ b/structs.go
@@ -150,11 +150,8 @@ type Entry struct {
 	hlen     int // Length of the header.
 }
 
-func (e *Entry) estimateSize(threshold int) int {
-	if len(e.Value) < threshold {
-		return len(e.Key) + len(e.Value) + 2 // Meta, UserMeta
-	}
-	return len(e.Key) + 12 + 2 // 12 for ValuePointer, 2 for metas.
+func (e *Entry) estimateSize() int {
+	return len(e.Key) + len(e.Value) + 2 // Meta, UserMeta
 }
 
 func (e Entry) print(prefix string) {

--- a/txn.go
+++ b/txn.go
@@ -295,11 +295,8 @@ func (txn *Txn) newPendingWritesIterator(reversed bool) *pendingWritesIterator {
 func (txn *Txn) checkSize(e *Entry) error {
 	count := txn.count + 1
 	// Extra bytes for the version in key.
-	// Choossing not to use e.estimateSize here since the value returned is inaccurate when e.Value > ValueThreshold.
-	// The entire entry ends up being stored in txn.pendingWrites so this is a more conservative approach that avoids OOM
-	// errors in the case that the user is writing lots of large values in a txn.
-	size := txn.size + int64(len(e.Key)+len(e.Value)+2) + 10
-	if count >= txn.db.opt.maxBatchCount || size >= txn.db.opt.maxBatchSize {
+	size := txn.size + int64(e.estimateSize()) + 10
+	if count >= txn.db.opt.maxBatchCount || size >= txn.db.opt.MaxBatchSize {
 		return ErrTxnTooBig
 	}
 	txn.count, txn.size = count, size

--- a/value.go
+++ b/value.go
@@ -545,10 +545,10 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 			}
 
 			ne.Value = append([]byte{}, e.Value...)
-			es := int64(ne.estimateSize(vlog.opt.ValueThreshold))
+			es := int64(ne.estimateSize())
 			// Ensure length and size of wb is within transaction limits.
 			if int64(len(wb)+1) >= vlog.opt.maxBatchCount ||
-				size+es >= vlog.opt.maxBatchSize {
+				size+es >= vlog.opt.MaxBatchSize {
 				tr.LazyPrintf("request has %d entries, size %d", len(wb), size)
 				if err := vlog.db.batchSet(wb); err != nil {
 					return err


### PR DESCRIPTION
This PR address a scenario that causes an OOM error.  

The Txn size is underestimated due to the calculation here: https://github.com/dgraph-io/badger/blob/407e5bde06c44e5503dc1eaf5a11cc9f2f348ac4/structs.go#L153

Since pending writes are stored in `*Txn.pendingWrites`, if you try to write thousands of large entries (~16mb in my use case) during a transaction (or using WriteBatch) you will encounter an OOM. 

I encountered this issue while using WriteBatch.  The code snippet below approximates my use case.
```
package main

import (
	"math/rand"
	"os"
	"time"

	"github.com/dgraph-io/badger"
	"github.com/sirupsen/logrus"
)

var logger *logrus.Logger
var log *logrus.Entry

func init() {
	logger = logrus.New()
	logger.SetLevel(logrus.DebugLevel)
	logger.SetFormatter(&logrus.JSONFormatter{
		TimestampFormat: time.RFC3339,
	})
	log = logger.WithFields(logrus.Fields{"ns": "main"})
}

func makeRandBytes(size int) []byte {
	val := make([]byte, size)
	_, err := rand.Read(val)
	if err != nil {
		log.Error("generating random bytes:", err)
		return val
	}
	return val
}

func write(tx *badger.WriteBatch, n int, valueSize int) {
	for j := 0; j < n; j++ {
		key := makeRandBytes(16)
		val := makeRandBytes(valueSize)
		err := tx.Set(key, val)
		if err != nil {
			log.Error("set:", err)
			continue
		}
		if j%100 == 0 {
			log.Infof("set %d items", j)
		}
	}
}

func main() {
	sub := logger.WithFields(logrus.Fields{"ns": "badger"})
	path := "./badger.db"
	opts := badger.DefaultOptions(path)
	opts = opts.WithLogger(sub)
	db, err := badger.Open(opts)
	if err != nil {
		log.Error("open badger:", err)
		os.Exit(1)
	}

	bt := db.NewWriteBatch()
	defer bt.Cancel()
        write(bt, 20000, 16000000)
	log.Infof("flush")
	err = bt.Flush()
	if err != nil {
		log.Error("flush err:", err)
	}
	log.Infof("done")
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1143)
<!-- Reviewable:end -->
