### PR TITLE
pre allocate the cache key

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -596,11 +596,13 @@ func (t *Table) block(idx int) (*block, error) {
 // bfCacheKey returns the cache key for bloom filter.
 func (t *Table) bfCacheKey() []byte {
 	y.AssertTrue(t.id < math.MaxUint32)
-	buf := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf, uint32(t.id))
-
+	buf := make([]byte, 6)
 	// Without the "bf" prefix, we will have conflict with the blockCacheKey.
-	return append([]byte("bf"), buf...)
+	buf[0] = 'b'
+	buf[1] = 'f'
+
+	binary.BigEndian.PutUint32(buf[2:], uint32(t.id))
+	return buf
 }
 
 func (t *Table) blockCacheKey(idx int) []byte {
@@ -617,10 +619,12 @@ func (t *Table) blockCacheKey(idx int) []byte {
 // blockOffsetsCacheKey returns the cache key for block offsets.
 func (t *Table) blockOffsetsCacheKey() []byte {
 	y.AssertTrue(t.id < math.MaxUint32)
-	buf := make([]byte, 4, 6)
-	binary.BigEndian.PutUint32(buf, uint32(t.id))
+	buf := make([]byte, 6)
+	buf[0] = 'b'
+	buf[1] = 'o'
 
-	return append([]byte("bo"), buf...)
+	binary.BigEndian.PutUint32(buf[2:], uint32(t.id))
+	return buf
 }
 
 // EstimatedSize returns the total size of key-values stored in this table (including the


### PR DESCRIPTION
Previously, cache key buffer grows while adding id. 

This PR, will prealloacte the buffer to generate cache key.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1371)
<!-- Reviewable:end -->
