### PR TITLE
Disable eventlogging by default

### DIFF
--- a/options.go
+++ b/options.go
@@ -156,7 +156,7 @@ func DefaultOptions(path string) Options {
 		Truncate:                      false,
 		Logger:                        defaultLogger,
 		LogRotatesToFlush:             2,
-		EventLogging:                  true,
+		EventLogging:                  false,
 		EncryptionKey:                 []byte{},
 		EncryptionKeyRotationDuration: 10 * 24 * time.Hour, // Default 10 days.
 	}
@@ -298,7 +298,7 @@ func (opt Options) WithLogger(val Logger) Options {
 //
 // EventLogging provides a way to enable or disable trace.EventLog logging.
 //
-// The default value of EventLogging is true.
+// The default value of EventLogging is false.
 func (opt Options) WithEventLogging(enabled bool) Options {
 	opt.EventLogging = enabled
 	return opt


### PR DESCRIPTION
The event logging on the following line takes up too much of CPU.
https://github.com/dgraph-io/badger/blob/4b539b98851fd2fb32683098cfe23f172c437a3f/y/watermark.go#L171
 
```
      20ms       20ms    198:		if until != doneUntil {
      30ms       40ms    199:			AssertTrue(atomic.CompareAndSwapUint64(&w.doneUntil, doneUntil, until))
      70ms      2.67s    200:			w.elog.Printf("%s: Done until %d. Loops: %d\n", w.Name, until, loops)
         .          .    201:		}
         .          .    202:
```

By default, event logging is enabled, this PR disables it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1285)
<!-- Reviewable:end -->
