### PR TITLE
Update ristretto to f66de99 commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3
+	github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3 h1:MQLRM35Pp0yAyBYksjbj1nZI/w6eyRY/mWoM1sFf4kU=
-github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=


### PR DESCRIPTION
The update brings following changes from ristretto

f66de99 Improve handling of updated items (https://github.com/dgraph-io/ristretto/pull/168)
aec7994 Fix flaky TestCacheDel test (https://github.com/dgraph-io/ristretto/pull/169)
a093fe6 Add benchmark plots to the project repo (https://github.com/dgraph-io/ristretto/pull/166)
49dc42c Add Anurag as codeowner (https://github.com/dgraph-io/ristretto/pull/158)
7a3f2d3 z: use MemHashString and xxhash.Sum64String (https://github.com/dgraph-io/ristretto/pull/153)
9c31bb2 Check conflict key before updating expiration map. (https://github.com/dgraph-io/ristretto/pull/154)
62cb731 Fix race condition in Cache.Clear (https://github.com/dgraph-io/ristretto/pull/133)
9af1934 Docs and whitespace changes for readability. (https://github.com/dgraph-io/ristretto/pull/143)
dbc185e Add changelog. (https://github.com/dgraph-io/ristretto/pull/142)
ff325ad Remove key from policy after TTL eviction (https://github.com/dgraph-io/ristretto/pull/130)
2dd5ff5 Use the require library in all the tests. (https://github.com/dgraph-io/ristretto/pull/128)
7c48141 Use require in all tests in cache_test.go (https://github.com/dgraph-io/ristretto/pull/127)
51e97ad Sets with TTL (https://github.com/dgraph-io/ristretto/pull/122)
d3e7c37 Add benchmarks for math.rand and fastrand (https://github.com/dgraph-io/ristretto/pull/118)
593823e Integrate fixes from PR https://github.com/dgraph-io/ristretto/pull/91. (https://github.com/dgraph-io/ristretto/pull/126)
29b4dd7 Fix comments. (https://github.com/dgraph-io/ristretto/pull/123)
ddf345c Removed workflows directory. (https://github.com/dgraph-io/ristretto/pull/124)
eb104d0 Add martinmr to CODEOWNERS file. (https://github.com/dgraph-io/ristretto/pull/125)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1391)
<!-- Reviewable:end -->
