### PR TITLE
Fix build on golang tip

### DIFF
--- a/histogram_test.go
+++ b/histogram_test.go
@@ -27,7 +27,7 @@ func TestBuildKeyValueSizeHistogram(t *testing.T) {
 		runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 			entries := int64(40)
 			err := db.Update(func(txn *Txn) error {
-				for i := int64(0); i < entries; i++ {
+				for i := rune(0); i < rune(entries); i++ {
 					err := txn.SetEntry(NewEntry([]byte(string(i)), []byte("B")))
 					if err != nil {
 						return err


### PR DESCRIPTION
Golang tip tests fail with:

    ./histogram_test.go:31:42: conversion from int64 to string yields a string of one rune

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1355)
<!-- Reviewable:end -->
