### PR TITLE
Always use fsync value from db.opt

### DIFF
--- a/db.go
+++ b/db.go
@@ -989,7 +989,7 @@ func (db *DB) handleFlushTask(ft flushTask) error {
 		return db.lc.addLevel0Table(tbl)
 	}
 
-	fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), true)
+	fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), db.opt.SyncWrites)
 	if err != nil {
 		return y.Wrap(err)
 	}

--- a/db2_test.go
+++ b/db2_test.go
@@ -543,7 +543,7 @@ func createTableWithRange(t *testing.T, db *DB, start, end int) *table.Table {
 	}
 
 	fileID := db.lc.reserveFileID()
-	fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), true)
+	fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), db.opt.SyncWrites)
 	require.NoError(t, err)
 
 	_, err = fd.Write(b.Finish())

--- a/levels.go
+++ b/levels.go
@@ -611,7 +611,9 @@ func (s *levelsController) compactBuildTables(
 		s.kv.opt.Debugf("LOG Compact. Added %d keys. Skipped %d keys. Iteration took: %v",
 			numKeys, numSkips, time.Since(timeStart))
 		build := func(fileID uint64) (*table.Table, error) {
-			fd, err := y.CreateSyncedFile(table.NewFilename(fileID, s.kv.opt.Dir), true)
+
+			fname := table.NewFilename(fileID, s.kv.opt.Dir)
+			fd, err := y.CreateSyncedFile(fname, s.kv.opt.SyncWrites)
 			if err != nil {
 				return nil, errors.Wrapf(err, "While opening new table: %d", fileID)
 			}

--- a/levels.go
+++ b/levels.go
@@ -611,7 +611,6 @@ func (s *levelsController) compactBuildTables(
 		s.kv.opt.Debugf("LOG Compact. Added %d keys. Skipped %d keys. Iteration took: %v",
 			numKeys, numSkips, time.Since(timeStart))
 		build := func(fileID uint64) (*table.Table, error) {
-
 			fname := table.NewFilename(fileID, s.kv.opt.Dir)
 			fd, err := y.CreateSyncedFile(fname, s.kv.opt.SyncWrites)
 			if err != nil {

--- a/levels_test.go
+++ b/levels_test.go
@@ -44,7 +44,8 @@ func createAndOpen(db *DB, td []keyValVersion, level int) {
 		val := y.ValueStruct{Value: []byte(item.val), Meta: item.meta}
 		b.Add(key, val, 0)
 	}
-	fd, err := y.CreateSyncedFile(table.NewFilename(db.lc.reserveFileID(), db.opt.Dir), true)
+	fname := table.NewFilename(db.lc.reserveFileID(), db.opt.Dir)
+	fd, err := y.CreateSyncedFile(fname, db.opt.SyncWrites)
 	if err != nil {
 		panic(err)
 	}

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -424,7 +424,7 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 			return err
 		}
 	} else {
-		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, w.db.opt.Dir), true)
+		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, w.db.opt.Dir), w.db.opt.SyncWrites)
 		if err != nil {
 			return err
 		}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -74,7 +74,7 @@ func buildTable(t *testing.T, keyValues [][]string, opts Options) *os.File {
 	// TODO: Add test for file garbage collection here. No files should be left after the tests here.
 
 	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Uint32())
-	f, err := y.CreateSyncedFile(filename, true)
+	f, err := y.CreateSyncedFile(filename, false)
 	require.NoError(t, err)
 
 	sort.Slice(keyValues, func(i, j int) bool {


### PR DESCRIPTION
The tables were opened in `SyncMode` even if badger was running with `SyncWrites=false`. This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1316)
<!-- Reviewable:end -->
