### PR TITLE
Remove second initialization of writech

### DIFF
--- a/db.go
+++ b/db.go
@@ -399,7 +399,6 @@ func Open(opt Options) (db *DB, err error) {
 	db.orc.readMark.Done(db.orc.nextTxnTs)
 	db.orc.incrementNextTs()
 
-	db.writeCh = make(chan *request, kvWriteChCapacity)
 	db.closers.writes = y.NewCloser(1)
 	go db.doWrites(db.closers.writes)
 


### PR DESCRIPTION
The `db.writeCh` is being initialized for the second time in `db.Open` which causes a race condition. 
The write channel was being closed in the `doWrites` goroutine earlier but that code was removed in https://github.com/dgraph-io/badger/commit/2b39009229f09bc05bc229a2032e912b5c65d880 . We no longer need the second initialization.

See build https://teamcity.dgraph.io/viewLog.html?buildId=72266&buildTypeId=Badger_UnitTests
```
------- Stdout: -------
=== RUN   TestDiscardStatsMove
badger 2020/06/23 10:48:58 INFO: All 0 tables opened in 0s
badger 2020/06/23 10:48:58 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
badger 2020/06/23 10:48:58 INFO: Running for level: 0
badger 2020/06/23 10:48:58 INFO: LOG Compact 0->1, del 2 tables, add 1 tables, took 6.73414ms
badger 2020/06/23 10:48:58 INFO: Compaction for level: 0 DONE
badger 2020/06/23 10:48:58 INFO: Force compaction on level 0 done
badger 2020/06/23 10:48:58 INFO: All 1 tables opened in 0s
badger 2020/06/23 10:48:58 INFO: Replaying file id: 2 at offset: 8262
badger 2020/06/23 10:48:58 INFO: Replay took: 13.438µs
==================
WARNING: DATA RACE
Read at 0x00c0005783a0 by goroutine 238:
  github.com/dgraph-io/badger/v2.(*DB).sendToWriteCh()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/db.go:815 +0x35f
  github.com/dgraph-io/badger/v2.(*valueLog).flushDiscardStats.func2()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/value.go:1868 +0x2bf
  github.com/dgraph-io/badger/v2.(*valueLog).flushDiscardStats()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/value.go:1884 +0x2e6

Previous write at 0x00c0005783a0 by goroutine 161:
  github.com/dgraph-io/badger/v2.Open()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/db.go:402 +0x16c7
  github.com/dgraph-io/badger/v2.TestDiscardStatsMove()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/value_test.go:1117 +0x8ad
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 238 (running) created at:
  github.com/dgraph-io/badger/v2.(*valueLog).open()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/value.go:1095 +0x96
  github.com/dgraph-io/badger/v2.Open()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/db.go:388 +0x1341
  github.com/dgraph-io/badger/v2.TestDiscardStatsMove()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/value_test.go:1117 +0x8ad
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 161 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1117 +0x2ff
  github.com/dgraph-io/badger/v2.TestMain()
      /home/pawan0201/go/src/github.com/dgraph-io/badger/db_test.go:2110 +0xd0
  main.main()
      _testmain.go:346 +0x223
==================
badger 2020/06/23 10:48:59 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
badger 2020/06/23 10:48:59 INFO: Running for level: 0
badger 2020/06/23 10:48:59 INFO: LOG Compact 0->1, del 2 tables, add 1 tables, took 8.027324ms
badger 2020/06/23 10:48:59 INFO: Compaction for level: 0 DONE
badger 2020/06/23 10:48:59 INFO: Force compaction on level 0 done
--- FAIL: TestDiscardStatsMove (1.11s)
    testing.go:853: race detected during execution of test
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1382)
<!-- Reviewable:end -->
