### PR TITLE
DropPrefix: Return error on blocked writes

### DIFF
--- a/db.go
+++ b/db.go
@@ -1532,7 +1532,7 @@ func (db *DB) dropAll() (func(), error) {
 	db.opt.Infof("DropAll called. Blocking writes...")
 	f, err := db.prepareToDrop()
 	if err != nil {
-		return nil, err
+		return f, err
 	}
 	// prepareToDrop will stop all the incomming write and flushes any pending flush tasks.
 	// Before we drop, we'll stop the compaction because anyways all the datas are going to

--- a/db.go
+++ b/db.go
@@ -1459,13 +1459,16 @@ func (db *DB) Flatten(workers int) error {
 	}
 }
 
-func (db *DB) blockWrite() {
+func (db *DB) blockWrite() error {
 	// Stop accepting new writes.
-	atomic.StoreInt32(&db.blockWrites, 1)
+	if !atomic.CompareAndSwapInt32(&db.blockWrites, 0, 1) {
+		return ErrBlockedWrites
+	}
 
 	// Make all pending writes finish. The following will also close writeCh.
 	db.closers.writes.SignalAndWait()
 	db.opt.Infof("Writes flushed. Stopping compactions now...")
+	return nil
 }
 
 func (db *DB) unblockWrite() {
@@ -1476,14 +1479,16 @@ func (db *DB) unblockWrite() {
 	atomic.StoreInt32(&db.blockWrites, 0)
 }
 
-func (db *DB) prepareToDrop() func() {
+func (db *DB) prepareToDrop() (func(), error) {
 	if db.opt.ReadOnly {
 		panic("Attempting to drop data in read-only mode.")
 	}
 	// In order prepare for drop, we need to block the incoming writes and
 	// write it to db. Then, flush all the pending flushtask. So that, we
 	// don't miss any entries.
-	db.blockWrite()
+	if err := db.blockWrite(); err != nil {
+		return nil, err
+	}
 	reqs := make([]*request, 0, 10)
 	for {
 		select {
@@ -1498,7 +1503,7 @@ func (db *DB) prepareToDrop() func() {
 				db.opt.Infof("Resuming writes")
 				db.startMemoryFlush()
 				db.unblockWrite()
-			}
+			}, nil
 		}
 	}
 }
@@ -1516,16 +1521,19 @@ func (db *DB) prepareToDrop() func() {
 // writes are paused before running DropAll, and resumed after it is finished.
 func (db *DB) DropAll() error {
 	f, err := db.dropAll()
-	defer f()
 	if err != nil {
 		return err
 	}
+	defer f()
 	return nil
 }
 
 func (db *DB) dropAll() (func(), error) {
 	db.opt.Infof("DropAll called. Blocking writes...")
-	f := db.prepareToDrop()
+	f, err := db.prepareToDrop()
+	if err != nil {
+		return nil, err
+	}
 	// prepareToDrop will stop all the incomming write and flushes any pending flush tasks.
 	// Before we drop, we'll stop the compaction because anyways all the datas are going to
 	// be deleted.
@@ -1577,7 +1585,10 @@ func (db *DB) dropAll() (func(), error) {
 // - Compact rest of the levels, Li->Li, picking tables which have Kp.
 // - Resume memtable flushes, compactions and writes.
 func (db *DB) DropPrefix(prefix []byte) error {
-	f := db.prepareToDrop()
+	f, err := db.prepareToDrop()
+	if err != nil {
+		return err
+	}
 	defer f()
 	// Block all foreign interactions with memory tables.
 	db.Lock()

--- a/db.go
+++ b/db.go
@@ -1521,10 +1521,10 @@ func (db *DB) prepareToDrop() (func(), error) {
 // writes are paused before running DropAll, and resumed after it is finished.
 func (db *DB) DropAll() error {
 	f, err := db.dropAll()
+	defer f()
 	if err != nil {
 		return err
 	}
-	defer f()
 	return nil
 }
 

--- a/db.go
+++ b/db.go
@@ -1521,10 +1521,10 @@ func (db *DB) prepareToDrop() (func(), error) {
 // writes are paused before running DropAll, and resumed after it is finished.
 func (db *DB) DropAll() error {
 	f, err := db.dropAll()
-	defer f()
 	if err != nil {
 		return err
 	}
+	defer f()
 	return nil
 }
 
@@ -1585,6 +1585,7 @@ func (db *DB) dropAll() (func(), error) {
 // - Compact rest of the levels, Li->Li, picking tables which have Kp.
 // - Resume memtable flushes, compactions and writes.
 func (db *DB) DropPrefix(prefix []byte) error {
+	db.opt.Infof("DropPrefix Called")
 	f, err := db.prepareToDrop()
 	if err != nil {
 		return err

--- a/db2_test.go
+++ b/db2_test.go
@@ -798,13 +798,23 @@ func TestDropAllDropPrefix(t *testing.T) {
 		require.NoError(t, wb.Flush())
 
 		var wg sync.WaitGroup
-		wg.Add(2)
+		wg.Add(3)
 		go func() {
 			defer wg.Done()
 			err := db.DropPrefix([]byte("000"))
 			for err == ErrBlockedWrites {
-				fmt.Printf("DropPrefix err: %v", err)
+				fmt.Printf("DropPrefix 000 err: %v", err)
 				err = db.DropPrefix([]byte("000"))
+				time.Sleep(time.Millisecond * 500)
+			}
+			require.NoError(t, err)
+		}()
+		go func() {
+			defer wg.Done()
+			err := db.DropPrefix([]byte("111"))
+			for err == ErrBlockedWrites {
+				fmt.Printf("DropPrefix 111 err: %v", err)
+				err = db.DropPrefix([]byte("111"))
 				time.Sleep(time.Millisecond * 500)
 			}
 			require.NoError(t, err)

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -121,7 +121,23 @@ func TestDropAll(t *testing.T) {
 	populate(db)
 	require.Equal(t, int(N), numKeys(db))
 
-	require.NoError(t, db.DropAll())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, db.DropAll())
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(time.Millisecond)
+		err := db.DropPrefix([]byte("aaa"))
+		for err != nil {
+			time.Sleep(time.Millisecond)
+			err = db.DropPrefix([]byte("aaa"))
+		}
+	}()
+	wg.Wait()
 	require.Equal(t, 0, numKeys(db))
 
 	// Check that we can still write to mdb, and using lower timestamps.

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -121,23 +121,7 @@ func TestDropAll(t *testing.T) {
 	populate(db)
 	require.Equal(t, int(N), numKeys(db))
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		require.NoError(t, db.DropAll())
-	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		time.Sleep(time.Millisecond)
-		err := db.DropPrefix([]byte("aaa"))
-		for err != nil {
-			time.Sleep(time.Millisecond)
-			err = db.DropPrefix([]byte("aaa"))
-		}
-	}()
-	wg.Wait()
+	require.NoError(t, db.DropAll())
 	require.Equal(t, 0, numKeys(db))
 
 	// Check that we can still write to mdb, and using lower timestamps.


### PR DESCRIPTION
DropAll and DropPrefix both of them block writes before they start their processing. If both of them were called concurrently, one of them would panic because the other call would've blocked the writes. This PR fixes it by returning an error on blocked writes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1329)
<!-- Reviewable:end -->
