### PR TITLE
TableInfo: Return valid Left key

### DIFF
--- a/levels_test.go
+++ b/levels_test.go
@@ -564,3 +564,38 @@ func TestL0Stall(t *testing.T) {
 		test(t, &opt)
 	})
 }
+
+func TestGetTableInfo(t *testing.T) {
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		kv := []keyValVersion{
+			{string(head), "", 1, 0},
+			{string(badgerMove), "", 1, 0},
+			{string(badgerMove), "", 2, 0},
+			{string("a"), "", 1, 0},
+			{string("b"), "", 1, 0},
+			{string("za"), "", 1, 0},
+		}
+		createAndOpen(db, kv, 1)
+
+		// Without key count.
+		tab := db.Tables(false)
+		require.Len(t, tab, 1)
+		require.Equal(t, "a", string(y.ParseKey(tab[0].Left)))
+		require.Equal(t, "za", string(y.ParseKey(tab[0].Right)))
+		require.Equal(t, uint64(0), tab[0].KeyCount)
+
+		// With Key count.
+		tab = db.Tables(true)
+		require.Len(t, tab, 1)
+		require.Equal(t, "a", string(y.ParseKey(tab[0].Left)))
+		require.Equal(t, "za", string(y.ParseKey(tab[0].Right)))
+		require.Equal(t, uint64(6), tab[0].KeyCount)
+
+		// Calculate it again, just for fun!
+		tab = db.Tables(true)
+		require.Len(t, tab, 1)
+		require.Equal(t, "a", string(y.ParseKey(tab[0].Left)))
+		require.Equal(t, "za", string(y.ParseKey(tab[0].Right)))
+		require.Equal(t, uint64(6), tab[0].KeyCount)
+	})
+}


### PR DESCRIPTION
`TableInfo` function returns table boundaries. This is used in dgraph to calculate tablet size. As seen in issue https://github.com/dgraph-io/dgraph/issues/5026, badger could return `!badger!head` or `!badger!move` keys as the start of the table. These are valid start keys for badger but they're invalid for dgraph.
This PR changes `TableInfo` function so that we return only valid table start. For a table which contains the following keys
```
!badger!Head!
!badger!Move!...
!badger!Move!...
a
b
za
```
The valid starting key (left key) should be `a` and the end key should be `za`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1309)
<!-- Reviewable:end -->
