### PR TITLE
Use BfCache instead of BlockCache for bloomfilters

### DIFF
--- a/db.go
+++ b/db.go
@@ -317,7 +317,7 @@ func Open(opt Options) (db *DB, err error) {
 			BufferItems: 64,
 			Metrics:     true,
 		}
-		db.blockCache, err = ristretto.NewCache(&config)
+		db.bfCache, err = ristretto.NewCache(&config)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create bf cache")
 		}


### PR DESCRIPTION
The `db.BlockCache` was being used instead of `db.BfCache`. This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1339)
<!-- Reviewable:end -->
