### PR TITLE
Tests: Do not leave behind state goroutines

### DIFF
--- a/db.go
+++ b/db.go
@@ -378,7 +378,7 @@ func Open(opt Options) (db *DB, err error) {
 	go db.doWrites(replayCloser)
 
 	if err = db.vlog.open(db, vptr, db.replayFunction()); err != nil {
-		// Perform cleanup
+		// Perform cleanup.
 		replayCloser.SignalAndWait()
 		db.closers.updateSize.SignalAndWait()
 		db.blockCache.Close()

--- a/db_test.go
+++ b/db_test.go
@@ -1269,7 +1269,6 @@ func TestExpiryImproperDBClose(t *testing.T) {
 		// graceful shutdown of db0.
 		db0, err := Open(opt.WithCompactL0OnClose(false))
 		require.NoError(t, err)
-		defer func() { require.NoError(t, db0.Close()) }()
 
 		dur := 1 * time.Hour
 		expiryTime := uint64(time.Now().Add(dur).Unix())
@@ -1289,13 +1288,8 @@ func TestExpiryImproperDBClose(t *testing.T) {
 			require.NoError(t, db0.valueDirGuard.release())
 			db0.valueDirGuard = nil
 		}
+		require.NoError(t, db0.Close())
 
-		// On windows, the vlog file is truncated to 2*MaxVlogSize and if we
-		// do not set the trucate flag, reopening the db would return Truncate
-		// Required Error.
-		if runtime.GOOS == "windows" {
-			opt.Truncate = true
-		}
 		db1, err := Open(opt)
 		require.NoError(t, err)
 		err = db1.View(func(txn *Txn) error {

--- a/db_test.go
+++ b/db_test.go
@@ -1291,6 +1291,12 @@ func TestExpiryImproperDBClose(t *testing.T) {
 			db0.valueDirGuard = nil
 		}
 
+		// On windows, the vlog file is truncated to 2*MaxVlogSize and if we
+		// do not set the trucate flag, reopening the db would return Truncate
+		// Required Error.
+		if runtime.GOOS == "windows" {
+			opt.Truncate = true
+		}
 		db1, err := Open(opt)
 		fmt.Printf("err = %+v\n", err)
 		require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -1269,6 +1269,7 @@ func TestExpiryImproperDBClose(t *testing.T) {
 		// graceful shutdown of db0.
 		db0, err := Open(opt.WithCompactL0OnClose(false))
 		require.NoError(t, err)
+		fmt.Printf("db0.opt.dir = %+v\n", db0.opt.Dir)
 		defer func() { require.NoError(t, db0.Close()) }()
 
 		dur := 1 * time.Hour
@@ -1292,6 +1293,7 @@ func TestExpiryImproperDBClose(t *testing.T) {
 
 		db1, err := Open(opt)
 		require.NoError(t, err)
+		fmt.Printf("db1.opt.dir = %+v\n", db1.opt.Dir)
 		err = db1.View(func(txn *Txn) error {
 			itm, err := txn.Get([]byte("test_key"))
 			require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -1265,8 +1265,11 @@ func TestExpiry(t *testing.T) {
 func TestExpiryImproperDBClose(t *testing.T) {
 	testReplay := func(opt Options) {
 
-		db0, err := Open(opt)
+		// L0 compaction doesn't affect the test in any way. It is set to allow
+		// graceful shutdown of db0.
+		db0, err := Open(opt.WithCompactL0OnClose(false))
 		require.NoError(t, err)
+		defer func() { require.NoError(t, db0.Close()) }()
 
 		dur := 1 * time.Hour
 		expiryTime := uint64(time.Now().Add(dur).Unix())
@@ -1280,17 +1283,12 @@ func TestExpiryImproperDBClose(t *testing.T) {
 		// Simulate a crash  by not closing db0, but releasing the locks.
 		if db0.dirLockGuard != nil {
 			require.NoError(t, db0.dirLockGuard.release())
+			db0.dirLockGuard = nil
 		}
 		if db0.valueDirGuard != nil {
 			require.NoError(t, db0.valueDirGuard.release())
+			db0.valueDirGuard = nil
 		}
-		// We need to close vlog to fix the vlog file size. On windows, the vlog file
-		// is truncated to 2*MaxVlogSize and if we don't close the vlog file, reopening
-		// it would return Truncate Required Error.
-		require.NoError(t, db0.vlog.Close())
-
-		require.NoError(t, db0.registry.Close())
-		require.NoError(t, db0.manifest.close())
 
 		db1, err := Open(opt)
 		require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -1292,6 +1292,7 @@ func TestExpiryImproperDBClose(t *testing.T) {
 		}
 
 		db1, err := Open(opt)
+		fmt.Printf("err = %+v\n", err)
 		require.NoError(t, err)
 		fmt.Printf("db1.opt.dir = %+v\n", db1.opt.Dir)
 		err = db1.View(func(txn *Txn) error {

--- a/db_test.go
+++ b/db_test.go
@@ -1269,7 +1269,6 @@ func TestExpiryImproperDBClose(t *testing.T) {
 		// graceful shutdown of db0.
 		db0, err := Open(opt.WithCompactL0OnClose(false))
 		require.NoError(t, err)
-		fmt.Printf("db0.opt.dir = %+v\n", db0.opt.Dir)
 		defer func() { require.NoError(t, db0.Close()) }()
 
 		dur := 1 * time.Hour
@@ -1298,9 +1297,7 @@ func TestExpiryImproperDBClose(t *testing.T) {
 			opt.Truncate = true
 		}
 		db1, err := Open(opt)
-		fmt.Printf("err = %+v\n", err)
 		require.NoError(t, err)
-		fmt.Printf("db1.opt.dir = %+v\n", db1.opt.Dir)
 		err = db1.View(func(txn *Txn) error {
 			itm, err := txn.Get([]byte("test_key"))
 			require.NoError(t, err)

--- a/levels_test.go
+++ b/levels_test.go
@@ -538,6 +538,15 @@ func TestL0Stall(t *testing.T) {
 					t.Log("Timeout triggered")
 					// Mark this test as successful since L0 is in memory and the
 					// addition of new table to L0 is supposed to stall.
+
+					// Remove tables from level 0 so that the stalled
+					// compaction can make progress. This does not have any
+					// effect on the test. This is done so that the goroutine
+					// stuck on addLevel0Table can make progress and end.
+					db.lc.levels[0].Lock()
+					db.lc.levels[0].tables = nil
+					db.lc.levels[0].Unlock()
+					<-done
 				} else {
 					t.Fatal("Test didn't finish in time")
 				}

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -524,9 +524,9 @@ func TestDropPrefixReadOnly(t *testing.T) {
 		require.Equal(t, err, ErrWindowsNotSupported)
 	} else {
 		require.NoError(t, err)
+		require.Panics(t, func() { db2.DropPrefix([]byte("key0")) })
+		require.NoError(t, db2.Close())
 	}
-	require.Panics(t, func() { db2.DropPrefix([]byte("key0")) })
-	require.NoError(t, db2.Close())
 }
 
 func TestDropPrefixRace(t *testing.T) {

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -162,6 +162,7 @@ func TestDropAllTwice(t *testing.T) {
 
 		// Call DropAll again.
 		require.NoError(t, db.DropAll())
+		require.NoError(t, db.Close())
 	}
 	t.Run("disk mode", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "badger-test")
@@ -175,7 +176,6 @@ func TestDropAllTwice(t *testing.T) {
 		opts := getTestOptions("")
 		opts.InMemory = true
 		test(t, opts)
-
 	})
 }
 
@@ -280,6 +280,7 @@ func TestDropReadOnly(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.Panics(t, func() { db2.DropAll() })
+	require.NoError(t, db2.Close())
 }
 
 func TestWriteAfterClose(t *testing.T) {
@@ -525,6 +526,7 @@ func TestDropPrefixReadOnly(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.Panics(t, func() { db2.DropPrefix([]byte("key0")) })
+	require.NoError(t, db2.Close())
 }
 
 func TestDropPrefixRace(t *testing.T) {
@@ -590,7 +592,7 @@ func TestDropPrefixRace(t *testing.T) {
 	after := numKeysManaged(db, math.MaxUint64)
 	t.Logf("Before: %d. After dropprefix: %d\n", before, after)
 	require.True(t, after < before)
-	db.Close()
+	require.NoError(t, db.Close())
 }
 
 func TestWriteBatchManagedMode(t *testing.T) {

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -278,9 +278,9 @@ func TestDropReadOnly(t *testing.T) {
 		require.Equal(t, err, ErrWindowsNotSupported)
 	} else {
 		require.NoError(t, err)
+		require.Panics(t, func() { db2.DropAll() })
+		require.NoError(t, db2.Close())
 	}
-	require.Panics(t, func() { db2.DropAll() })
-	require.NoError(t, db2.Close())
 }
 
 func TestWriteAfterClose(t *testing.T) {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -229,7 +229,6 @@ func (sw *StreamWriter) Flush() error {
 	if err := headWriter.Done(); err != nil {
 		return err
 	}
-	headWriter.closer.SignalAndWait()
 
 	if !sw.db.opt.managedTxns {
 		if sw.db.orc != nil {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -226,6 +226,7 @@ func (sw *StreamWriter) Flush() error {
 	if err := headWriter.Done(); err != nil {
 		return err
 	}
+	headWriter.closer.SignalAndWait()
 
 	if !sw.db.opt.managedTxns {
 		if sw.db.orc != nil {

--- a/value.go
+++ b/value.go
@@ -1219,7 +1219,7 @@ func (lf *logFile) init() error {
 }
 
 func (vlog *valueLog) Close() error {
-	if vlog.db.opt.InMemory {
+	if vlog == nil || vlog.db == nil || vlog.db.opt.InMemory {
 		return nil
 	}
 	// close flushDiscardStats.

--- a/value_test.go
+++ b/value_test.go
@@ -801,7 +801,6 @@ func TestPenultimateLogCorruption(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, db1.Close())
-
 }
 
 func checkKeys(t *testing.T, kv *DB, keys [][]byte) {

--- a/value_test.go
+++ b/value_test.go
@@ -762,6 +762,7 @@ func TestPenultimateLogCorruption(t *testing.T) {
 
 	db0, err := Open(opt)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, db0.Close()) }()
 
 	h := testHelper{db: db0, t: t}
 	h.writeRange(0, 7)
@@ -780,13 +781,12 @@ func TestPenultimateLogCorruption(t *testing.T) {
 	// Simulate a crash by not closing db0, but releasing the locks.
 	if db0.dirLockGuard != nil {
 		require.NoError(t, db0.dirLockGuard.release())
+		db0.dirLockGuard = nil
 	}
 	if db0.valueDirGuard != nil {
 		require.NoError(t, db0.valueDirGuard.release())
+		db0.valueDirGuard = nil
 	}
-	require.NoError(t, db0.vlog.Close())
-	require.NoError(t, db0.manifest.close())
-	require.NoError(t, db0.registry.Close())
 
 	opt.Truncate = true
 	db1, err := Open(opt)
@@ -801,6 +801,7 @@ func TestPenultimateLogCorruption(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, db1.Close())
+
 }
 
 func checkKeys(t *testing.T, kv *DB, keys [][]byte) {


### PR DESCRIPTION
A bunch of tests would start goroutines and never stop them. This
PR fixes that. There should not be any goroutines left after all the
tests are completed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1349)
<!-- Reviewable:end -->
