### PR TITLE
fix: Fix race condition in block.incRef

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -364,6 +364,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 		WithNumVersionsToKeep(int(math.MaxInt32)).
 		WithValueThreshold(1). // Make all values go to value log
 		WithCompression(options.ZSTD).
+		WithKeepL0InMemory(false).
 		WithMaxCacheSize(10 << 20)
 
 	if mmap {

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -197,8 +197,8 @@ func diff(a, b []account) string {
 
 var errFailure = errors.New("test failed due to balance mismatch")
 
-// get function will fetch the value for the key "k" either by using tht
-// txn.Get API or the iterator.Seek API
+// get function will fetch the value for the key "k" either by using the
+// txn.Get API or the iterator.Seek API.
 func get(txn *badger.Txn, k []byte) (*badger.Item, error) {
 	if rand.Int()%2 == 0 {
 		return txn.Get(k)

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -44,8 +44,6 @@ func (itr *blockIterator) setBlock(b *block) {
 	// Decrement the ref for the old block. If the old block was compressed, we
 	// might be able to reuse it.
 	itr.block.decrRef()
-	// Increment the ref for the new block.
-	b.incrRef()
 
 	itr.block = b
 	itr.err = nil

--- a/table/table.go
+++ b/table/table.go
@@ -187,16 +187,18 @@ type block struct {
 	ref               int32
 }
 
+// incrRef increments the ref of a block and return a bool indicating if the
+// increment was successful. A true value indicates that the block can be used.
 func (b *block) incrRef() bool {
-	for {
-		ref := atomic.LoadInt32(&b.ref)
-		if ref == 0 {
-			return false
-		}
-		if atomic.CompareAndSwapInt32(&b.ref, ref, ref+1) {
-			return true
-		}
+	// The ref should not be equal to 1 after incrementing unless the existing
+	// value was 0. If the existing value was 0, it mean that the block is
+	// already added the the blockPool and cannot be used anymore. The ref of a
+	// new block is 1 so the following condition will be true only if the block
+	// got reused before we could increment its ref.
+	if atomic.AddInt32(&b.ref, 1) == 1 {
+		return false
 	}
+	return true
 }
 func (b *block) decrRef() {
 	if b == nil {
@@ -426,6 +428,9 @@ func (t *Table) readIndex() error {
 	return nil
 }
 
+// block function return a new block. Each block holds a ref and the byte
+// slice stored in the block will be reused when the ref becomes zero. The
+// caller should release the block by calling block.decrRef() on it.
 func (t *Table) block(idx int) (*block, error) {
 	y.AssertTruef(idx >= 0, "idx=%d", idx)
 	if idx >= len(t.blockIndex) {
@@ -436,6 +441,9 @@ func (t *Table) block(idx int) (*block, error) {
 		blk, ok := t.opt.Cache.Get(key)
 		if ok && blk != nil {
 			b := blk.(*block)
+			// Use the block only if the increment was successful. The block
+			// could get evicted from the cache between the Get() call and the
+			// incrRef() call.
 			if b.incrRef() {
 				return b, nil
 			}
@@ -501,7 +509,11 @@ func (t *Table) block(idx int) (*block, error) {
 	}
 	if t.opt.Cache != nil {
 		key := t.blockCacheKey(idx)
+		// incrRef should never return false here because we're calling it on a
+		// new block with ref=1.
 		y.AssertTrue(blk.incrRef())
+
+		// Decrement the block ref if we could not insert it in the cache.
 		if !t.opt.Cache.Set(key, blk, blk.size()) {
 			blk.decrRef()
 		}


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/dgraph/issues/5456 .

This PR fixes the crash that could occur when a block was read from the cache.
There was a logical race condition. The following sequence of events could occur which would cause the crash.
1. An iterator makes `t.Block(idx)` call
2. The `t.Block` function finds the block in the cache. The newly found block has `ref=1` which means it was held only by the cache.
3. The `t.Block` function is holding the block and at the same time the block gets evicted from the cache. The existing ref of the block was `1` so the cache eviction would decrement the ref and make it `0`. When the ref becomes `0`, the block is added to the `sync.Pool` and is ready to be reused.
4. While the block got evicted from the cache, the iterator received the block and it incremented the ref from `0` to `1` and starts using this.

Since the block was inserted into the syncPool in the 3rd event, it could be modified by anyone while the iterator is using it.

The fix is to not increment the block ref if it is already zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1337)
<!-- Reviewable:end -->
