### PR TITLE
Fix removeDir function in tests.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -2025,11 +2025,9 @@ func ExampleDB_Subscribe() {
 	// a-key is now set to a-value
 }
 
-func removeDir(dir string) func() {
-	return func() {
-		if err := os.RemoveAll(dir); err != nil {
-			panic(err)
-		}
+func removeDir(dir string) {
+	if err := os.RemoveAll(dir); err != nil {
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
All the usages of removeDir only called the function itself and not the returned func. This change does away with the returned func, so calling removeDir will remove the badger directories during the test.

I had a bunch of badger test directories in /tmp after running tests. Now that's all cleaned up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1145)
<!-- Reviewable:end -->
