### PR TITLE
Force KeepL0InMemory to be true when InMemory is true

### DIFF
--- a/db.go
+++ b/db.go
@@ -218,8 +218,7 @@ func Open(opt Options) (db *DB, err error) {
 	if opt.Compression == options.ZSTD && !y.CgoEnabled {
 		return nil, y.ErrZstdCgo
 	}
-	// Keep L0 in memory if either it is set or if InMemory is set. We
-	// shoudln't have L0 on disk in InMemory Mode.
+	// Keep L0 in memory if either KeepL0InMemory is set or if InMemory is set.
 	opt.KeepL0InMemory = opt.KeepL0InMemory || opt.InMemory
 
 	// Compact L0 on close if either it is set or if KeepL0InMemory is set. When

--- a/db.go
+++ b/db.go
@@ -218,6 +218,9 @@ func Open(opt Options) (db *DB, err error) {
 	if opt.Compression == options.ZSTD && !y.CgoEnabled {
 		return nil, y.ErrZstdCgo
 	}
+	// Keep L0 in memory if either it is set or if InMemory is set. We
+	// shoudln't have L0 on disk in InMemory Mode.
+	opt.KeepL0InMemory = opt.KeepL0InMemory || opt.InMemory
 
 	// Compact L0 on close if either it is set or if KeepL0InMemory is set. When
 	// keepL0InMemory is set we need to compact L0 on close otherwise we might lose data.


### PR DESCRIPTION
InMemory mode used to create L0 sst tables when KeepL0InMemory was false as mentioned in #1374

This commit will keep L0 in memory if either KeepL0InMemory is set or InMemory is set.

On running ` go test .`
Before : sst files were visible for a second 
Now : sst files won't created/visible

Fixes #1374

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1375)
<!-- Reviewable:end -->
