### PR TITLE
Support multiple iterators in read-write transactions.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -816,17 +816,19 @@ func TestIterateParallel(t *testing.T) {
 		txn := db.NewTransaction(true)
 		itr := txn.NewIterator(DefaultIteratorOptions)
 		require.NotPanics(t, func() {
-			// Now that multiple iterators are supported in read-write transactions, make sure this does not panic
-			// anymore. Then just close the iterator.
+			// Now that multiple iterators are supported in read-write
+			// transactions, make sure this does not panic anymore. Then just
+			// close the iterator.
 			txn.NewIterator(DefaultIteratorOptions).Close()
 		})
-		// The transaction should still panic since there is still one pending iterator that is open.
+		// The transaction should still panic since there is still one pending
+		// iterator that is open.
 		require.Panics(t, txn.Discard)
 		itr.Close()
 		txn.Discard()
 
-		// (Regression) Make sure that creating multiple concurrent iterators within a read only transaction continues
-		// to work.
+		// (Regression) Make sure that creating multiple concurrent iterators
+		// within a read only transaction continues to work.
 		t.Run("multiple read-only iterators", func(t *testing.T) {
 			// Run multiple iterators for a RO txn.
 			txn = db.NewTransaction(false)
@@ -838,8 +840,8 @@ func TestIterateParallel(t *testing.T) {
 			wg.Wait()
 		})
 
-		// Make sure that when we create multiple concurrent iterators within a read-write transaction that it actually
-		// iterates successfully.
+		// Make sure that when we create multiple concurrent iterators within a
+		// read-write transaction that it actually iterates successfully.
 		t.Run("multiple read-write iterators", func(t *testing.T) {
 			// Run multiple iterators for a RO txn.
 			txn = db.NewTransaction(true)

--- a/db_test.go
+++ b/db_test.go
@@ -812,24 +812,44 @@ func TestIterateParallel(t *testing.T) {
 
 		wg.Wait()
 
-		// Check that a RW txn can't run multiple iterators.
+		// Check that a RW txn can run multiple iterators.
 		txn := db.NewTransaction(true)
 		itr := txn.NewIterator(DefaultIteratorOptions)
-		require.Panics(t, func() {
-			txn.NewIterator(DefaultIteratorOptions)
+		require.NotPanics(t, func() {
+			// Now that multiple iterators are supported in read-write transactions, make sure this does not panic
+			// anymore. Then just close the iterator.
+			txn.NewIterator(DefaultIteratorOptions).Close()
 		})
+		// The transaction should still panic since there is still one pending iterator that is open.
 		require.Panics(t, txn.Discard)
 		itr.Close()
 		txn.Discard()
 
-		// Run multiple iterators for a RO txn.
-		txn = db.NewTransaction(false)
-		defer txn.Discard()
-		wg.Add(3)
-		go iterate(txn, &wg)
-		go iterate(txn, &wg)
-		go iterate(txn, &wg)
-		wg.Wait()
+		// (Regression) Make sure that creating multiple concurrent iterators within a read only transaction continues
+		// to work.
+		t.Run("multiple read-only iterators", func(t *testing.T) {
+			// Run multiple iterators for a RO txn.
+			txn = db.NewTransaction(false)
+			defer txn.Discard()
+			wg.Add(3)
+			go iterate(txn, &wg)
+			go iterate(txn, &wg)
+			go iterate(txn, &wg)
+			wg.Wait()
+		})
+
+		// Make sure that when we create multiple concurrent iterators within a read-write transaction that it actually
+		// iterates successfully.
+		t.Run("multiple read-write iterators", func(t *testing.T) {
+			// Run multiple iterators for a RO txn.
+			txn = db.NewTransaction(true)
+			defer txn.Discard()
+			wg.Add(3)
+			go iterate(txn, &wg)
+			go iterate(txn, &wg)
+			go iterate(txn, &wg)
+			wg.Wait()
+		})
 	})
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -442,16 +442,17 @@ type Iterator struct {
 //
 // Multiple Iterators:
 // For a read-only txn, multiple iterators can be running simultaneously.  However, for a read-write
-// txn, only one can be running at one time to avoid race conditions, because Txn is thread-unsafe.
+// txn, iterators have the nuance of being a snapshot of the writes for the transaction at the time
+// iterator was created. If writes are performed after an iterator is created, then that iterator
+// will not be able to see those writes. Only writes performed before an iterator was created can be
+// viewed.
 func (txn *Txn) NewIterator(opt IteratorOptions) *Iterator {
 	if txn.discarded {
 		panic("Transaction has already been discarded")
 	}
-	// Do not change the order of the next if. We must track the number of running iterators.
-	if atomic.AddInt32(&txn.numIterators, 1) > 1 && txn.update {
-		atomic.AddInt32(&txn.numIterators, -1)
-		panic("Only one iterator can be active at one time, for a RW txn.")
-	}
+
+	// Keep track of the number of active iterators.
+	atomic.AddInt32(&txn.numIterators, 1)
 
 	// TODO: If Prefix is set, only pick those memtables which have keys with
 	// the prefix.

--- a/txn.go
+++ b/txn.go
@@ -433,16 +433,12 @@ func (txn *Txn) addReadKey(key []byte) {
 	if txn.update {
 		fp := z.MemHash(key)
 
-		// Acquire lock only if we have more than one iterator. Single iterator
-		// cannot cause a race condition.
-		if atomic.LoadInt32(&txn.numIterators) > 1 {
-			// Because of the possibility of multiple iterators it is now possible
-			// for multiple threads within a read-write transaction to read keys at
-			// the same time. The reads slice is not currently thread-safe and
-			// needs to be locked whenever we mark a key as read.
-			txn.readsLock.Lock()
-			defer txn.readsLock.Unlock()
-		}
+		// Because of the possibility of multiple iterators it is now possible
+		// for multiple threads within a read-write transaction to read keys at
+		// the same time. The reads slice is not currently thread-safe and
+		// needs to be locked whenever we mark a key as read.
+		txn.readsLock.Lock()
+		defer txn.readsLock.Unlock()
 		txn.reads = append(txn.reads, fp)
 	}
 }

--- a/txn.go
+++ b/txn.go
@@ -438,8 +438,8 @@ func (txn *Txn) addReadKey(key []byte) {
 		// the same time. The reads slice is not currently thread-safe and
 		// needs to be locked whenever we mark a key as read.
 		txn.readsLock.Lock()
-		defer txn.readsLock.Unlock()
 		txn.reads = append(txn.reads, fp)
+		txn.readsLock.Unlock()
 	}
 }
 


### PR DESCRIPTION
This adds support for multiple iterators during a read-write transaction. But iterators created in a read-write transaction will only be able to see writes that were performed before the iterator was created. Any writes that occur after the iterator is created will be invisible to the iterator.

This references an issue I opened previously: #981

I had closed this issue as I was able to work with a single iterator but I'm not trying to read multiple sequences of keys and values from different areas in the database at the same time, and the most efficient way to do this seems to be with multiple iterators.

Fixes https://github.com/dgraph-io/badger/issues/981
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1286)
<!-- Reviewable:end -->
