### PR TITLE
Set default value of NumVersionsToKeep to 0

### DIFF
--- a/options.go
+++ b/options.go
@@ -126,7 +126,7 @@ func DefaultOptions(path string) Options {
 		BloomFalsePositive:      0.01,
 		BlockSize:               4 * 1024,
 		SyncWrites:              true,
-		NumVersionsToKeep:       1,
+		NumVersionsToKeep:       0,
 		CompactL0OnClose:        true,
 		KeepL0InMemory:          true,
 		VerifyValueChecksum:     false,


### PR DESCRIPTION
Issue https://github.com/dgraph-io/badger/issues/1228 showed that badger doesn't clean SST files even if all the keys are deleted. This is the expected behavior if `NumVersionsToKeep` is set to `1` but for the users this is counter-intuitive. When a key is deleted, it should be removed from the system. This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1300)
<!-- Reviewable:end -->
