### PR TITLE
Increase test timeout from 10m to 15m

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -38,9 +38,9 @@ go test -v -race $packages
 echo
 echo "==> Starting tests with value log mmapped..."
 # Run top level package tests with mmap flag.
-go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=true
+go test -timeout=15m -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=true
 
 echo
 echo "==> Starting tests with value log not mmapped..."
-go test -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=false
+go test -timeout=15m -v -race github.com/dgraph-io/badger/v2 --vlog_mmap=false
 


### PR DESCRIPTION
Teamcity build fails intermittently because of the 10-minute timeout. The 10-minute timeout is for the complete test suite. This PR increases the test timeout from 10 minutes to 15 minutes. We might need to increase the timeout in future when more tests are added.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1340)
<!-- Reviewable:end -->
