### PR TITLE
Fix merge iterator duplicates issue

### DIFF
--- a/table/merge_iterator.go
+++ b/table/merge_iterator.go
@@ -160,11 +160,7 @@ func (mi *MergeIterator) Next() {
 }
 
 func (mi *MergeIterator) setCurrent() {
-	if cap(mi.curKey) < len(mi.small.key) {
-		mi.curKey = make([]byte, 2*len(mi.small.key))
-	}
-	mi.curKey = mi.curKey[:len(mi.small.key)]
-	copy(mi.curKey, mi.small.key)
+	mi.curKey = append(mi.curKey[:0], mi.small.key...)
 }
 
 // Rewind seeks to first element (or last element for reverse iterator).

--- a/table/merge_iterator_test.go
+++ b/table/merge_iterator_test.go
@@ -157,37 +157,6 @@ func TestMergeSingleReversed(t *testing.T) {
 	require.EqualValues(t, reversed(vals), v)
 	closeAndCheck(t, mergeIt, 1)
 }
-func TestMergeDuplicates(t *testing.T) {
-	it := newSimpleIterator([]string{"1", "1", "1"}, []string{"a1", "a3", "a7"}, false)
-	it2 := newSimpleIterator([]string{"1", "1", "1"}, []string{"b2", "b3", "b5"}, false)
-	it3 := newSimpleIterator([]string{"1"}, []string{"c1"}, false)
-	it4 := newSimpleIterator([]string{"1", "1", "2"}, []string{"d1", "d7", "d9"}, false)
-	t.Run("forward", func(t *testing.T) {
-		expectedKeys := []string{"1", "2"}
-		expectedVals := []string{"a1", "d9"}
-		mergeIt := NewMergeIterator([]y.Iterator{it, it2, it3, it4}, false)
-		mergeIt.Rewind()
-		k, v := getAll(mergeIt)
-		require.EqualValues(t, expectedKeys, k)
-		require.EqualValues(t, expectedVals, v)
-		closeAndCheck(t, mergeIt, 4)
-	})
-
-	t.Run("reverse", func(t *testing.T) {
-		it.reversed = true
-		it2.reversed = true
-		it3.reversed = true
-		it4.reversed = true
-		expectedKeys := []string{"2", "1"}
-		expectedVals := []string{"d9", "a7"}
-		mergeIt := NewMergeIterator([]y.Iterator{it, it2, it3, it4}, true)
-		mergeIt.Rewind()
-		k, v := getAll(mergeIt)
-		require.EqualValues(t, expectedKeys, k)
-		require.EqualValues(t, expectedVals, v)
-		closeAndCheck(t, mergeIt, 4)
-	})
-}
 
 func TestMergeMore(t *testing.T) {
 	it := newSimpleIterator([]string{"1", "3", "7"}, []string{"a1", "a3", "a7"}, false)
@@ -365,5 +334,37 @@ func TestMergeIteratorDuplicate(t *testing.T) {
 		k, v := getAll(it)
 		require.Equal(t, expectedKeys, k)
 		require.Equal(t, expectedVals, v)
+	})
+}
+
+func TestMergeDuplicates(t *testing.T) {
+	it := newSimpleIterator([]string{"1", "1", "1"}, []string{"a1", "a3", "a7"}, false)
+	it2 := newSimpleIterator([]string{"1", "1", "1"}, []string{"b2", "b3", "b5"}, false)
+	it3 := newSimpleIterator([]string{"1"}, []string{"c1"}, false)
+	it4 := newSimpleIterator([]string{"1", "1", "2"}, []string{"d1", "d7", "d9"}, false)
+	t.Run("forward", func(t *testing.T) {
+		expectedKeys := []string{"1", "2"}
+		expectedVals := []string{"a1", "d9"}
+		mergeIt := NewMergeIterator([]y.Iterator{it, it2, it3, it4}, false)
+		mergeIt.Rewind()
+		k, v := getAll(mergeIt)
+		require.EqualValues(t, expectedKeys, k)
+		require.EqualValues(t, expectedVals, v)
+		closeAndCheck(t, mergeIt, 4)
+	})
+
+	t.Run("reverse", func(t *testing.T) {
+		it.reversed = true
+		it2.reversed = true
+		it3.reversed = true
+		it4.reversed = true
+		expectedKeys := []string{"2", "1"}
+		expectedVals := []string{"d9", "a7"}
+		mergeIt := NewMergeIterator([]y.Iterator{it, it2, it3, it4}, true)
+		mergeIt.Rewind()
+		k, v := getAll(mergeIt)
+		require.EqualValues(t, expectedKeys, k)
+		require.EqualValues(t, expectedVals, v)
+		closeAndCheck(t, mergeIt, 4)
 	})
 }


### PR DESCRIPTION
Fixes: https://github.com/dgraph-io/badger/issues/1153

The tree-based merge iterator would not skip duplicate keys. This PR fixes it.
If merge iterator consists of 3 iterator
```
it1 = [1, 1, 1]
it2 = [1, 1, 1, 1, 2]
it3 = [1, 1, 1, 1, 2]
```
The result should be
```
[1, 2]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1157)
<!-- Reviewable:end -->
