### PR TITLE
Initialize vlog before starting compactions in db.Open

### DIFF
--- a/db.go
+++ b/db.go
@@ -331,16 +331,6 @@ func Open(opt Options) (db *DB, err error) {
 		return nil, err
 	}
 
-	if !opt.ReadOnly {
-		db.closers.compactors = y.NewCloser(1)
-		db.lc.startCompact(db.closers.compactors)
-
-		db.closers.memtable = y.NewCloser(1)
-		go func() {
-			_ = db.flushMemtable(db.closers.memtable) // Need levels controller to be up.
-		}()
-	}
-
 	headKey := y.KeyWithTs(head, math.MaxUint64)
 	// Need to pass with timestamp, lsm get removes the last 8 bytes and compares key
 	vs, err := db.get(headKey)
@@ -360,6 +350,16 @@ func Open(opt Options) (db *DB, err error) {
 		return db, y.Wrapf(err, "During db.vlog.open")
 	}
 	replayCloser.SignalAndWait() // Wait for replay to be applied first.
+
+	if !opt.ReadOnly {
+		db.closers.compactors = y.NewCloser(1)
+		db.lc.startCompact(db.closers.compactors)
+
+		db.closers.memtable = y.NewCloser(1)
+		go func() {
+			_ = db.flushMemtable(db.closers.memtable) // Need levels controller to be up.
+		}()
+	}
 
 	// Let's advance nextTxnTs to one more than whatever we observed via
 	// replaying the logs.

--- a/value_test.go
+++ b/value_test.go
@@ -412,6 +412,7 @@ func TestValueGC4(t *testing.T) {
 	err = kv.vlog.Close()
 	require.NoError(t, err)
 
+	kv.vlog.init(kv)
 	err = kv.vlog.open(kv, valuePointer{Fid: 2}, kv.replayFunction())
 	require.NoError(t, err)
 
@@ -642,8 +643,11 @@ func TestPartialAppendToValueLog(t *testing.T) {
 	checkKeys(t, kv, [][]byte{k3})
 	// Replay value log from beginning, badger head is past k2.
 	require.NoError(t, kv.vlog.Close())
-	require.NoError(t,
-		kv.vlog.open(kv, valuePointer{Fid: 0}, kv.replayFunction()))
+
+	kv.vlog.init(kv)
+	require.NoError(
+		t, kv.vlog.open(kv, valuePointer{Fid: 0}, kv.replayFunction()),
+	)
 	require.NoError(t, kv.Close())
 }
 


### PR DESCRIPTION
If compaction is started before opening vlog, badger might crash with
nil pointer error when trying to push discard stats at the end of
compactions because discard stats are initialized in vlog open.

Fixes https://github.com/dgraph-io/badger/issues/1209

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1226)
<!-- Reviewable:end -->
