### PR TITLE
StreamWriter: Close head writer

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -223,10 +223,12 @@ func (sw *StreamWriter) Flush() error {
 		y.ValueStruct{Value: data}); err != nil {
 		return err
 	}
+
+	headWriter.closer.SignalAndWait()
+
 	if err := headWriter.Done(); err != nil {
 		return err
 	}
-	headWriter.closer.SignalAndWait()
 
 	if !sw.db.opt.managedTxns {
 		if sw.db.orc != nil {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -226,6 +226,7 @@ func (sw *StreamWriter) Flush() error {
 	if err := headWriter.Done(); err != nil {
 		return err
 	}
+	headWriter.closer.SignalAndWait()
 
 	if !sw.db.opt.managedTxns {
 		if sw.db.orc != nil {


### PR DESCRIPTION
The head writer was not being closed which would leak the
`handleRequests` go routine. This PR fixes it by closing the head
writer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1347)
<!-- Reviewable:end -->
