### PR TITLE
Support disabling the cache completely. (#1183)

### DIFF
--- a/db.go
+++ b/db.go
@@ -278,17 +278,6 @@ func Open(opt Options) (db *DB, err error) {
 		elog = trace.NewEventLog("Badger", "DB")
 	}
 
-	config := ristretto.Config{
-		// Use 5% of cache memory for storing counters.
-		NumCounters: int64(float64(opt.MaxCacheSize) * 0.05 * 2),
-		MaxCost:     int64(float64(opt.MaxCacheSize) * 0.95),
-		BufferItems: 64,
-		Metrics:     true,
-	}
-	cache, err := ristretto.NewCache(&config)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create cache")
-	}
 	db = &DB{
 		imm:           make([]*skl.Skiplist, 0, opt.NumMemtables),
 		flushChan:     make(chan flushTask, opt.NumMemtables),
@@ -300,7 +289,20 @@ func Open(opt Options) (db *DB, err error) {
 		valueDirGuard: valueDirLockGuard,
 		orc:           newOracle(opt),
 		pub:           newPublisher(),
-		blockCache:    cache,
+	}
+
+	if opt.MaxCacheSize > 0 {
+		config := ristretto.Config{
+			// Use 5% of cache memory for storing counters.
+			NumCounters: int64(float64(opt.MaxCacheSize) * 0.05 * 2),
+			MaxCost:     int64(float64(opt.MaxCacheSize) * 0.95),
+			BufferItems: 64,
+			Metrics:     true,
+		}
+		db.blockCache, err = ristretto.NewCache(&config)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create cache")
+		}
 	}
 
 	if db.opt.InMemory {
@@ -386,7 +388,10 @@ func Open(opt Options) (db *DB, err error) {
 
 // CacheMetrics returns the metrics for the underlying cache.
 func (db *DB) CacheMetrics() *ristretto.Metrics {
-	return db.blockCache.Metrics
+	if db.blockCache != nil {
+		return db.blockCache.Metrics
+	}
+	return nil
 }
 
 // Close closes a DB. It's crucial to call it to ensure all the pending updates make their way to
@@ -477,7 +482,9 @@ func (db *DB) close() (err error) {
 	db.elog.Printf("Waiting for closer")
 	db.closers.updateSize.SignalAndWait()
 	db.orc.Stop()
-	db.blockCache.Close()
+	if db.blockCache != nil {
+		db.blockCache.Close()
+	}
 
 	db.elog.Finish()
 	if db.opt.InMemory {
@@ -1500,7 +1507,9 @@ func (db *DB) dropAll() (func(), error) {
 	db.vhead = valuePointer{} // Zero it out.
 	db.lc.nextFileID = 1
 	db.opt.Infof("Deleted %d value log files. DropAll done.\n", num)
-	db.blockCache.Clear()
+	if db.blockCache != nil {
+		db.blockCache.Clear()
+	}
 	return resume, nil
 }
 

--- a/db.go
+++ b/db.go
@@ -482,9 +482,7 @@ func (db *DB) close() (err error) {
 	db.elog.Printf("Waiting for closer")
 	db.closers.updateSize.SignalAndWait()
 	db.orc.Stop()
-	if db.blockCache != nil {
-		db.blockCache.Close()
-	}
+	db.blockCache.Close()
 
 	db.elog.Finish()
 	if db.opt.InMemory {
@@ -1507,9 +1505,8 @@ func (db *DB) dropAll() (func(), error) {
 	db.vhead = valuePointer{} // Zero it out.
 	db.lc.nextFileID = 1
 	db.opt.Infof("Deleted %d value log files. DropAll done.\n", num)
-	if db.blockCache != nil {
-		db.blockCache.Clear()
-	}
+	db.blockCache.Clear()
+
 	return resume, nil
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -289,6 +289,13 @@ func TestGet(t *testing.T) {
 		test(t, db)
 		require.NoError(t, db.Close())
 	})
+	t.Run("cache disabled", func(t *testing.T) {
+		opts := DefaultOptions("").WithInMemory(true).WithMaxCacheSize(0)
+		db, err := Open(opts)
+		require.NoError(t, err)
+		test(t, db)
+		require.NoError(t, db.Close())
+	})
 }
 
 func TestGetAfterDelete(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -539,7 +539,8 @@ func (opt Options) WithChecksumVerificationMode(cvMode options.ChecksumVerificat
 // WithMaxCacheSize returns a new Options value with MaxCacheSize set to the given value.
 //
 // This value specifies how much data cache should hold in memory. A small size of cache means lower
-// memory consumption and lookups/iterations would take longer.
+// memory consumption and lookups/iterations would take longer. Setting size to zero disables the
+// cache altogether.
 func (opt Options) WithMaxCacheSize(size int64) Options {
 	opt.MaxCacheSize = size
 	return opt


### PR DESCRIPTION
All public methods on `"github.com/dgraph-io/ristretto".Cache` already support being called on the `nil` values, except `Close` and `Clear` so this is pretty straightforward.

Fixes #1183
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1185)
<!-- Reviewable:end -->
