### PR TITLE
Fix assert in background compression and encryption.

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -151,9 +151,9 @@ func (b *Builder) handleBlock() {
 
 		// BlockBuf should always less than or equal to allocated space. If the blockBuf is greater
 		// than allocated space that means the data from this block cannot be stored in its
-		// existing location and trying to copy it over would mean we would over-writesome data
+		// existing location and trying to copy it over would mean we would over-write some data
 		// of the next block.
-		allocatedSpace := (item.end - item.start) + padding
+		allocatedSpace := (item.end - item.start) + padding + 1
 		y.AssertTruef(uint32(len(blockBuf)) <= allocatedSpace, "newend: %d oldend: %d padding: %d",
 			item.start+uint32(len(blockBuf)), item.end, padding)
 

--- a/table/builder.go
+++ b/table/builder.go
@@ -154,8 +154,12 @@ func (b *Builder) handleBlock() {
 		// that means the data from this block cannot be stored in its existing
 		// location and trying to copy it over would mean we would over-write
 		// some data of the next block.
-		y.AssertTruef(uint32(len(blockBuf)) <= item.end+padding,
-			"newend: %d item.end: %d padding: %d", len(blockBuf), item.end, padding)
+		allocatedSpace := (item.end - item.start) + padding
+		y.AssertTruef(uint32(len(blockBuf)) <= allocatedSpace,
+			"newend: %d item.end: %d padding: %d",
+			(allocatedSpace-uint32(len(blockBuf)))+item.end,
+			item.end,
+			padding)
 
 		// Acquire the buflock here. The builder.grow function might change
 		// the b.buf while this goroutine was running.

--- a/table/builder.go
+++ b/table/builder.go
@@ -149,17 +149,13 @@ func (b *Builder) handleBlock() {
 			blockBuf = eBlock
 		}
 
-		// The newend should always be less than or equal to the original end
-		// plus the padding. If the new end is greater than item.end+padding
-		// that means the data from this block cannot be stored in its existing
-		// location and trying to copy it over would mean we would over-write
-		// some data of the next block.
+		// BlockBuf should always less than or equal to allocated space. If the blockBuf is greater
+		// than allocated space that means the data from this block cannot be stored in its
+		// existing location and trying to copy it over would mean we would over-writesome data
+		// of the next block.
 		allocatedSpace := (item.end - item.start) + padding
-		y.AssertTruef(uint32(len(blockBuf)) <= allocatedSpace,
-			"newend: %d item.end: %d padding: %d",
-			(allocatedSpace-uint32(len(blockBuf)))+item.end,
-			item.end,
-			padding)
+		y.AssertTruef(uint32(len(blockBuf)) <= allocatedSpace, "newend: %d oldend: %d padding: %d",
+			item.start+uint32(len(blockBuf)), item.end, padding)
 
 		// Acquire the buflock here. The builder.grow function might change
 		// the b.buf while this goroutine was running.


### PR DESCRIPTION
use assert to find whether, the async compression/encryption able to fit thedestination block in the allocated space. Allocated space is calculated using (item.end-item.start) + padding.

Signed-off-by: Tiger <rbalajis25@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1366)
<!-- Reviewable:end -->
