### PR TITLE
Fail fast if cgo is disabled and compression is ZSTD

### DIFF
--- a/db.go
+++ b/db.go
@@ -216,6 +216,11 @@ func Open(opt Options) (db *DB, err error) {
 		return nil, ErrInvalidLoadingMode
 	}
 
+	// Return error if badger is built without cgo and compression is set to ZSTD.
+	if opt.Compression == options.ZSTD && !y.CgoEnabled {
+		return nil, y.ErrZstdCgo
+	}
+
 	// Compact L0 on close if either it is set or if KeepL0InMemory is set. When
 	// keepL0InMemory is set we need to compact L0 on close otherwise we might lose data.
 	opt.CompactL0OnClose = opt.CompactL0OnClose || opt.KeepL0InMemory

--- a/y/y.go
+++ b/y/y.go
@@ -37,6 +37,9 @@ var (
 	// and encountering the end of slice.
 	ErrEOF = errors.New("End of mapped region")
 
+	// ErrZstdCgo indicates that badger was built without cgo but ZSTD
+	// compression algorithm is being used for compression. ZSTD cannot work
+	// without CGO.
 	ErrZstdCgo = errors.New("zstd compression requires building badger with cgo enabled")
 )
 

--- a/y/y.go
+++ b/y/y.go
@@ -32,9 +32,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrEOF indicates an end of file when trying to read from a memory mapped file
-// and encountering the end of slice.
-var ErrEOF = errors.New("End of mapped region")
+var (
+	// ErrEOF indicates an end of file when trying to read from a memory mapped file
+	// and encountering the end of slice.
+	ErrEOF = errors.New("End of mapped region")
+
+	ErrZstdCgo = errors.New("zstd compression requires building badger with cgo enabled")
+)
 
 const (
 	// Sync indicates that O_DSYNC should be set on the underlying file,

--- a/y/zstd_nocgo.go
+++ b/y/zstd_nocgo.go
@@ -18,21 +18,15 @@
 
 package y
 
-import (
-	"errors"
-)
-
-var errZstdCgo = errors.New("zstd compression requires building badger with cgo enabled")
-
 // CgoEnabled is used to check if CGO is enabled while building badger.
 const CgoEnabled = false
 
 // ZSTDDecompress decompresses a block using ZSTD algorithm.
 func ZSTDDecompress(dst, src []byte) ([]byte, error) {
-	return nil, errZstdCgo
+	return nil, ErrZstdCgo
 }
 
 // ZSTDCompress compresses a block using ZSTD algorithm.
 func ZSTDCompress(dst, src []byte, compressionLevel int) ([]byte, error) {
-	return nil, errZstdCgo
+	return nil, ErrZstdCgo
 }


### PR DESCRIPTION
As seen in issue https://github.com/dgraph-io/dgraph/issues/4995, if badger is built without CGO and compression is set to ZSTD, badger would crash when level 0 is compacted. This could take from a few seconds to a few minutes for the crash to show up.

With this PR, `badger.Open()` call will return an error if compression is set to ZSTD and badger was built without CGO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1284)
<!-- Reviewable:end -->
