### PR TITLE
Allow the stream framework to know the thread number

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -438,6 +438,11 @@ type Iterator struct {
 	lastKey []byte // Used to skip over multiple versions of the same key.
 
 	closed bool
+
+	// ThreadId is an optional value that can be set to identify which goroutine created
+	// the iterator. It can be used, for example, to uniquely identify each of the
+	// iterators created by the stream interface
+	ThreadId int
 }
 
 // NewIterator returns a new iterator. Depending upon the options, either only keys, or both

--- a/stream.go
+++ b/stream.go
@@ -332,7 +332,8 @@ func (st *Stream) Orchestrate(ctx context.Context) error {
 	var wg sync.WaitGroup
 	for i := 0; i < st.NumGo; i++ {
 		wg.Add(1)
-		// Copy value of i to prevent the value from changing in the next iteration.
+		// Copy value of i to prevent the value from changing by the time the goroutine
+		// below starts executing.
 		threadId := i
 
 		go func() {

--- a/stream.go
+++ b/stream.go
@@ -66,8 +66,8 @@ type Stream struct {
 	KeyToList func(key []byte, itr *Iterator) (*pb.KVList, error)
 
 	// KeyToListWithThreadNum works similarly to KeyToList but it's passed the goroutine
-	// number. This is useful to simulate thread-local storage. Only one of the two fields
-	// should be set. Preference is given to this function if both are set.
+	// number. This is useful to simulate thread-local storage. Only one of the two KeyToList
+	// functions should be set. Preference is given to this function if both are set.
 	KeyToListWithThreadNum func(key []byte, itr *Iterator, threadNum int) (*pb.KVList, error)
 
 	// This is the method where Stream sends the final output. All calls to Send are done by a

--- a/stream.go
+++ b/stream.go
@@ -332,11 +332,8 @@ func (st *Stream) Orchestrate(ctx context.Context) error {
 	var wg sync.WaitGroup
 	for i := 0; i < st.NumGo; i++ {
 		wg.Add(1)
-		// Copy value of i to prevent the value from changing by the time the goroutine
-		// below starts executing.
-		threadId := i
 
-		go func() {
+		go func(threadId int) {
 			defer wg.Done()
 			// Picks up ranges from rangeCh, generates KV lists, and sends them to kvChan.
 			if err := st.produceKVs(ctx, threadId); err != nil {
@@ -345,7 +342,7 @@ func (st *Stream) Orchestrate(ctx context.Context) error {
 				default:
 				}
 			}
-		}()
+		}(i)
 	}
 
 	// Pick up key-values from kvChan and send to stream.

--- a/stream_test.go
+++ b/stream_test.go
@@ -205,4 +205,5 @@ func TestStreamWithThreadNum(t *testing.T) {
 	for pred, count := range m {
 		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
 	}
+	require.NoError(t, db.Close())
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -160,7 +160,7 @@ func TestStream(t *testing.T) {
 	require.NoError(t, db.Close())
 }
 
-func TestStreamWithThreadNum(t *testing.T) {
+func TestStreamWithThreadId(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
@@ -180,9 +180,9 @@ func TestStreamWithThreadNum(t *testing.T) {
 
 	stream := db.NewStreamAt(math.MaxUint64)
 	stream.LogPrefix = "Testing"
-	stream.KeyToListWithThreadNum = func(key []byte, itr *Iterator, threadNum int) (
+	stream.KeyToList = func(key []byte, itr *Iterator) (
 		*bpb.KVList, error) {
-		require.Less(t, threadNum, stream.NumGo)
+		require.Less(t, itr.ThreadId, stream.NumGo)
 		return stream.ToList(key, itr)
 	}
 	c := &collector{}

--- a/stream_test.go
+++ b/stream_test.go
@@ -181,7 +181,7 @@ func TestStreamWithThreadNum(t *testing.T) {
 	stream := db.NewStreamAt(math.MaxUint64)
 	stream.LogPrefix = "Testing"
 	stream.KeyToListWithThreadNum = func(key []byte, itr *Iterator, threadNum int) (
-		*bpb.KVList, error){
+		*bpb.KVList, error) {
 		require.Less(t, threadNum, stream.NumGo)
 		return stream.ToList(key, itr)
 	}


### PR DESCRIPTION
Add an optional KeyToList function that gets passed the thread number.
This should allow uses to simulate thread-local storage. The original
KeyToList function is kept for backwards compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1327)
<!-- Reviewable:end -->
