### PR TITLE
Avoid sync in inmemory mode

### DIFF
--- a/value.go
+++ b/value.go
@@ -1315,7 +1315,7 @@ func (reqs requests) IncrRef() {
 // if fid >= vlog.maxFid. In some cases such as replay(while opening db), it might be called with
 // fid < vlog.maxFid. To sync irrespective of file id just call it with math.MaxUint32.
 func (vlog *valueLog) sync(fid uint32) error {
-	if vlog.opt.SyncWrites {
+	if vlog.opt.SyncWrites || vlog.opt.InMemory {
 		return nil
 	}
 


### PR DESCRIPTION
This makes `db.Sync()` which calls `valueLog.Sync()` a no-op.
The code in master unnecessarily loads up an atomic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1190)
<!-- Reviewable:end -->
