### PR TITLE
Expose BatchSet API

### DIFF
--- a/batch_set.go
+++ b/batch_set.go
@@ -1,0 +1,153 @@
+package badger
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/dgraph-io/badger/v2/y"
+	"github.com/pkg/errors"
+)
+
+type batchSet struct {
+	sync.Mutex
+
+	db       *DB
+	err      error
+	count    int64
+	size     int64
+	entries  []*Entry
+	throttle *y.Throttle
+}
+
+func (db *DB) NewBatchSet() (*batchSet, error) {
+	if !db.opt.managedTxns {
+		return nil, errors.New("Batchset can only be used in managed mode")
+	}
+	return newBatchSet(db), nil
+}
+
+func newBatchSet(db *DB) *batchSet {
+	return &batchSet{
+		db:       db,
+		entries:  make([]*Entry, 0, 1000),
+		throttle: y.NewThrottle(16),
+	}
+}
+
+func (bs *batchSet) Set(k, v []byte) error {
+	return bs.SetEntry(&Entry{Key: k, Value: v})
+}
+
+func (bs *batchSet) SetEntry(e *Entry) error {
+	bs.Lock()
+	defer bs.Unlock()
+
+	const maxKeySize = 65000
+
+	switch {
+	case len(e.Key) == 0:
+		return ErrEmptyKey
+	case bytes.HasPrefix(e.Key, badgerPrefix):
+		return ErrInvalidKey
+	case len(e.Key) > maxKeySize:
+		// Key length can't be more than uint16, as determined by table::header.  To
+		// keep things safe and allow badger move prefix and a timestamp suffix, let's
+		// cut it down to 65000, instead of using 65536.
+		return exceedsSize("Key", maxKeySize, e.Key)
+	case int64(len(e.Value)) > bs.db.opt.ValueLogFileSize:
+		return exceedsSize("Value", bs.db.opt.ValueLogFileSize, e.Value)
+	case bs.db.opt.InMemory && len(e.Value) > bs.db.opt.ValueThreshold:
+		return exceedsSize("Value", int64(bs.db.opt.ValueThreshold), e.Value)
+	}
+
+	err := bs.add(e)
+	switch err {
+	case nil:
+		return nil
+	case ErrTxnTooBig:
+		if err := bs.throttle.Do(); err != nil {
+			return err
+		}
+		err = bs.batchSetListAsync(bs.entries, func(err error) {
+			defer bs.throttle.Done(err)
+			if err != nil {
+				bs.err = err
+				return
+			}
+		})
+		bs.reset()
+		bs.add(e)
+		return err
+	default:
+		return err
+
+	}
+	return nil
+}
+
+func (bs *batchSet) add(e *Entry) error {
+	err := bs.checkSize(e)
+	if err != nil {
+		return err
+	}
+	bs.entries = append(bs.entries, e)
+	return nil
+}
+
+func (bs *batchSet) reset() {
+	bs.entries = make([]*Entry, 0, 1000)
+	bs.count = 0
+	bs.size = 0
+}
+
+func (bs *batchSet) Flush() error {
+	bs.Lock()
+	defer bs.Unlock()
+
+	if err := bs.throttle.Finish(); err != nil {
+		return err
+	}
+
+	return bs.err
+}
+
+// batchSet applies a list of badger.Entry. If a request level error occurs it
+// will be returned.
+func (bs *batchSet) batchSetList(entries []*Entry) error {
+	req, err := bs.db.sendToWriteCh(entries)
+	if err != nil {
+		return err
+	}
+
+	return req.Wait()
+}
+
+// batchSetAsync is the asynchronous version of batchSet. It accepts a callback
+// function which is called when all the sets are complete. If a request level
+// error occurs, it will be passed back via the callback.
+//   err := kv.BatchSetAsync(entries, func(err error)) {
+//      Check(err)
+//   }
+func (bs *batchSet) batchSetListAsync(entries []*Entry, f func(error)) error {
+	req, err := bs.db.sendToWriteCh(entries)
+	if err != nil {
+		return err
+	}
+	go func() {
+		err := req.Wait()
+		// Write is complete. Let's call the callback function now.
+		f(err)
+	}()
+	return nil
+}
+
+func (bs *batchSet) checkSize(e *Entry) error {
+	count := bs.count + 1
+	// Extra bytes for the version in key.
+	size := bs.size + int64(e.estimateSize(bs.db.opt.ValueThreshold)) + 10
+	if count >= bs.db.opt.maxBatchCount || size >= bs.db.opt.maxBatchSize {
+		return ErrTxnTooBig
+	}
+	bs.count, bs.size = count, size
+	return nil
+}

--- a/managed_db.go
+++ b/managed_db.go
@@ -48,7 +48,7 @@ func (db *DB) NewWriteBatchAt(commitTs uint64) *WriteBatch {
 	}
 
 	wb := db.newWriteBatch()
-	wb.commitTs = commitTs
+	//wb.commitTs = commitTs
 	wb.txn.commitTs = commitTs
 	return wb
 }

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -594,8 +594,13 @@ func TestDropPrefixRace(t *testing.T) {
 }
 
 func TestWriteBatchManagedMode(t *testing.T) {
+	tt := uint64(0)
+	ts := func() uint64 {
+		tt++
+		return tt
+	}
 	key := func(i int) []byte {
-		return []byte(fmt.Sprintf("%10d", i))
+		return y.KeyWithTs([]byte(fmt.Sprintf("%10d", i)), ts())
 	}
 	val := func(i int) []byte {
 		return []byte(fmt.Sprintf("%128d", i))
@@ -626,7 +631,7 @@ func TestWriteBatchManagedMode(t *testing.T) {
 			i := M
 			for itr.Rewind(); itr.Valid(); itr.Next() {
 				item := itr.Item()
-				require.Equal(t, string(key(i)), string(item.Key()))
+				require.Equal(t, string(y.ParseKey(key(i))), string(item.Key()))
 				valcopy, err := item.ValueCopy(nil)
 				require.NoError(t, err)
 				require.Equal(t, val(i), valcopy)


### PR DESCRIPTION
key, val size = 5 bytes
```
Writer/TxnWriter-8           2.13s ± 3%
Writer/WriteBatch-8          1.37s ± 8%
Writer/BatchSet-8  792ms ± 5%
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1299)
<!-- Reviewable:end -->
