### PR TITLE
GC: Consider size of value while batching

### DIFF
--- a/value.go
+++ b/value.go
@@ -564,10 +564,11 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 
 			ne.Value = append([]byte{}, e.Value...)
 			es := int64(ne.estimateSize(vlog.opt.ValueThreshold))
-			// Consider size of value as well while considering the size. There
-			// has been reports of high memory usage in rewrite because we
-			// don't consider the value size.
+			// Consider size of value as well while considering the total size
+			// of the batch. There have been reports of high memory usage in
+			// rewrite because we don't consider the value size. See #1292.
 			es += int64(len(e.Value))
+
 			// Ensure length and size of wb is within transaction limits.
 			if int64(len(wb)+1) >= vlog.opt.maxBatchCount ||
 				size+es >= vlog.opt.maxBatchSize {

--- a/value.go
+++ b/value.go
@@ -564,6 +564,10 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 
 			ne.Value = append([]byte{}, e.Value...)
 			es := int64(ne.estimateSize(vlog.opt.ValueThreshold))
+			// Consider size of value as well while considering the size. There
+			// has been reports of high memory usage in rewrite because we
+			// don't consider the value size.
+			es += int64(len(e.Value))
 			// Ensure length and size of wb is within transaction limits.
 			if int64(len(wb)+1) >= vlog.opt.maxBatchCount ||
 				size+es >= vlog.opt.maxBatchSize {


### PR DESCRIPTION
The existing code doesn't consider the size of the value while calculating the size of the batch. This PR fixes it.

Fixes https://github.com/dgraph-io/badger/issues/1292

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1357)
<!-- Reviewable:end -->
