### PR TITLE
Simplify single version compaction

### DIFF
--- a/levels_test.go
+++ b/levels_test.go
@@ -254,6 +254,72 @@ func TestCompaction(t *testing.T) {
 			getAllAndCheck(t, db, []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}})
 		})
 	})
+
+	t.Run("level 1 to level 2 with delete", func(t *testing.T) {
+		t.Run("with overlap", func(t *testing.T) {
+			runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+				l1 := []keyValVersion{{"foo", "bar", 3, bitDelete}, {"fooz", "baz", 1, bitDelete}}
+				l2 := []keyValVersion{{"foo", "bar", 2, 0}}
+				l3 := []keyValVersion{{"foo", "bar", 1, 0}}
+				createAndOpen(db, l1, 1)
+				createAndOpen(db, l2, 2)
+				createAndOpen(db, l3, 3)
+
+				// Set a high discard timestamp so that all the keys are below the discard timestamp.
+				db.SetDiscardTs(10)
+
+				getAllAndCheck(t, db, []keyValVersion{
+					{"foo", "bar", 3, 1}, {"foo", "bar", 2, 0}, {"foo", "bar", 1, 0}, {"fooz", "baz", 1, 1},
+				})
+				cdef := compactDef{
+					thisLevel: db.lc.levels[1],
+					nextLevel: db.lc.levels[2],
+					top:       db.lc.levels[1].tables,
+					bot:       db.lc.levels[2].tables,
+				}
+				require.NoError(t, db.lc.runCompactDef(1, cdef))
+				// foo bar version 2 should be dropped after compaction. fooz baz version 1 will remain because overlap exists,
+				// which is expected because `hasOverlap` is only checked once at the beginning of `compactBuildTables` method.
+				// everything from level 1 is now in level 2.
+				getAllAndCheck(t, db, []keyValVersion{{"foo", "bar", 3, bitDelete}, {"foo", "bar", 1, 0}, {"fooz", "baz", 1, 1}})
+
+				cdef = compactDef{
+					thisLevel: db.lc.levels[2],
+					nextLevel: db.lc.levels[3],
+					top:       db.lc.levels[2].tables,
+					bot:       db.lc.levels[3].tables,
+				}
+				require.NoError(t, db.lc.runCompactDef(2, cdef))
+				// everything should be removed now
+				getAllAndCheck(t, db, []keyValVersion{})
+			})
+		})
+		t.Run("without overlap", func(t *testing.T) {
+			runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+				l1 := []keyValVersion{{"foo", "bar", 3, bitDelete}, {"fooz", "baz", 1, bitDelete}}
+				l2 := []keyValVersion{{"fooo", "barr", 2, 0}}
+				createAndOpen(db, l1, 1)
+				createAndOpen(db, l2, 2)
+
+				// Set a high discard timestamp so that all the keys are below the discard timestamp.
+				db.SetDiscardTs(10)
+
+				getAllAndCheck(t, db, []keyValVersion{
+					{"foo", "bar", 3, 1}, {"fooo", "barr", 2, 0}, {"fooz", "baz", 1, 1},
+				})
+				cdef := compactDef{
+					thisLevel: db.lc.levels[1],
+					nextLevel: db.lc.levels[2],
+					top:       db.lc.levels[1].tables,
+					bot:       db.lc.levels[2].tables,
+				}
+				require.NoError(t, db.lc.runCompactDef(1, cdef))
+				// foo version 2 should be dropped after compaction.
+				getAllAndCheck(t, db, []keyValVersion{{"fooo", "barr", 2, 0}})
+			})
+		})
+	})
+
 }
 
 func TestHeadKeyCleanup(t *testing.T) {


### PR DESCRIPTION
When `NumVersionsToKeep` is `1`, deleted and expired entries should always be removed if there is no overlap with lower levels. Otherwise, deleted entries will continue to grow for heavy write/delete use cases with many transient keys.

This PR adds simplified logic when `NumVersionsToKeep` is `1` that always sets the `skipKey` and only writes deleted or expired entries when `hasOverlap` is `true`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1303)
<!-- Reviewable:end -->
