### PR TITLE
Rename option builder from WithInmemory to WithInMemory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ Please note that Badger obtains a lock on the directories so multiple processes
 cannot open the same database at the same time.
 
 #### In-Memory Mode/Diskless Mode
-By default, badger ensures all the data is presisted to the disk. It also supports a pure
-`In-Memory` mode. When Badger is running in `in-memory` mode, all the data is stored in the memory.
-The read/writes are much faster in `in-memory` mode but all the data stored in badger will be lost
-in case of a crash or close. To open badger in `in-memory` mode, set the `InMemory` option.
+By default, Badger ensures all the data is persisted to the disk. It also supports a pure
+in-memory mode. When Badger is running in in-memory mode, all the data is stored in the memory.
+Reads and writes are much faster in in-memory mode, but all the data stored in Badger will be lost
+in case of a crash or close. To open badger in in-memory mode, set the `InMemory` option.
 
 ```
-opt := badger.DefaultOptions("").WithInmemory(true)
+opt := badger.DefaultOptions("").WithInMemory(true)
 ```
 
 ### Transactions

--- a/db_test.go
+++ b/db_test.go
@@ -283,7 +283,7 @@ func TestGet(t *testing.T) {
 		})
 	})
 	t.Run("InMemory mode", func(t *testing.T) {
-		opts := DefaultOptions("").WithInmemory(true)
+		opts := DefaultOptions("").WithInMemory(true)
 		db, err := Open(opts)
 		require.NoError(t, err)
 		test(t, db)
@@ -543,7 +543,7 @@ func TestExistsMore(t *testing.T) {
 		})
 	})
 	t.Run("InMemory mode", func(t *testing.T) {
-		opt := DefaultOptions("").WithInmemory(true)
+		opt := DefaultOptions("").WithInMemory(true)
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -617,7 +617,7 @@ func TestIterate2Basic(t *testing.T) {
 		})
 	})
 	t.Run("InMemory mode", func(t *testing.T) {
-		opt := DefaultOptions("").WithInmemory(true)
+		opt := DefaultOptions("").WithInMemory(true)
 		db, err := Open(opt)
 		require.NoError(t, err)
 		test(t, db)
@@ -1662,7 +1662,7 @@ func TestGoroutineLeak(t *testing.T) {
 		test(t, nil)
 	})
 	t.Run("InMemory mode", func(t *testing.T) {
-		opt := DefaultOptions("").WithInmemory(true)
+		opt := DefaultOptions("").WithInMemory(true)
 		test(t, &opt)
 	})
 }
@@ -2034,7 +2034,7 @@ func removeDir(dir string) {
 }
 
 func TestWriteInemory(t *testing.T) {
-	opt := DefaultOptions("").WithInmemory(true)
+	opt := DefaultOptions("").WithInMemory(true)
 	db, err := Open(opt)
 	require.NoError(t, err)
 	defer func() {

--- a/options.go
+++ b/options.go
@@ -549,7 +549,7 @@ func (opt Options) WithMaxCacheSize(size int64) Options {
 //
 // When badger is running in InMemory mode, everything is stored in memory. No value/sst files are
 // created. In case of a crash all data will be lost.
-func (opt Options) WithInmemory(b bool) Options {
+func (opt Options) WithInMemory(b bool) Options {
 	opt.InMemory = b
 	return opt
 }


### PR DESCRIPTION
The name of the option builder func should be spelled the same as the
option name itself.

The godoc already has the func documented as "WithInMemory".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1169)
<!-- Reviewable:end -->
