### PR TITLE
Use XorFilter instead of Bloomfilter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/DataDog/zstd v1.4.1
+	github.com/FastFilter/xorfilter v0.0.0-20200125145223-fef157c13a91
 	github.com/cespare/xxhash v1.1.0
 	github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/FastFilter/xorfilter v0.0.0-20200125145223-fef157c13a91 h1:zo6+vr3bMH1vIMXsF2WCKI8m+VPA1B+EvJhoYfOsu5Y=
+github.com/FastFilter/xorfilter v0.0.0-20200125145223-fef157c13a91/go.mod h1:QYZKpUr2O2jUPF7FfgbT5lwDkr34i3IW2LkUoq1ZcH0=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -301,7 +301,7 @@ func BenchmarkIteratePrefixSingleKey(b *testing.B) {
 	})
 }
 
-// go test -run xxx --bench KeyIterator --count 10 > result.txt
+// go test -run xxx -bench KeyIterator -count 10 > result.txt
 // benchstat result.txt
 // name           time/op
 // KeyIterator-8  121µs ± 7%

--- a/table/builder.go
+++ b/table/builder.go
@@ -374,7 +374,7 @@ The table structure looks like
 // In case the data is encrypted, the "IV" is added to the end of the index.
 func (b *Builder) Finish() []byte {
 	var keySlice = make([]uint64, 0, len(b.keyHashes))
-	for i, _ := range b.keyHashes {
+	for i := range b.keyHashes {
 		keySlice = append(keySlice, i)
 	}
 	xfilter, err := xorfilter.Populate(keySlice)

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -98,7 +98,7 @@ func TestTableIndex(t *testing.T) {
 			blockFirstKeys := make([][]byte, 0)
 			blockCount := 0
 			for i := 0; i < keysCount; i++ {
-				k := y.KeyWithTs([]byte(fmt.Sprintf("%016d", i)), 1)
+				k := []byte(fmt.Sprintf("%016d", i))
 				v := fmt.Sprintf("%d", i)
 				vs := y.ValueStruct{Value: []byte(v)}
 				if i == 0 { // This is first key for first block.
@@ -261,8 +261,16 @@ func BenchmarkBloom(b *testing.B) {
 		})
 		b.Run("xorFilter", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				filter, _ := xorfilter.Populate(keyHashes)
-				res, _ = json.Marshal(filter)
+				filter, err := xorfilter.Populate(keyHashes)
+				if i == 0 && err != nil {
+					b.Log(err)
+					b.Fail()
+				}
+				res, err = json.Marshal(filter)
+				if i == 0 && err != nil {
+					b.Log(err)
+					b.Fail()
+				}
 			}
 		})
 	})


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/1263 

This PR proposes use of https://github.com/FastFilter/xorfilter instead of `bbloom` https://github.com/dgraph-io/ristretto/blob/master/z/bbloom.go .

Following are the performance benchmarks
```
name                           time/op
Set/bloom-8              23.2ms ± 3%
Set/xorFilter-8           121ms ± 4%
Get/success/bloom-8      20.9ns ± 5%
Get/success/xorFilter-8  7.41ns ± 7%
Get/failure/bloom-8      8.27ns ± 6%
Get/failure/xorFilter-8  7.52ns ± 5%
```
The size xor filter is lesser than bbloom.
```
Number of keys = 2070594 (~ 2 million)
Size of bloom filter  	= 5592436 (5.59 MB)
Size of xor filter	= 3395912 (3.39 MB)
```

Xorfilter is definitely faster than bbloom filter but there isn't a significant performance difference in `key iterator` or `get` operation.
```
name           old time/op  new time/op  delta
KeyIterator-8   123µs ± 7%   121µs ± 7%   ~     (p=0.436 n=10+10)
```

Benchmarks are stored in `builder_test.go` and `iterator_test.go`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1264)
<!-- Reviewable:end -->
