### PR TITLE
Run all tests on CI

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -26,7 +26,6 @@ import (
 	"log"
 	"math"
 	"math/rand"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1957,12 +1956,7 @@ func TestVerifyChecksum(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	// call flag.Parse() here if TestMain uses flags
-	go func() {
-		if err := http.ListenAndServe("localhost:8080", nil); err != nil {
-			panic("Unable to open http port at 8080")
-		}
-	}()
+	flag.Parse()
 	os.Exit(m.Run())
 }
 

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,10 @@ set -e
 
 go version
 
+if [[ ! -z "$TEAMCITY_VERSION" ]]; then
+  export GOFLAGS="-json"
+fi
+
 # Ensure that we can compile the binary.
 pushd badger
 go build -v .

--- a/test.sh
+++ b/test.sh
@@ -23,6 +23,13 @@ rm -rf p
 
 # Then the normal tests.
 echo
+echo "==> Starting test for table, skl and y package"
+sleep 5
+# Run test for all package except the top level packge. The top level package support the
+# `vlog_mmap` flag which rest of the packages don't support.
+go test -v -race $(go list ./... | grep github.com/dgraph-io/badger/v2/. | tr -d '"')
+
+echo
 echo "==> Starting tests with value log mmapped..."
 sleep 5
 # Run top level package tests with mmap flag.
@@ -31,7 +38,4 @@ echo
 echo "==> Starting tests with value log not mmapped..."
 sleep 5
 go test -v --vlog_mmap=false -race github.com/dgraph-io/badger/v2
-
-# Run test for rest of the packages.
-go test -v -race $(go list ./... | grep github.com/dgraph-io/badger/v2/.)
 

--- a/test.sh
+++ b/test.sh
@@ -31,7 +31,7 @@ rm -rf p
 echo
 echo "==> Starting test for table, skl and y package"
 go test -v -race github.com/dgraph-io/badger/v2/skl
-# Run test for all package except the top level packge. The top level package support the
+# Run test for all package except the top level package. The top level package support the
 # `vlog_mmap` flag which rest of the packages don't support.
 go test -v -race $packages
 
@@ -42,5 +42,5 @@ go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=true
 
 echo
 echo "==> Starting tests with value log not mmapped..."
-go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=false 
+go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=false
 

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,8 @@ set -e
 
 go version
 
+packages=$(go list ./... | grep github.com/dgraph-io/badger/v2/)
+
 if [[ ! -z "$TEAMCITY_VERSION" ]]; then
   export GOFLAGS="-json"
 fi
@@ -32,7 +34,7 @@ sleep 5
 go test -v -race github.com/dgraph-io/badger/v2/skl
 # Run test for all package except the top level packge. The top level package support the
 # `vlog_mmap` flag which rest of the packages don't support.
-go test -v -race $(go list ./... | grep github.com/dgraph-io/badger/v2/. | tr -d '"')
+go test -v -race $packages
 
 echo
 echo "==> Starting tests with value log mmapped..."

--- a/test.sh
+++ b/test.sh
@@ -30,7 +30,6 @@ rm -rf p
 # Then the normal tests.
 echo
 echo "==> Starting test for table, skl and y package"
-sleep 5
 go test -v -race github.com/dgraph-io/badger/v2/skl
 # Run test for all package except the top level packge. The top level package support the
 # `vlog_mmap` flag which rest of the packages don't support.
@@ -38,11 +37,10 @@ go test -v -race $packages
 
 echo
 echo "==> Starting tests with value log mmapped..."
-sleep 5
 # Run top level package tests with mmap flag.
 go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=true
+
 echo
 echo "==> Starting tests with value log not mmapped..."
-sleep 5
 go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=false 
 

--- a/test.sh
+++ b/test.sh
@@ -25,6 +25,7 @@ rm -rf p
 echo
 echo "==> Starting test for table, skl and y package"
 sleep 5
+go test -v -race github.com/dgraph-io/badger/v2/skl
 # Run test for all package except the top level packge. The top level package support the
 # `vlog_mmap` flag which rest of the packages don't support.
 go test -v -race $(go list ./... | grep github.com/dgraph-io/badger/v2/. | tr -d '"')

--- a/test.sh
+++ b/test.sh
@@ -16,15 +16,15 @@ go build -v .
 popd
 
 # Run the memory intensive tests first.
-go test -v --manual=true -run='TestBigKeyValuePairs$'
-go test -v --manual=true -run='TestPushValueLogLimit'
+go test -v -run='TestBigKeyValuePairs$' --manual=true
+go test -v -run='TestPushValueLogLimit' --manual=true
 
 # Run the special Truncate test.
 rm -rf p
-go test -v --manual=true -run='TestTruncateVlogNoClose$' .
+go test -v -run='TestTruncateVlogNoClose$' --manual=true
 truncate --size=4096 p/000000.vlog
-go test -v --manual=true -run='TestTruncateVlogNoClose2$' .
-go test -v --manual=true -run='TestTruncateVlogNoClose3$' .
+go test -v -run='TestTruncateVlogNoClose2$' --manual=true
+go test -v -run='TestTruncateVlogNoClose3$' --manual=true
 rm -rf p
 
 # Then the normal tests.
@@ -40,9 +40,9 @@ echo
 echo "==> Starting tests with value log mmapped..."
 sleep 5
 # Run top level package tests with mmap flag.
-go test -v --vlog_mmap=true -race github.com/dgraph-io/badger/v2
+go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=true
 echo
 echo "==> Starting tests with value log not mmapped..."
 sleep 5
-go test -v --vlog_mmap=false -race github.com/dgraph-io/badger/v2
+go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=false 
 

--- a/test.sh
+++ b/test.sh
@@ -25,9 +25,13 @@ rm -rf p
 echo
 echo "==> Starting tests with value log mmapped..."
 sleep 5
-go test -v --vlog_mmap=true -race ./...
-
+# Run top level package tests with mmap flag.
+go test -v --vlog_mmap=true -race github.com/dgraph-io/badger/v2
 echo
 echo "==> Starting tests with value log not mmapped..."
 sleep 5
-go test -v --vlog_mmap=false -race ./...
+go test -v --vlog_mmap=false -race github.com/dgraph-io/badger/v2
+
+# Run test for rest of the packages.
+go test -v -race $(go list ./... | grep github.com/dgraph-io/badger/v2/.)
+


### PR DESCRIPTION
This could possibly be a bug in `go test` command https://github.com/golang/go/issues/36527 .

The `go test` command would skip tests in sub-packages if the top-level package has a `custom flag` defined and the sub-packages don't define it.

Issue https://github.com/golang/go/issues/36527#issue-548887632 has an example of this.

This PR also removes the code from the test that would unnecessary start a web server. I see two problems here
1. An unnecessary web server running.
2. We cannot run multiple tests are the same time since the second run of the test would try to start a web server and crash saying `port already in use`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1189)
<!-- Reviewable:end -->
