### PR TITLE
Fix race condition in DoesNotHave

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -382,6 +382,7 @@ func (t *Table) readIndex() error {
 	t.blockIndex = index.Offsets
 
 	if t.opt.LoadBloomsOnOpen {
+		// We don't need to acquire lock here because this will be called in sequential manner.
 		t.bf, _ = t.readBloomFilter()
 	}
 

--- a/table/table.go
+++ b/table/table.go
@@ -382,8 +382,9 @@ func (t *Table) readIndex() error {
 	t.blockIndex = index.Offsets
 
 	if t.opt.LoadBloomsOnOpen {
-		// We don't need to acquire lock here because this will be called in sequential manner.
+		t.bfLock.Lock()
 		t.bf, _ = t.readBloomFilter()
+		t.bfLock.Unlock()
 	}
 
 	return nil


### PR DESCRIPTION
There is a race condition in the `t.bf` variable if `table.LoadBloomsOnOpen` is set to `false`.
This issue was also seen in https://github.com/dgraph-io/dgraph/issues/4689#issuecomment-607374797
```
==================
WARNING: DATA RACE
Read at 0x00c00028eed8 by goroutine 20:
  github.com/dgraph-io/badger/v2/table.(*Table).DoesNotHave()
      /home/aman/gocode/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20200316175624-91c31ebe8c22/table/table.go:515 +0x3f8
  github.com/dgraph-io/badger/v2.(*IteratorOptions).pickTables()
      /home/aman/gocode/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20200316175624-91c31ebe8c22/iterator.go:407 +0x29e
  github.com/dgraph-io/badger/v2.(*levelHandler).appendIterators()
      /home/aman/gocode/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20200316175624-91c31ebe8c22/level_handler.go:308 +0x38e
  github.com/dgraph-io/badger/v2.(*levelsController).appendIterators()
      /home/aman/gocode/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20200316175624-91c31ebe8c22/levels.go:1025 +0xcc
  github.com/dgraph-io/badger/v2.(*Txn).NewIterator()
      /home/aman/gocode/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20200316175624-91c31ebe8c22/iterator.go:468 +0x4d3
  github.com/dgraph-io/badger/v2.(*Txn).NewKeyIterator()
      /home/aman/gocode/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20200316175624-91c31ebe8c22/iterator.go:489 +0xfb
  github.com/dgraph-io/dgraph/posting.getNew()
      /home/aman/gocode/src/github.com/dgraph-io/dgraph/posting/mvcc.go:345 +0x20c
  github.com/dgraph-io/dgraph/posting.(*LocalCache).getInternal()
      /home/aman/gocode/src/github.com/dgraph-io/dgraph/posting/lists.go:208 +0x4d6
  github.com/dgraph-io/dgraph/worker.(*queryState).handleUidPostings.func1()
      /home/aman/gocode/src/github.com/dgraph-io/dgraph/posting/lists.go:241 +0x416
  github.com/dgraph-io/dgraph/worker.(*queryState).handleUidPostings.func2()
      /home/aman/gocode/src/github.com/dgraph-io/dgraph/worker/task.go:811 +0x47
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1287)
<!-- Reviewable:end -->
