### PR TITLE
Fix segmentation fault in vlog.Read

### DIFF
--- a/value.go
+++ b/value.go
@@ -854,7 +854,10 @@ func (lf *logFile) open(path string, flags uint32) error {
 	if err != nil {
 		return errFile(err, lf.path, "Unable to run file.Stat")
 	}
-	if fi.Size() < vlogHeaderSize {
+	sz := fi.Size()
+	y.AssertTruef(sz <= math.MaxUint32, "file size: %d greater than %d", sz, math.MaxUint32)
+	lf.size = uint32(sz)
+	if sz < vlogHeaderSize {
 		// Every vlog file should have at least vlogHeaderSize. If it is less than vlogHeaderSize
 		// then it must have been corrupted. But no need to handle here. log replayer will truncate
 		// and bootstrap the logfile. So ignoring here.

--- a/value.go
+++ b/value.go
@@ -228,8 +228,8 @@ func (lf *logFile) read(p valuePointer, s *y.Slice) (buf []byte, err error) {
 		valsz := p.Len
 		lfsz := atomic.LoadUint32(&lf.size)
 		if int64(offset) >= size || int64(offset+valsz) > size ||
-			// Ensure the read is within the file's actual size. It might be possible that the
-			// offset+valsz length is beyond the file's actual size. This could happen when
+			// Ensure that the read is within the file's actual size. It might be possible that
+			// the offset+valsz length is beyond the file's actual size. This could happen when
 			// dropAll and iterations are running simultaneously.
 			int64(offset+valsz) > int64(lfsz) {
 			err = y.ErrEOF

--- a/value.go
+++ b/value.go
@@ -1322,7 +1322,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 		y.NumBytesWritten.Add(int64(n))
 		vlog.elog.Printf("Done")
 		atomic.AddUint32(&vlog.writableLogOffset, uint32(n))
-		atomic.AddUint32(&curlf.size, uint32(n))
+		atomic.StoreUint32(&curlf.size, vlog.writableLogOffset)
 		return nil
 	}
 	toDisk := func() error {

--- a/value.go
+++ b/value.go
@@ -1317,7 +1317,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 		y.NumWrites.Add(1)
 		y.NumBytesWritten.Add(int64(n))
 		vlog.elog.Printf("Done")
-		atomic.AddUint32(&vlog.writableLogOffset, uint32(n))
+		curlf.size = atomic.AddUint32(&vlog.writableLogOffset, uint32(n))
 		return nil
 	}
 	toDisk := func() error {


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/1136 and https://github.com/dgraph-io/badger/issues/1131


## The problem
In both the reported issues the segmentation fault would occur after `vlog.DropAll` (or if the log file was deleted). In case of dropAll, here's how we delete files
https://github.com/dgraph-io/badger/blob/8b99eb433aa799029b2e4cecc3c6e9b19c527490/value.go#L739-L757

At the same time, there could be a read on the same vlog file. Here's the code that reads from the file
https://github.com/dgraph-io/badger/blob/8b99eb433aa799029b2e4cecc3c6e9b19c527490/value.go#L1411-L1419

The problem occurs if we try to access the `buf` returned by `readValueBytes`. There is a window in which if we try to access the `buf`, we get a segmentation fault.

The following sequence of events would cause the segmentation fault.
1. `vlog.Read` is called and the control is at line 1411
https://github.com/dgraph-io/badger/blob/8b99eb433aa799029b2e4cecc3c6e9b19c527490/value.go#L1411-L1419 
2. `vlog.DropAll` is called at the same time. `vlog.DropAll` completes while the control is at line 1411 in `vlog.Read`. This essentially means all the log files are deleted and a new `vlog0` file is created. This file has a `fmap` (mmap buffer) of `2 GB` and the file size is `0` bytes (since we haven't written anything)
3. Now, the execution continues on `vlog.Read` and `header.Decode` (which is were the buf accessed for the first time) crashes with Segmentation fault ( `SIGBUS` error). As mentioned in comment https://github.com/dgraph-io/badger/pull/1140#issue-346833259, the `SIGBUS` occurs when we try to access a mmap buffer which is beyond the actual file size. 

With the following changes, I was able to reproduce the segmentation fault. Notice that we stop the execution at `line 1411` in `vlog.Read` until `DropAll` completes.

```diff
diff --git a/managed_db_test.go b/managed_db_test.go
index 5a25174..c4e27ba 100644
--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -209,7 +209,10 @@ func TestDropAllWithPendingTxn(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		itr := txn.NewIterator(DefaultIteratorOptions)
+		d := DefaultIteratorOptions
+		// This is necessary otherwise we'll run into a deadlock in this test.
+		d.PrefetchValues = false
+		itr := txn.NewIterator(d)
 		defer itr.Close()
 
 		var keys []string
@@ -246,6 +249,7 @@ func TestDropAllWithPendingTxn(t *testing.T) {
 		defer wg.Done()
 		time.Sleep(2 * time.Second)
 		require.NoError(t, db.DropAll())
+		db.vlog.ch <- struct{}{}
 	}()
 	wg.Wait()
 }
diff --git a/value.go b/value.go
index b28b2b1..a63a519 100644
--- a/value.go
+++ b/value.go
@@ -780,6 +780,7 @@ type lfDiscardStats struct {
 
 type valueLog struct {
 	dirPath string
+	ch      chan struct{}
 	elog    trace.EventLog
 
 	// guards our view of which files exist, which to be deleted, how many active iterators
@@ -1004,6 +1005,7 @@ func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) e
 func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 	vlog.opt = db.opt
 	vlog.db = db
+	vlog.ch = make(chan struct{}, 1)
 	// We don't need to open any vlog files or collect stats for GC if DB is opened
 	// in InMemory mode. InMemory mode doesn't create any files/directories on disk.
 	if vlog.opt.InMemory {
@@ -1413,6 +1415,7 @@ func (vlog *valueLog) Read(vp valuePointer, s *y.Slice) ([]byte, func(), error)
 			"Invalid value pointer offset: %d greater than current offset: %d",
 			vp.Offset, vlog.woffset())
 	}
+	<-vlog.ch
 	buf, lf, err := vlog.readValueBytes(vp, s)
 	// log file is locked so, decide whether to lock immediately or let the caller to
 	// unlock it, after caller uses it.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1150)
<!-- Reviewable:end -->
