### PR TITLE
Add separate cache for bloomfilters

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -160,6 +160,7 @@ func newLevelsController(db *DB, mf *Manifest) (*levelsController, error) {
 			topt.Compression = tf.Compression
 			topt.DataKey = dk
 			topt.Cache = db.blockCache
+			topt.BfCache = db.bfCache
 			t, err := table.OpenTable(fd, topt)
 			if err != nil {
 				if strings.HasPrefix(err.Error(), "CHECKSUM_MISMATCH:") {
@@ -530,6 +531,7 @@ func (s *levelsController) compactBuildTables(
 		bopts.DataKey = dk
 		// Builder does not need cache but the same options are used for opening table.
 		bopts.Cache = s.kv.blockCache
+		bopts.BfCache = s.kv.bfCache
 		builder := table.NewTableBuilder(bopts)
 		var numKeys, numSkips uint64
 		for ; it.Valid(); it.Next() {

--- a/options.go
+++ b/options.go
@@ -126,7 +126,7 @@ func DefaultOptions(path string) Options {
 		KeepL0InMemory:          true,
 		VerifyValueChecksum:     false,
 		Compression:             options.None,
-		MaxCacheSize:            0, // 1 << 30, // 1 GB
+		MaxCacheSize:            1 << 30, // 1 GB
 		MaxBfCacheSize:          0,
 		LoadBfLazily:            false,
 		// The following benchmarks were done on a 4 KB block size (default block size). The

--- a/options.go
+++ b/options.go
@@ -65,7 +65,7 @@ type Options struct {
 	KeepL0InMemory     bool
 	MaxCacheSize       int64
 	MaxBfCacheSize     int64
-	LoadBfLazily       bool
+	LoadBloomOnOpen    bool
 
 	NumLevelZeroTables      int
 	NumLevelZeroTablesStall int
@@ -128,7 +128,7 @@ func DefaultOptions(path string) Options {
 		Compression:             options.None,
 		MaxCacheSize:            1 << 30, // 1 GB
 		MaxBfCacheSize:          0,
-		LoadBfLazily:            false,
+		LoadBloomOnOpen:         true,
 		// The following benchmarks were done on a 4 KB block size (default block size). The
 		// compression is ratio supposed to increase with increasing compression level but since the
 		// input for compression algorithm is small (4 KB), we don't get significant benefit at
@@ -161,7 +161,7 @@ func buildTableOptions(opt Options) table.Options {
 	return table.Options{
 		BlockSize:            opt.BlockSize,
 		BloomFalsePositive:   opt.BloomFalsePositive,
-		LoadBfLazily:         opt.LoadBfLazily,
+		LoadBloomOnOpen:      opt.LoadBloomOnOpen,
 		LoadingMode:          opt.TableLoadingMode,
 		ChkMode:              opt.ChecksumVerificationMode,
 		Compression:          opt.Compression,
@@ -596,15 +596,15 @@ func (opt Options) WithMaxBfCacheSize(size int64) Options {
 	return opt
 }
 
-// WithLoadBfLazily returns a new Options value with LoadBfLazily set to the given value.
+// WithLoadBloomOnOpen returns a new Options value with LoadBloomOnOpen set to the given value.
 //
-// Badger uses bloom filters to speed up key lookups. When LoadBfLazily is set
+// Badger uses bloom filters to speed up key lookups. When LoadBloomOnOpen is set
 // to false, all bloom filters will be loaded on DB open. This is supposed to
 // improve the read speed but it will affect the time taken to open the DB. Set
 // this option to true to reduce the time taken to open the DB.
 //
-// The default value of LoadBfLazily is false.
-func (opt Options) WithLoadBfLazily(b bool) Options {
-	opt.LoadBfLazily = b
+// The default value of LoadBloomOnOpen is false.
+func (opt Options) WithLoadBloomOnOpen(b bool) Options {
+	opt.LoadBloomOnOpen = b
 	return opt
 }

--- a/options.go
+++ b/options.go
@@ -65,7 +65,7 @@ type Options struct {
 	KeepL0InMemory     bool
 	MaxCacheSize       int64
 	MaxBfCacheSize     int64
-	LoadBloomOnOpen    bool
+	LoadBloomsOnOpen   bool
 
 	NumLevelZeroTables      int
 	NumLevelZeroTablesStall int
@@ -133,7 +133,7 @@ func DefaultOptions(path string) Options {
 		Compression:             options.None,
 		MaxCacheSize:            1 << 30, // 1 GB
 		MaxBfCacheSize:          0,
-		LoadBloomOnOpen:         true,
+		LoadBloomsOnOpen:        true,
 		// The following benchmarks were done on a 4 KB block size (default block size). The
 		// compression is ratio supposed to increase with increasing compression level but since the
 		// input for compression algorithm is small (4 KB), we don't get significant benefit at
@@ -167,7 +167,7 @@ func buildTableOptions(opt Options) table.Options {
 		TableSize:            uint64(opt.MaxTableSize),
 		BlockSize:            opt.BlockSize,
 		BloomFalsePositive:   opt.BloomFalsePositive,
-		LoadBloomOnOpen:      opt.LoadBloomOnOpen,
+		LoadBloomsOnOpen:     opt.LoadBloomsOnOpen,
 		LoadingMode:          opt.TableLoadingMode,
 		ChkMode:              opt.ChecksumVerificationMode,
 		Compression:          opt.Compression,
@@ -615,15 +615,15 @@ func (opt Options) WithMaxBfCacheSize(size int64) Options {
 	return opt
 }
 
-// WithLoadBloomOnOpen returns a new Options value with LoadBloomOnOpen set to the given value.
+// WithLoadsBloomOnOpen returns a new Options value with LoadBloomsOnOpen set to the given value.
 //
-// Badger uses bloom filters to speed up key lookups. When LoadBloomOnOpen is set
+// Badger uses bloom filters to speed up key lookups. When LoadBloomsOnOpen is set
 // to false, all bloom filters will be loaded on DB open. This is supposed to
 // improve the read speed but it will affect the time taken to open the DB. Set
 // this option to true to reduce the time taken to open the DB.
 //
-// The default value of LoadBloomOnOpen is false.
-func (opt Options) WithLoadBloomOnOpen(b bool) Options {
-	opt.LoadBloomOnOpen = b
+// The default value of LoadBloomsOnOpen is false.
+func (opt Options) WithLoadBloomsOnOpen(b bool) Options {
+	opt.LoadBloomsOnOpen = b
 	return opt
 }

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -416,6 +416,7 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 	opts := buildTableOptions(w.db.opt)
 	opts.DataKey = builder.DataKey()
 	opts.Cache = w.db.blockCache
+	opts.BfCache = w.db.bfCache
 	var tbl *table.Table
 	if w.db.opt.InMemory {
 		var err error

--- a/table/table.go
+++ b/table/table.go
@@ -75,9 +75,9 @@ type Options struct {
 	// ZSTDCompressionLevel is the ZSTD compression level used for compressing blocks.
 	ZSTDCompressionLevel int
 
-	// When LoadBfLazily is set, bloom filters will be read only when they are accessed.
+	// When LoadBloomOnOpen is set, bloom filters will be read only when they are accessed.
 	// Otherwise they will be loaded on table open.
-	LoadBfLazily bool
+	LoadBloomOnOpen bool
 }
 
 // TableInterface is useful for testing.
@@ -377,7 +377,7 @@ func (t *Table) readIndex() error {
 	t.estimatedSize = index.EstimatedSize
 	t.blockIndex = index.Offsets
 
-	if !t.opt.LoadBfLazily {
+	if !t.opt.LoadBloomOnOpen {
 		t.bf, _ = t.readBloomFilter()
 	}
 
@@ -510,7 +510,7 @@ func (t *Table) DoesNotHave(hash uint64) bool {
 	if t.opt.BfCache == nil {
 		// Load bloomfilter into memory if the cache is absent.
 		if t.bf == nil {
-			y.AssertTrue(t.opt.LoadBfLazily)
+			y.AssertTrue(t.opt.LoadBloomOnOpen)
 			t.bf, _ = t.readBloomFilter()
 		}
 		return !t.bf.Has(hash)

--- a/table/table.go
+++ b/table/table.go
@@ -78,9 +78,9 @@ type Options struct {
 	// ZSTDCompressionLevel is the ZSTD compression level used for compressing blocks.
 	ZSTDCompressionLevel int
 
-	// When LoadBloomOnOpen is set, bloom filters will be read only when they are accessed.
+	// When LoadBloomsOnOpen is set, bloom filters will be read only when they are accessed.
 	// Otherwise they will be loaded on table open.
-	LoadBloomOnOpen bool
+	LoadBloomsOnOpen bool
 }
 
 // TableInterface is useful for testing.
@@ -380,7 +380,7 @@ func (t *Table) readIndex() error {
 	t.estimatedSize = index.EstimatedSize
 	t.blockIndex = index.Offsets
 
-	if !t.opt.LoadBloomOnOpen {
+	if !t.opt.LoadBloomsOnOpen {
 		t.bf, _ = t.readBloomFilter()
 	}
 
@@ -513,7 +513,7 @@ func (t *Table) DoesNotHave(hash uint64) bool {
 	if t.opt.BfCache == nil {
 		// Load bloomfilter into memory if the cache is absent.
 		if t.bf == nil {
-			y.AssertTrue(t.opt.LoadBloomOnOpen)
+			y.AssertTrue(t.opt.LoadBloomsOnOpen)
 			t.bf, _ = t.readBloomFilter()
 		}
 		return !t.bf.Has(hash)


### PR DESCRIPTION
https://github.com/dgraph-io/badger/pull/1256 showed that a single
cache might not be enough to store the data blocks and the bloom
filters.
This commit adds a separate cache for the bloom filters. This
commit also adds a new flag `LoadBloomOnOpen` which determines
if the bloom filters should be loaded when the table is opened on
or not.

The default value of `MaxBfCacheSize` is `zero` and 
`LoadBloomOnOpen` is true.

This change has significant performance improvement on read speeds
because a single cache would lead to bloom filter eviction and we
would read the bloomfilter from the disk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1260)
<!-- Reviewable:end -->
