### PR TITLE
Backport fix for issue #1090 Data Loss during GC

### DIFF
--- a/db.go
+++ b/db.go
@@ -539,7 +539,7 @@ func (db *DB) get(key []byte) (y.ValueStruct, error) {
 			*maxVs = vs
 		}
 	}
-	return db.lc.get(key, maxVs)
+	return db.lc.get(key, maxVs, 0)
 }
 
 func (db *DB) updateHead(ptrs []valuePointer) {
@@ -1039,7 +1039,7 @@ func (db *DB) RunValueLogGC(discardRatio float64) error {
 	// Find head on disk
 	headKey := y.KeyWithTs(head, math.MaxUint64)
 	// Need to pass with timestamp, lsm get removes the last 8 bytes and compares key
-	val, err := db.lc.get(headKey, nil)
+	val, err := db.lc.get(headKey, nil, 0)
 	if err != nil {
 		return errors.Wrap(err, "Retrieving head from on-disk LSM")
 	}

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/levels.go
+++ b/levels.go
@@ -899,7 +899,8 @@ func (s *levelsController) close() error {
 }
 
 // get returns the found value if any. If not found, we return nil.
-func (s *levelsController) get(key []byte, maxVs *y.ValueStruct, startLevel int) (y.ValueStruct, error) {
+func (s *levelsController) get(key []byte, maxVs *y.ValueStruct, startLevel int) (
+	y.ValueStruct, error) {
 	// It's important that we iterate the levels from 0 on upward.  The reason is, if we iterated
 	// in opposite order, or in parallel (naively calling all the h.RLock() in some order) we could
 	// read level L's tables post-compaction and level L+1's tables pre-compaction.  (If we do

--- a/levels.go
+++ b/levels.go
@@ -899,7 +899,7 @@ func (s *levelsController) close() error {
 }
 
 // get returns the found value if any. If not found, we return nil.
-func (s *levelsController) get(key []byte, maxVs *y.ValueStruct) (y.ValueStruct, error) {
+func (s *levelsController) get(key []byte, maxVs *y.ValueStruct, startLevel int) (y.ValueStruct, error) {
 	// It's important that we iterate the levels from 0 on upward.  The reason is, if we iterated
 	// in opposite order, or in parallel (naively calling all the h.RLock() in some order) we could
 	// read level L's tables post-compaction and level L+1's tables pre-compaction.  (If we do
@@ -907,6 +907,10 @@ func (s *levelsController) get(key []byte, maxVs *y.ValueStruct) (y.ValueStruct,
 	// number.)
 	version := y.ParseTs(key)
 	for _, h := range s.levels {
+		// Ignore all levels below startLevel. This is useful for GC when L0 is kept in memory.
+		if h.level < startLevel {
+			continue
+		}
 		vs, err := h.get(key) // Calls h.RLock() and h.RUnlock().
 		if err != nil {
 			return y.ValueStruct{}, errors.Wrapf(err, "get key: %q", key)


### PR DESCRIPTION
This is an experiment, please tell me if this is absolutely crazy but I have run the tests and they still pass. I know I could wait until 2.0.0 is officially released.

We have been seeing data loss using 1.6.0 and wondered whether the fix #1090 would work despite it using options introduced in 2.0. 

To reproduce on 1.6.0, I create  a key with a default value, I then update the key with a different value and then call close and the key disappears. It looks like its the Garbage collection in the close that is doing it. If I update the key a second time with a different value before calling close they key persists.

	options = badger.DefaultOptions(storageDir).WithNumVersionsToKeep(0).WithMaxTableSize(32 << 20).WithValueLogFileSize(640 << 20).WithSyncWrites(true)

These are the options we are using. It would appear that if I remove WithNumVersionsToKeep(0) the data loss stops happening but the DB directory keeps growing due to the size of the vlog file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1152)
<!-- Reviewable:end -->
