### PR TITLE
Fix flaky TestPageBufferReader2 test

### DIFF
--- a/y/y_test.go
+++ b/y/y_test.go
@@ -176,7 +176,7 @@ func TestPagebufferReader2(t *testing.T) {
 	require.Equal(t, n, 10, "length of buffer and length written should be equal")
 	require.NoError(t, err, "unable to write bytes to buffer")
 
-	randOffset := int(rand.Int31n(int32(b.length)))
+	randOffset := int(rand.Int31n(int32(b.length) - 1))
 	randLength := int(rand.Int31n(int32(b.length - randOffset)))
 	reader := b.NewReaderAt(randOffset)
 	// Read randLength bytes.


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/1197

The `TestPageBufferReader2` test would fail often because of an `off-by-1` issue.
The problem can be reproduced by setting `randOffset` to the biggest number that randInt31n may return statically like:

```
        //randOffset := int(rand.Int31n(int32(b.length)))
        randOffset := int(int32(b.length-1))
```

This makes the problem reliably reproducible as the offset is now pointing at EOF.

Thus changing the line to this should hopefully solve the problem:
`randOffset := int(rand.Int31n(int32(b.length-1)))`
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1210)
<!-- Reviewable:end -->
