### PR TITLE
Fixed panic when iterating past the last item in the database.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -786,6 +786,8 @@ func TestIterateEnd(t *testing.T) {
 		// panic.
 		err := db.View(func(txn *Txn) error {
 			itr := txn.NewIterator(DefaultIteratorOptions)
+			defer itr.Close()
+
 			itr.Rewind() // Move the iterator the beginning of the database.
 
 			for {

--- a/iterator.go
+++ b/iterator.go
@@ -504,7 +504,14 @@ func (it *Iterator) newItem() *Item {
 
 // Item returns pointer to the current key-value pair.
 // This item is only valid until it.Next() gets called.
+// If it returns nil, then there are no more items to iterate over.
 func (it *Iterator) Item() *Item {
+	// Make sure that we aren't at the end of the database. If we are and we don't check this then it could panic if the
+	// user tries to read the item after calling Next after the last item in the DB.
+	if it.item == nil {
+		return nil
+	}
+
 	tx := it.txn
 	tx.addReadKey(it.item.Key())
 	return it.item


### PR DESCRIPTION
Currently if you try to iterate over an entire database without any logic that would stop the iterator, the iterator will reach the end of the database and then panic if you call `itr.Item()`.

This behavior can be seen with the following test.

```golang
func TestIterateEnd(t *testing.T) {
	N := 100
	key := func(account int) []byte {
		var b [4]byte
		binary.BigEndian.PutUint32(b[:], uint32(account))
		return append([]byte("/record/"), b[:]...)
	}

	opt := DefaultOptions("")
	runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
		// Seed the database with some basic values.
		for i := 0; i < N; i++ {
			txn := db.NewTransaction(true)
			require.NoError(t, txn.SetEntry(NewEntry(key(i), []byte("1000"))))
			require.NoError(t, txn.Commit(), "transaction should commit successfully")
		}

		// Then try to iterate over all of the records in the database. Make sure that once we hit the end it does not
		// panic.
		err := db.View(func(txn *Txn) error {
			itr := txn.NewIterator(DefaultIteratorOptions)
			itr.Rewind() // Move the iterator the beginning of the database.

			for {
				var item *Item

				// Previously this would panic after Next is called on the last record in the DB. This test should
				// verify that when there are no more items the DB, then Item should return nil rather than panicking.
				item = itr.Item()

				// If the item is nil, then there are no more items.
				if item == nil {
					break
				}

				// Try to grab the next item.
				itr.Next()
			}

			return nil
		})
		require.NoError(t, err)
	})
}
```

Which results in this on master:

```
=== RUN   TestIterateEnd
badger 2020/05/16 19:24:15 INFO: All 0 tables opened in 0s
badger 2020/05/16 19:24:15 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
badger 2020/05/16 19:24:15 INFO: Running for level: 0
badger 2020/05/16 19:24:15 INFO: LOG Compact 0->1, del 1 tables, add 1 tables, took 12.675893ms
badger 2020/05/16 19:24:15 INFO: Compaction for level: 0 DONE
badger 2020/05/16 19:24:15 INFO: Force compaction on level 0 done
--- FAIL: TestIterateEnd (0.08s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x448e955]

goroutine 6 [running]:
testing.tRunner.func1(0xc0000f0200)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:874 +0x3a3
panic(0x4610b40, 0x4add360)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
github.com/dgraph-io/badger/v2.(*Item).Key(...)
	/Users/elliotcourant/projects/badger/iterator.go:70
github.com/dgraph-io/badger/v2.(*Iterator).Item(...)
	/Users/elliotcourant/projects/badger/iterator.go:509
github.com/dgraph-io/badger/v2.TestIterateEnd.func2.1(0xc0000c5b80, 0x0, 0x0)
	/Users/elliotcourant/projects/badger/db_test.go:798 +0xf5
github.com/dgraph-io/badger/v2.(*DB).View(0xc000086400, 0x46cadd8, 0x0, 0x0)
	/Users/elliotcourant/projects/badger/txn.go:756 +0x9b
github.com/dgraph-io/badger/v2.TestIterateEnd.func2(0xc0000f0200, 0xc000086400)
	/Users/elliotcourant/projects/badger/db_test.go:787 +0x243
github.com/dgraph-io/badger/v2.runBadgerTest(0xc0000f0200, 0xc000065e18, 0xc0056a7e00)
	/Users/elliotcourant/projects/badger/db_test.go:136 +0x2b3
github.com/dgraph-io/badger/v2.TestIterateEnd(0xc0000f0200)
	/Users/elliotcourant/projects/badger/db_test.go:777 +0xd7
testing.tRunner(0xc0000f0200, 0x46cade0)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:960 +0x350

Process finished with exit code 1
```

This fixes the issue by checking to see if the current item is nil before even trying to evaluate the addReadKey. If the current item is nil then nil is simply returned and no other actions are performed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1333)
<!-- Reviewable:end -->
