### PR TITLE
DefaultOptions: Set KeepL0InMemory to false

### DIFF
--- a/options.go
+++ b/options.go
@@ -127,7 +127,7 @@ func DefaultOptions(path string) Options {
 		SyncWrites:              true,
 		NumVersionsToKeep:       1,
 		CompactL0OnClose:        true,
-		KeepL0InMemory:          true,
+		KeepL0InMemory:          false,
 		VerifyValueChecksum:     false,
 		Compression:             options.None,
 		MaxCacheSize:            0,
@@ -454,6 +454,7 @@ func (opt Options) WithNumCompactors(val int) Options {
 // CompactL0OnClose determines whether Level 0 should be compacted before closing the DB.
 // This ensures that both reads and writes are efficient when the DB is opened later.
 // CompactL0OnClose is set to true if KeepL0InMemory is set to true.
+//
 // The default value of CompactL0OnClose is true.
 func (opt Options) WithCompactL0OnClose(val bool) Options {
 	opt.CompactL0OnClose = val
@@ -501,7 +502,7 @@ func (opt Options) WithEncryptionKeyRotationDuration(d time.Duration) Options {
 // will take longer to complete since memtables and all level 0 tables will have to be recreated.
 // This option also sets CompactL0OnClose option to true.
 //
-// The default value of KeepL0InMemory is true.
+// The default value of KeepL0InMemory is false.
 func (opt Options) WithKeepL0InMemory(val bool) Options {
 	opt.KeepL0InMemory = val
 	return opt


### PR DESCRIPTION
This commit sets the default value of KeepL0InMemory to false. There
have been multiple reports of slow value log replays which is a side
effect of keeping level 0 tables in memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1345)
<!-- Reviewable:end -->
