### PR TITLE
Iterator: Always add key to txn.reads

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -505,8 +505,8 @@ func (it *Iterator) newItem() *Item {
 // Item returns pointer to the current key-value pair.
 // This item is only valid until it.Next() gets called.
 func (it *Iterator) Item() *Item {
-	// tx := it.txn
-	// tx.addReadKey(it.item.Key())
+	tx := it.txn
+	tx.addReadKey(it.item.Key())
 	return it.item
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -505,6 +505,8 @@ func (it *Iterator) newItem() *Item {
 // Item returns pointer to the current key-value pair.
 // This item is only valid until it.Next() gets called.
 func (it *Iterator) Item() *Item {
+	// tx := it.txn
+	// tx.addReadKey(it.item.Key())
 	return it.item
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -505,8 +505,6 @@ func (it *Iterator) newItem() *Item {
 // Item returns pointer to the current key-value pair.
 // This item is only valid until it.Next() gets called.
 func (it *Iterator) Item() *Item {
-	// tx := it.txn
-	// tx.addReadKey(it.item.Key())
 	return it.item
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -712,8 +712,7 @@ func (it *Iterator) prefetch() {
 // Behavior would be reversed if iterating backwards.
 func (it *Iterator) Seek(key []byte) {
 	if len(key) > 0 {
-		tx := it.txn
-		tx.addReadKey(key)
+		it.txn.addReadKey(key)
 	}
 	for i := it.data.pop(); i != nil; i = it.data.pop() {
 		i.wg.Wait()

--- a/iterator.go
+++ b/iterator.go
@@ -505,8 +505,8 @@ func (it *Iterator) newItem() *Item {
 // Item returns pointer to the current key-value pair.
 // This item is only valid until it.Next() gets called.
 func (it *Iterator) Item() *Item {
-	tx := it.txn
-	tx.addReadKey(it.item.Key())
+	// tx := it.txn
+	// tx.addReadKey(it.item.Key())
 	return it.item
 }
 
@@ -713,6 +713,10 @@ func (it *Iterator) prefetch() {
 // smallest key greater than the provided key if iterating in the forward direction.
 // Behavior would be reversed if iterating backwards.
 func (it *Iterator) Seek(key []byte) {
+	if len(key) > 0 {
+		tx := it.txn
+		tx.addReadKey(key)
+	}
 	for i := it.data.pop(); i != nil; i = it.data.pop() {
 		i.wg.Wait()
 		it.waste.push(i)

--- a/txn.go
+++ b/txn.go
@@ -439,7 +439,6 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 func (txn *Txn) addReadKey(key []byte) {
 	if txn.update {
 		fp := z.MemHash(key)
-
 		// Because of the possibility of multiple iterators it is now possible
 		// for multiple threads within a read-write transaction to read keys at
 		// the same time. The reads slice is not currently thread-safe and

--- a/txn.go
+++ b/txn.go
@@ -486,6 +486,7 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 func (txn *Txn) addReadKey(key []byte) {
 	if txn.update {
 		fp := z.MemHash(key)
+
 		// Because of the possibility of multiple iterators it is now possible
 		// for multiple threads within a read-write transaction to read keys at
 		// the same time. The reads slice is not currently thread-safe and

--- a/txn_test.go
+++ b/txn_test.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -864,4 +865,82 @@ func TestArmV7Issue311Fix(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
+}
+
+// This test tries to perform a GetAndSet operation using multiple concurrent
+// transaction and only one of the transactions should be successful.
+// Regression test for https://github.com/dgraph-io/badger/issues/1289
+func TestConflict(t *testing.T) {
+	key := []byte("foo")
+	setCount := uint32(0)
+
+	testAndSet := func(wg *sync.WaitGroup, db *DB) {
+		defer wg.Done()
+		txn := db.NewTransaction(true)
+		defer txn.Discard()
+
+		_, err := txn.Get(key)
+		if err == ErrKeyNotFound {
+			// Unset the error.
+			err = nil
+			require.NoError(t, txn.Set(key, []byte("AA")))
+			txn.CommitWith(func(err error) {
+				if err == nil {
+					require.LessOrEqual(t, uint32(1), atomic.AddUint32(&setCount, 1))
+				} else {
+
+					require.Error(t, err, ErrConflict)
+				}
+			})
+		}
+		require.NoError(t, err)
+	}
+	testAndSetItr := func(wg *sync.WaitGroup, db *DB) {
+		defer wg.Done()
+		txn := db.NewTransaction(true)
+		defer txn.Discard()
+
+		iopt := DefaultIteratorOptions
+		it := txn.NewIterator(iopt)
+
+		found := false
+		for it.Seek(key); it.Valid(); it.Next() {
+			found = true
+		}
+		it.Close()
+
+		if !found {
+			require.NoError(t, txn.Set(key, []byte("AA")))
+			txn.CommitWith(func(err error) {
+				if err == nil {
+					require.LessOrEqual(t, atomic.AddUint32(&setCount, 1), uint32(1))
+				} else {
+					require.Error(t, err, ErrConflict)
+				}
+			})
+		}
+	}
+
+	runTest := func(t *testing.T, fn func(wg *sync.WaitGroup, db *DB)) {
+		loop := 10
+		numGo := 16 // This many concurrent transactions.
+		for i := 0; i < loop; i++ {
+			var wg sync.WaitGroup
+			wg.Add(numGo)
+			setCount = 0
+			runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+				for j := 0; j < numGo; j++ {
+					go fn(&wg, db)
+				}
+				wg.Wait()
+			})
+			require.Equal(t, uint32(1), setCount)
+		}
+	}
+	t.Run("TxnGet", func(t *testing.T) {
+		runTest(t, testAndSet)
+	})
+	t.Run("ItrSeek", func(t *testing.T) {
+		runTest(t, testAndSetItr)
+	})
 }

--- a/txn_test.go
+++ b/txn_test.go
@@ -934,7 +934,7 @@ func TestConflict(t *testing.T) {
 				}
 				wg.Wait()
 			})
-			require.Equal(t, uint32(1), setCount)
+			require.Equal(t, uint32(1), atomic.LoadUint32(&setCount))
 		}
 	}
 	t.Run("TxnGet", func(t *testing.T) {


### PR DESCRIPTION
The SSI guarantees provided by badger are respected when multiple concurrent transactions try to update the same key at once using the txn.Get and txn.Set API
```
// txn.Get
// if not found; txn.Set and Commit
```
but the same guarantees fail when an `iterator` is used instead of the `txn.Get` API
```
// itr.Seek(key)
// if not itr.Valid(); txn.Set and Commit
```
If the code about is executed via multiple concurrent transactions, we might lose some updates.

The test `TestConflict` added in this PR fails on master but works fine on this PR.

Fixes https://github.com/dgraph-io/badger/issues/1289

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1328)
<!-- Reviewable:end -->
