### PR TITLE
Make linear reads optional

### DIFF
--- a/options.go
+++ b/options.go
@@ -58,6 +58,7 @@ type Options struct {
 	MaxLevels           int
 	ValueThreshold      int
 	NumMemtables        int
+	LinearReads         bool
 	// Changing BlockSize across DB runs will not break badger. The block size is
 	// read from the block index stored at the end of the table.
 	BlockSize          int
@@ -115,6 +116,7 @@ func DefaultOptions(path string) Options {
 		LevelSizeMultiplier: 10,
 		TableLoadingMode:    options.MemoryMap,
 		ValueLogLoadingMode: options.MemoryMap,
+		LinearReads:         false,
 		// table.MemoryMap to mmap() the tables.
 		// table.Nothing to not preload the tables.
 		MaxLevels:               7,


### PR DESCRIPTION
Benchmark result of set and get operations with Keysize = 9 bytes and value size = 256 bytes.
```
With linear reads
badger/nofsync set rate: 72622 op/s, mean: 1721 ns, took: 60 s
badger/nofsync get rate: 368813 op/s, mean: 338 ns, took: 60 s

without linear reads
badger/nofsync set rate: 87904 op/s, mean: 1421 ns, took: 60 s
badger/nofsync get rate: 414717 op/s, mean: 301 ns, took: 60 s

```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1290)
<!-- Reviewable:end -->
