### PR TITLE
Do not stall Level 1

### DIFF
--- a/level_handler.go
+++ b/level_handler.go
@@ -188,7 +188,9 @@ func (s *levelHandler) tryAddLevel0Table(t *table.Table) bool {
 	// Need lock as we may be deleting the first table during a level 0 compaction.
 	s.Lock()
 	defer s.Unlock()
-	if len(s.tables) >= s.db.opt.NumLevelZeroTablesStall {
+	// Return false only if L0 is in memory and number of tables is more than number of
+	// ZeroTableStall. For on disk L0, we should just add the tables to the level.
+	if s.db.opt.KeepL0InMemory && len(s.tables) >= s.db.opt.NumLevelZeroTablesStall {
 		return false
 	}
 

--- a/levels.go
+++ b/levels.go
@@ -925,15 +925,13 @@ func (s *levelsController) addLevel0Table(t *table.Table) error {
 			s.cstatus.RUnlock()
 			timeStart = time.Now()
 		}
-		// Before we unstall, we need to make sure that level 0 and 1 are healthy. Otherwise, we
-		// will very quickly fill up level 0 again and if the compaction strategy favors level 0,
-		// then level 1 is going to super full.
+		// Before we unstall, we need to make sure that level 0 is healthy. Otherwise, we
+		// will very quickly fill up level 0 again.
 		for i := 0; ; i++ {
-			// Passing 0 for delSize to compactable means we're treating incomplete compactions as
-			// not having finished -- we wait for them to finish.  Also, it's crucial this behavior
-			// replicates pickCompactLevels' behavior in computing compactability in order to
-			// guarantee progress.
-			if !s.isLevel0Compactable() && !s.levels[1].isCompactable(0) {
+			// It's crucial that this behavior replicates pickCompactLevels' behavior in
+			// computing compactability in order to guarantee progress.
+			// Break the loop once L0 has enough space to accommodate new tables.
+			if !s.isLevel0Compactable() {
 				break
 			}
 			time.Sleep(10 * time.Millisecond)

--- a/levels.go
+++ b/levels.go
@@ -424,9 +424,6 @@ func (s *levelsController) pickCompactLevels() (prios []compactionPriority) {
 			prios = append(prios, pri)
 		}
 	}
-	sort.Slice(prios, func(i, j int) bool {
-		return prios[i].score > prios[j].score
-	})
 	return prios
 }
 

--- a/levels.go
+++ b/levels.go
@@ -424,6 +424,10 @@ func (s *levelsController) pickCompactLevels() (prios []compactionPriority) {
 			prios = append(prios, pri)
 		}
 	}
+	// We used to sort compaction priorities based on the score. But, we
+	// decided to compact based on the level, not the priority. So, upper
+	// levels (level 0, level 1, etc) always get compacted first, before the
+	// lower levels -- this allows us to avoid stalls.
 	return prios
 }
 

--- a/levels_test.go
+++ b/levels_test.go
@@ -455,16 +455,10 @@ func TestL1Stall(t *testing.T) {
 	opt.LevelOneSize = 10
 
 	runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
-		l0 := []keyValVersion{{"foo", "bar", 1, 0}}
-		l01 := []keyValVersion{{"foo", "bar", 2, 0}}
-		l02 := []keyValVersion{{"foo", "bar", 3, 0}}
-		l03 := []keyValVersion{{"foo", "bar", 4, 0}}
-
-		// Level 0 has all the tables.
-		createAndOpen(db, l0, 0)
-		createAndOpen(db, l01, 0)
-		createAndOpen(db, l02, 0)
-		createAndOpen(db, l03, 0)
+		// Level 0 has 4 tables.
+		db.lc.levels[0].Lock()
+		db.lc.levels[0].tables = []*table.Table{createEmptyTable(db), createEmptyTable(db),
+			createEmptyTable(db), createEmptyTable(db)}
 
 		timeout := time.After(5 * time.Second)
 		done := make(chan bool)

--- a/levels_test.go
+++ b/levels_test.go
@@ -459,6 +459,7 @@ func TestL1Stall(t *testing.T) {
 		db.lc.levels[0].Lock()
 		db.lc.levels[0].tables = []*table.Table{createEmptyTable(db), createEmptyTable(db),
 			createEmptyTable(db), createEmptyTable(db)}
+		db.lc.levels[0].Unlock()
 
 		timeout := time.After(5 * time.Second)
 		done := make(chan bool)

--- a/levels_test.go
+++ b/levels_test.go
@@ -477,9 +477,11 @@ func TestL0Stall(t *testing.T) {
 		}()
 		time.Sleep(time.Second)
 
+		db.lc.levels[0].Lock()
 		// Drop two tables from Level 0 so that addLevel0Table can make progress. Earlier table
 		// count was 4 which is equal to L0 stall count.
 		db.lc.levels[0].tables = db.lc.levels[0].tables[2:]
+		db.lc.levels[0].Unlock()
 
 		select {
 		case <-timeout:


### PR DESCRIPTION
We don't need to stall writes if Level 1 does not have enough space. Level 1 is stored on the disk and it should be okay to have more number of tables (more size) on Level 1 than the `max level 1 size`. These tables will eventually be compacted to lower levels.

This commit changes the following 
- We no longer stall writes if L1 doesn't have enough space.
- We stall L0 only if `KeepL0InMemory` is true.
- Upper levels (L0, L1, etc) get priority in compaction (previously, level with higher priority score would get preference)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1186)
<!-- Reviewable:end -->
