### PR TITLE
Remove ExampleDB_Subscribe Test

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math"
 	"math/rand"
 	"os"
@@ -1965,70 +1964,6 @@ func TestVerifyChecksum(t *testing.T) {
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())
-}
-
-func ExampleDB_Subscribe() {
-	prefix := []byte{'a'}
-
-	// This key should be printed, since it matches the prefix.
-	aKey := []byte("a-key")
-	aValue := []byte("a-value")
-
-	// This key should not be printed.
-	bKey := []byte("b-key")
-	bValue := []byte("b-value")
-
-	// Open the DB.
-	dir, err := ioutil.TempDir("", "badger-test")
-	if err != nil {
-		panic(err)
-	}
-	defer removeDir(dir)
-	db, err := Open(DefaultOptions(dir))
-	if err != nil {
-		panic(err)
-	}
-	defer db.Close()
-
-	// Create the context here so we can cancel it after sending the writes.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Use the WaitGroup to make sure we wait for the subscription to stop before continuing.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		cb := func(kvs *KVList) error {
-			for _, kv := range kvs.Kv {
-				fmt.Printf("%s is now set to %s\n", kv.Key, kv.Value)
-			}
-			return nil
-		}
-		if err := db.Subscribe(ctx, cb, prefix); err != nil && err != context.Canceled {
-			panic(err)
-		}
-		log.Printf("subscription closed")
-	}()
-
-	// Wait for the above go routine to be scheduled.
-	time.Sleep(time.Second)
-	// Write both keys, but only one should be printed in the Output.
-	err = db.Update(func(txn *Txn) error { return txn.Set(aKey, aValue) })
-	if err != nil {
-		panic(err)
-	}
-	err = db.Update(func(txn *Txn) error { return txn.Set(bKey, bValue) })
-	if err != nil {
-		panic(err)
-	}
-
-	log.Printf("stopping subscription")
-	cancel()
-	log.Printf("waiting for subscription to close")
-	wg.Wait()
-	// Output:
-	// a-key is now set to a-value
 }
 
 func removeDir(dir string) {


### PR DESCRIPTION
The test ExampleDB_Subscribe doesn't run reliably on appveyor. This
commit removes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1214)
<!-- Reviewable:end -->
