### PR TITLE
Fix ValueThreshold for in-memory mode

### DIFF
--- a/db.go
+++ b/db.go
@@ -308,7 +308,8 @@ func Open(opt Options) (db *DB, err error) {
 
 	if db.opt.InMemory {
 		db.opt.SyncWrites = false
-		db.opt.ValueThreshold = maxValueThreshold
+		// If badger is running in memory mode, push everything into the LSM Tree.
+		db.opt.ValueThreshold = math.MaxInt32
 	}
 	krOpt := KeyRegistryOptions{
 		ReadOnly:                      opt.ReadOnly,

--- a/txn.go
+++ b/txn.go
@@ -327,6 +327,8 @@ func (txn *Txn) modify(e *Entry) error {
 		return exceedsSize("Key", maxKeySize, e.Key)
 	case int64(len(e.Value)) > txn.db.opt.ValueLogFileSize:
 		return exceedsSize("Value", txn.db.opt.ValueLogFileSize, e.Value)
+	case txn.db.opt.InMemory && len(e.Value) > txn.db.opt.ValueThreshold:
+		return exceedsSize("Value", int64(txn.db.opt.ValueThreshold), e.Value)
 	}
 
 	if err := txn.checkSize(e); err != nil {


### PR DESCRIPTION
This commit increases the ValueThreshold for in-memory mode. The
existing threshold was of 1 MB which means badger would crash if
len(value) was greater than 1 MB. This commit sets the value threshold
to MaxInt32 (around 2 GB). Badger transactions would return an error if
badger is running in in-memory mode and length of the value is greater than
the value threshold.

Fixes https://github.com/dgraph-io/badger/issues/1234


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1235)
<!-- Reviewable:end -->
