### PR TITLE
RFC: Clean up transaction oracle as we go

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -29,7 +29,9 @@ type WriteBatch struct {
 	db       *DB
 	throttle *y.Throttle
 	err      error
-	commitTs uint64
+
+	isManaged bool
+	commitTs  uint64
 }
 
 // NewWriteBatch creates a new WriteBatch. This provides a way to conveniently do a lot of writes,
@@ -41,14 +43,15 @@ func (db *DB) NewWriteBatch() *WriteBatch {
 	if db.opt.managedTxns {
 		panic("cannot use NewWriteBatch in managed mode. Use NewWriteBatchAt instead")
 	}
-	return db.newWriteBatch()
+	return db.newWriteBatch(false)
 }
 
-func (db *DB) newWriteBatch() *WriteBatch {
+func (db *DB) newWriteBatch(isManaged bool) *WriteBatch {
 	return &WriteBatch{
-		db:       db,
-		txn:      db.newTransaction(true, true),
-		throttle: y.NewThrottle(16),
+		db:        db,
+		isManaged: isManaged,
+		txn:       db.newTransaction(true, isManaged),
+		throttle:  y.NewThrottle(16),
 	}
 }
 
@@ -142,8 +145,7 @@ func (wb *WriteBatch) commit() error {
 		return err
 	}
 	wb.txn.CommitWith(wb.callback)
-	wb.txn = wb.db.newTransaction(true, true)
-	wb.txn.readTs = 0 // We're not reading anything.
+	wb.txn = wb.db.newTransaction(true, wb.isManaged)
 	wb.txn.commitTs = wb.commitTs
 	return wb.err
 }

--- a/managed_db.go
+++ b/managed_db.go
@@ -47,7 +47,7 @@ func (db *DB) NewWriteBatchAt(commitTs uint64) *WriteBatch {
 		panic("cannot use NewWriteBatchAt with managedDB=false. Use NewWriteBatch instead")
 	}
 
-	wb := db.newWriteBatch()
+	wb := db.newWriteBatch(true)
 	wb.commitTs = commitTs
 	wb.txn.commitTs = commitTs
 	return wb


### PR DESCRIPTION
In the current implementation, if you happen to always have at least one write transaction open the memory usage of the transaction oracle is unbounded. It is actually relatively easy to hit when batch importing data. If you have more than one `WriteBatch` active during the import the transaction oracle will never be cleaned up.

This is a RFC on an approach to fix this. The core idea is to:

* Avoid increasing contention on purely read transactions; so only clean up the transaction oracle when write transactions are committed even if technically we could free memory sooner;
* Split the big `oracle.commit` map into one map per previously committed transaction; (this allows Go to release memory sooner than when performing deletes on a single map);
* Take advantage of the fact that we have acquired the oracle lock in `oracle.newCommitTs` to do the cleanup

I am assuming here that the number of committed-but-still-tracked transactions is small, which makes an implementation based on a simple slice reasonable. If that's not the case we will need some form of a sorted data-structure (i.e. a b-tree) here.

Comments welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1198)
<!-- Reviewable:end -->
