### PR TITLE
Update head while replaying

### DIFF
--- a/db.go
+++ b/db.go
@@ -1002,7 +1002,8 @@ func (db *DB) handleFlushTask(ft flushTask) error {
 	if ft.mt.Empty() {
 		return nil
 	}
-	// vptr can be zero in-inmemory mode and that's okay because we don't have any value log files and there won't be any replays.
+	// vptr can be zero in-inmemory mode and that's okay because we don't have
+	// any value log files and there won't be any replays.
 	if !db.opt.InMemory {
 		y.AssertTrue(!ft.vptr.IsZero())
 	}

--- a/db.go
+++ b/db.go
@@ -139,6 +139,7 @@ func (db *DB) replayFunction() func(Entry, valuePointer) error {
 			// Update vhead. If the crash happens while replay was in progess
 			// and the head is not updated, we will end up replaying all the
 			// files again.
+			y.AssertTrue(!vp.Less(db.vhead))
 			db.vhead = vp
 		}
 
@@ -1002,6 +1003,7 @@ func (db *DB) handleFlushTask(ft flushTask) error {
 		return nil
 	}
 
+	y.AssertTrue(!ft.vptr.IsZero())
 	// Store badger head even if vptr is zero, need it for readTs
 	db.opt.Debugf("Storing value log head: %+v\n", ft.vptr)
 	db.opt.Debugf("Storing offset: %+v\n", ft.vptr)

--- a/db.go
+++ b/db.go
@@ -136,6 +136,10 @@ func (db *DB) replayFunction() func(Entry, valuePointer) error {
 		} else {
 			nv = vp.Encode()
 			meta = meta | bitValuePointer
+			// Update vhead. If the crash happens while replay was in progess
+			// and the head is not updated, we will end up replaying all the
+			// files again.
+			db.vhead = vp
 		}
 
 		v := y.ValueStruct{

--- a/db.go
+++ b/db.go
@@ -1002,8 +1002,10 @@ func (db *DB) handleFlushTask(ft flushTask) error {
 	if ft.mt.Empty() {
 		return nil
 	}
-
-	y.AssertTrue(!ft.vptr.IsZero())
+	// vptr can be zero in-inmemory mode and that's okay because we don't have any value log files and there won't be any replays.
+	if !db.opt.InMemory {
+		y.AssertTrue(!ft.vptr.IsZero())
+	}
 	// Store badger head even if vptr is zero, need it for readTs
 	db.opt.Debugf("Storing value log head: %+v\n", ft.vptr)
 	db.opt.Debugf("Storing offset: %+v\n", ft.vptr)

--- a/db.go
+++ b/db.go
@@ -1003,11 +1003,7 @@ func (db *DB) handleFlushTask(ft flushTask) error {
 	if ft.mt.Empty() {
 		return nil
 	}
-	// vptr can be zero in-inmemory mode and that's okay because we don't have
-	// any value log files and there won't be any replays.
-	if !db.opt.InMemory {
-		y.AssertTrue(!ft.vptr.IsZero())
-	}
+
 	// Store badger head even if vptr is zero, need it for readTs
 	db.opt.Debugf("Storing value log head: %+v\n", ft.vptr)
 	db.opt.Debugf("Storing offset: %+v\n", ft.vptr)

--- a/value_test.go
+++ b/value_test.go
@@ -409,11 +409,9 @@ func TestValueGC4(t *testing.T) {
 	kv.vlog.rewrite(lf0, tr)
 	kv.vlog.rewrite(lf1, tr)
 
-	err = kv.vlog.Close()
-	require.NoError(t, err)
+	require.NoError(t, kv.Close())
 
-	kv.vlog.init(kv)
-	err = kv.vlog.open(kv, valuePointer{Fid: 2}, kv.replayFunction())
+	kv, err = Open(opt)
 	require.NoError(t, err)
 
 	for i := 0; i < 8; i++ {

--- a/value_test.go
+++ b/value_test.go
@@ -642,6 +642,11 @@ func TestPartialAppendToValueLog(t *testing.T) {
 	// Replay value log from beginning, badger head is past k2.
 	require.NoError(t, kv.vlog.Close())
 
+	// clean up the current db.vhead so that we can replay from the beginning.
+	// If we don't clear the current vhead, badger will error out since new
+	// head passed while opening vlog is zero in the following lines.
+	kv.vhead = valuePointer{}
+
 	kv.vlog.init(kv)
 	require.NoError(
 		t, kv.vlog.open(kv, valuePointer{Fid: 0}, kv.replayFunction()),

--- a/value_test.go
+++ b/value_test.go
@@ -370,7 +370,6 @@ func TestValueGC4(t *testing.T) {
 
 	kv, err := Open(opt)
 	require.NoError(t, err)
-	defer kv.Close()
 
 	sz := 128 << 10 // 5 entries per value log file.
 	txn := kv.NewTransaction(true)
@@ -433,6 +432,7 @@ func TestValueGC4(t *testing.T) {
 			return nil
 		}))
 	}
+	require.NoError(t, kv.Close())
 }
 
 func TestPersistLFDiscardStats(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/1363

The head pointer was not being updated when we perform replays. The head pointer would be updated only when the replay completes. If badger crashed between the point when replay started and replay finished, we would end up replaying all the value log files. This PR fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1372)
<!-- Reviewable:end -->
