### PR TITLE
Separate darwin syscalls for mmap

### DIFF
--- a/y/mmap.go
+++ b/y/mmap.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin
+// +build !windows
 
 /*
  * Copyright 2017 Dgraph Labs, Inc. and Contributors
@@ -20,32 +20,22 @@ package y
 
 import (
 	"os"
-
-	"golang.org/x/sys/unix"
 )
 
 // Mmap uses the mmap system call to memory-map a file. If writable is true,
 // memory protection of the pages is set so that they may be written to as well.
-func mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
-	mtype := unix.PROT_READ
-	if writable {
-		mtype |= unix.PROT_WRITE
-	}
-	return unix.Mmap(int(fd.Fd()), 0, int(size), mtype, unix.MAP_SHARED)
+func Mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
+	return mmap(fd, writable, size)
 }
 
 // Munmap unmaps a previously mapped slice.
-func munmap(b []byte) error {
-	return unix.Munmap(b)
+func Munmap(b []byte) error {
+	return munmap(b)
 }
 
 // Madvise uses the madvise system call to give advise about the use of memory
 // when using a slice that is memory-mapped to a file. Set the readahead flag to
 // false if page references are expected in random order.
-func madvise(b []byte, readahead bool) error {
-	flags := unix.MADV_NORMAL
-	if !readahead {
-		flags = unix.MADV_RANDOM
-	}
-	return unix.Madvise(b, flags)
+func Madvise(b []byte, readahead bool) error {
+	return madvise(b, readahead)
 }

--- a/y/mmap.go
+++ b/y/mmap.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
  * Copyright 2019 Dgraph Labs, Inc. and Contributors
  *

--- a/y/mmap.go
+++ b/y/mmap.go
@@ -1,7 +1,7 @@
 // +build !windows
 
 /*
- * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/y/mmap_darwin.go
+++ b/y/mmap_darwin.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package y
 
 import (

--- a/y/mmap_darwin.go
+++ b/y/mmap_darwin.go
@@ -1,0 +1,39 @@
+package y
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Mmap uses the mmap system call to memory-map a file. If writable is true,
+// memory protection of the pages is set so that they may be written to as well.
+func mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
+	mtype := unix.PROT_READ
+	if writable {
+		mtype |= unix.PROT_WRITE
+	}
+	return unix.Mmap(int(fd.Fd()), 0, int(size), mtype, unix.MAP_SHARED)
+}
+
+// Munmap unmaps a previously mapped slice.
+func munmap(b []byte) error {
+	return unix.Munmap(b)
+}
+
+// This is required because the unix package does not support the madvise system call on OS X.
+func madvise(b []byte, readahead bool) error {
+	advice := unix.MADV_NORMAL
+	if !readahead {
+		advice = unix.MADV_RANDOM
+	}
+
+	_, _, e1 := syscall.Syscall(syscall.SYS_MADVISE, uintptr(unsafe.Pointer(&b[0])),
+		uintptr(len(b)), uintptr(advice))
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}

--- a/y/mmap_unix.go
+++ b/y/mmap_unix.go
@@ -1,7 +1,7 @@
 // +build !windows,!darwin
 
 /*
- * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/y/mmap_windows.go
+++ b/y/mmap_windows.go
@@ -1,7 +1,7 @@
 // +build windows
 
 /*
- * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/y/mmap_windows.go
+++ b/y/mmap_windows.go
@@ -25,7 +25,7 @@ import (
 	"unsafe"
 )
 
-func Mmap(fd *os.File, write bool, size int64) ([]byte, error) {
+func mmap(fd *os.File, write bool, size int64) ([]byte, error) {
 	protect := syscall.PAGE_READONLY
 	access := syscall.FILE_MAP_READ
 
@@ -81,11 +81,11 @@ func Mmap(fd *os.File, write bool, size int64) ([]byte, error) {
 	return data, nil
 }
 
-func Munmap(b []byte) error {
+func munmap(b []byte) error {
 	return syscall.UnmapViewOfFile(uintptr(unsafe.Pointer(&b[0])))
 }
 
-func Madvise(b []byte, readahead bool) error {
+func madvise(b []byte, readahead bool) error {
 	// Do Nothing. We don’t care about this setting on Windows
 	return nil
 }


### PR DESCRIPTION
Using the `unix` package by default for other systems instead of `syscall`.

This way when systems get added to `unix`, they will work without change.
And the special case is restricted only to darwin builds.

I encountered problems building on Solaris prior to this patch:
`github.com/dgraph-io/badger/y/mmap_unix.go:57:30: undefined: syscall.SYS_MADVISE`
But `unix.Madvise` works fine on that platform (and others).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1149)
<!-- Reviewable:end -->
