### PR TITLE
Remove global rand lock in skiplist

### DIFF
--- a/skl/skl.go
+++ b/skl/skl.go
@@ -80,7 +80,7 @@ type Skiplist struct {
 	head   *node
 	ref    int32
 	arena  *Arena
-	rng    rand.Source
+	rand   *rand.Rand
 }
 
 // IncrRef increases the refcount
@@ -134,7 +134,7 @@ func NewSkiplist(arenaSize int64) *Skiplist {
 		head:   head,
 		arena:  arena,
 		ref:    1,
-		rng:    rand.NewSource(time.Now().UnixNano()),
+		rand:   rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -170,7 +170,7 @@ func (s *node) casNextOffset(h int, old, val uint32) bool {
 
 func (s *Skiplist) randomHeight() int {
 	h := 1
-	for h < maxHeight && uint32(s.rng.Int63()) <= heightIncrease {
+	for h < maxHeight && s.rand.Uint32() <= heightIncrease {
 		h++
 	}
 	return h

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -170,6 +170,8 @@ func (s *node) casNextOffset(h int, old, val uint32) bool {
 
 func (s *Skiplist) randomHeight() int {
 	h := 1
+	// rand.Uint32() is not thread safe. Currently, all writes to memtable are sequential
+	// so it should be okay to use rand.Uint32.
 	for h < maxHeight && s.rand.Uint32() <= heightIncrease {
 		h++
 	}

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -516,3 +516,16 @@ func BenchmarkReadWriteMap(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkWrite(b *testing.B) {
+	value := newValue(123)
+	l := NewSkiplist(int64((b.N + 1) * MaxNodeSize))
+	defer l.DecrRef()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		for pb.Next() {
+			l.Put(randomKey(rng), y.ValueStruct{Value: value, Meta: 0, UserMeta: 0})
+		}
+	})
+}

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -499,7 +499,7 @@ func BenchmarkReadWriteMap(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				for pb.Next() {
-					if rand.Float32() < readFrac {
+					if rng.Float32() < readFrac {
 						mutex.RLock()
 						_, ok := m[string(randomKey(rng))]
 						mutex.RUnlock()

--- a/table/table.go
+++ b/table/table.go
@@ -317,13 +317,13 @@ func (t *Table) readNoFail(off, sz int) []byte {
 func (t *Table) readIndex() error {
 	readPos := t.tableSize
 
-	if readPos <= 0 {
-		return errors.New("readPos less than zero. Data corrupted")
-	}
 	// Read checksum len from the last 4 bytes.
 	readPos -= 4
 	buf := t.readNoFail(readPos, 4)
 	checksumLen := int(y.BytesToU32(buf))
+	if checksumLen < 0 {
+		return errors.New("checksum length less than zero. Data corrupted")
+	}
 
 	// Read checksum.
 	expectedChk := &pb.Checksum{}

--- a/table/table.go
+++ b/table/table.go
@@ -232,6 +232,7 @@ func OpenTable(fd *os.File, opts Options) (*Table, error) {
 	if err := t.initBiggestAndSmallest(); err != nil {
 		return nil, errors.Wrapf(err, "failed to initialize table")
 	}
+
 	if opts.ChkMode == options.OnTableRead || opts.ChkMode == options.OnTableAndBlockRead {
 		if err := t.VerifyChecksum(); err != nil {
 			_ = fd.Close()
@@ -316,6 +317,7 @@ func (t *Table) readNoFail(off, sz int) []byte {
 func (t *Table) readIndex() error {
 	readPos := t.tableSize
 
+	y.AssertTruef(readPos > 0, "readPos less than zero: %d", readPos)
 	// Read checksum len from the last 4 bytes.
 	readPos -= 4
 	buf := t.readNoFail(readPos, 4)

--- a/table/table.go
+++ b/table/table.go
@@ -317,7 +317,9 @@ func (t *Table) readNoFail(off, sz int) []byte {
 func (t *Table) readIndex() error {
 	readPos := t.tableSize
 
-	y.AssertTruef(readPos > 0, "readPos less than zero: %d", readPos)
+	if readPos <= 0 {
+		return errors.New("readPos less than zero. Data corrupted")
+	}
 	// Read checksum len from the last 4 bytes.
 	readPos -= 4
 	buf := t.readNoFail(readPos, 4)

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -743,7 +743,10 @@ func TestTableChecksum(t *testing.T) {
 	f := buildTestTable(t, "k", 10000, opts)
 	fi, err := f.Stat()
 	require.NoError(t, err, "unable to get file information")
-	f.WriteAt(rb, rand.Int63n(fi.Size()))
+	// Write random bytes at random location.
+	n, err := f.WriteAt(rb, rand.Int63n(fi.Size()))
+	require.NoError(t, err)
+	require.Equal(t, n, len(rb))
 
 	_, err = OpenTable(f, opts)
 	if err == nil || !strings.Contains(err.Error(), "checksum") {


### PR DESCRIPTION
The math/rand package (https://golang.org/src/math/rand/rand.go) uses a global lock to allow concurrent access to the rand object. We do not write to skiplist concurrently and hence we don't need a lock at all.

This blog has some interesting details https://blog.sgmansfield.com/2016/01/the-hidden-dangers-of-default-rand/

The PR replaces `math.Rand` with `ristretto/z.FastRand()`. `FastRand` is much faster than `math.Rand` and `rand.New(..)` generators.

The change improves concurrent writes to skiplist by ~30%
```go
func BenchmarkWrite(b *testing.B) {
	value := newValue(123)
	l := NewSkiplist(int64((b.N + 1) * MaxNodeSize))
	defer l.DecrRef()
	b.ResetTimer()
	b.RunParallel(func(pb *testing.PB) {
		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
		for pb.Next() {
			l.Put(randomKey(rng), y.ValueStruct{Value: value, Meta: 0, UserMeta: 0})
		}
	})
}
```
```
name      old time/op  new time/op  delta
Write-16   657ns ± 3%   441ns ± 1%  -32.94%  (p=0.000 n=9+10)
```


This PR also fixes the `test timed out after 10 minutes` issue on teamcity (see build https://teamcity.dgraph.io/viewLog.html?buildId=36889&buildTypeId=Badger_UnitTests#testNameId521499096021883325 )
The problem here is that the test `TestValueGCManaged` tries to create many bufferes with random data
https://github.com/dgraph-io/badger/blob/ea01d380cedea306b4c9e0e04d072c60cd55e973/value_test.go#L119-L124

The `rand.Read(...)` acquires a global lock (https://golang.org/src/math/rand/rand.go) and since `N=10,000` in the above test, it leads to starvation. We would have too many `rand.Read(...)` calls waiting to acquire the same lock. At the same time, every insert to skip list also needs to acquire the same lock 
https://github.com/dgraph-io/badger/blob/ea01d380cedea306b4c9e0e04d072c60cd55e973/skl/skl.go#L168-L174

Hence, the test wouldn't complete in 10 minutes and the build fails.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1173)
<!-- Reviewable:end -->
