### PR TITLE
Fix encryption in stream writer

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -442,6 +442,7 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 	// Now that table can be opened successfully, let's add this to the MANIFEST.
 	change := &pb.ManifestChange{
 		Id:          tbl.ID(),
+		KeyId:       tbl.KeyID(),
 		Op:          pb.ManifestChange_CREATE,
 		Level:       uint32(lhandler.level),
 		Compression: uint32(tbl.CompressionType()),


### PR DESCRIPTION
We store information about tables in the table manifest. When stream
writer would create a new table, it wouldn't store the key ID for the
respective table in the manifest file. This commit fixes it.


Fixes https://github.com/dgraph-io/badger/issues/1144

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1146)
<!-- Reviewable:end -->
