### PR TITLE
Add Write method to batch write

### DIFF
--- a/value.go
+++ b/value.go
@@ -1435,11 +1435,11 @@ func (vlog *valueLog) write(reqs []*request) error {
 			// log (this happens when a transaction contains entries with large value sizes) and
 			// badger might run into out of memory errors. We flush the buffer here if it's size
 			// grows beyond the max value log size.
-			if int64(buf.Len()) > vlog.db.opt.ValueLogFileSize {
-				if err := flushWrites(); err != nil {
-					return err
-				}
-			}
+			// if int64(buf.Len()) > vlog.db.opt.ValueLogFileSize {
+			// 	if err := flushWrites(); err != nil {
+			// 		return err
+			// 	}
+			// }
 		}
 		vlog.numEntriesWritten += uint32(written)
 		// We write to disk here so that all entries that are part of the same transaction are

--- a/value.go
+++ b/value.go
@@ -1435,11 +1435,11 @@ func (vlog *valueLog) write(reqs []*request) error {
 			// log (this happens when a transaction contains entries with large value sizes) and
 			// badger might run into out of memory errors. We flush the buffer here if it's size
 			// grows beyond the max value log size.
-			// if int64(buf.Len()) > vlog.db.opt.ValueLogFileSize {
-			// 	if err := flushWrites(); err != nil {
-			// 		return err
-			// 	}
-			// }
+			if int64(buf.Len()) > vlog.db.opt.ValueLogFileSize {
+				if err := flushWrites(); err != nil {
+					return err
+				}
+			}
 		}
 		vlog.numEntriesWritten += uint32(written)
 		// We write to disk here so that all entries that are part of the same transaction are


### PR DESCRIPTION
This PR adds a new `writeBatch.Write()` method which allows inserting a `pb.KVList` via write batch.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1321)
<!-- Reviewable:end -->
