### PR TITLE
Enable cross-compiled 32bit tests on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,26 @@ jobs:
       env: GOARCH=386
     - go: tip
       env: GOARCH=386
+  include:
+    # Define one extra linux build, which we use to run cross
+    # compiled 32 bit tests
+    - os: linux
+      go: "1.14"
+      env: go_32=yes
 
 notifications:
   email: false
   slack:
     secure: X7uBLWYbuUhf8QFE16CoS5z7WvFR8EN9j6cEectMW6mKZ3vwXGwVXRIPsgUq/606DsQdCCx34MR8MRWYGlu6TBolbSe9y0EP0i46yipPz22YtuT7umcVUbGEyx8MZKgG0v1u/zA0O4aCsOBpGAA3gxz8h3JlEHDt+hv6U8xRsSllVLzLSNb5lwxDtcfEDxVVqP47GMEgjLPM28Pyt5qwjk7o5a4YSVzkfdxBXxd3gWzFUWzJ5E3cTacli50dK4GVfiLcQY2aQYoYO7AAvDnvP+TPfjDkBlUEE4MUz5CDIN51Xb+WW33sX7g+r3Bj7V5IRcF973RiYkpEh+3eoiPnyWyxhDZBYilty3b+Hysp6d4Ov/3I3ll7Bcny5+cYjakjkMH3l9w3gs6Y82GlpSLSJshKWS8vPRsxFe0Pstj6QSJXTd9EBaFr+l1ScXjJv/Sya9j8N9FfTuOTESWuaL1auX4Y7zEEVHlA8SCNOO8K0eTfxGZnC/YcIHsR8rePEAcFxfOYQppkyLF/XvAtnb/LMUuu0g4y2qNdme6Oelvyar1tFEMRtbl4mRCdu/krXBFtkrsfUaVY6WTPdvXAGotsFJ0wuA53zGVhlcd3+xAlSlR3c1QX95HIMeivJKb5L4nTjP+xnrmQNtnVk+tG4LSH2ltuwcZSSczModtcBmRefrk=
 
-script:
-- go test -v ./...
-# Another round of tests after turning off mmap.
-- go test -v -vlog_mmap=false github.com/dgraph-io/badger
+script: >-
+    if [ $TRAVIS_OS_NAME = "linux" ] && [ $go_32 ]; then
+      uname -a
+      GOOS=linux GOARCH=386 go test -v ./...
+      # Another round of tests after turning off mmap.
+      GOOS=linux GOARCH=386 go test -v -vlog_mmap=false github.com/dgraph-io/badger
+    else
+      go test -v ./...
+      # Another round of tests after turning off mmap.
+      go test -v -vlog_mmap=false github.com/dgraph-io/badger
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
     # Define one extra linux build, which we use to run cross
     # compiled 32 bit tests
     - os: linux
+      arch: arm64
       go: "1.14"
       env: go_32=yes
 
@@ -39,9 +40,9 @@ notifications:
 script: >-
     if [ $TRAVIS_OS_NAME = "linux" ] && [ $go_32 ]; then
       uname -a
-      GOOS=linux GOARCH=386 go test -v ./...
+      GOOS=linux GOARCH=arm go test -v ./...
       # Another round of tests after turning off mmap.
-      GOOS=linux GOARCH=386 go test -v -vlog_mmap=false github.com/dgraph-io/badger
+      GOOS=linux GOARCH=arm go test -v -vlog_mmap=false github.com/dgraph-io/badger
     else
       go test -v ./...
       # Another round of tests after turning off mmap.


### PR DESCRIPTION
I think it should be possible to run the tests on cross-compiled 32bit binaries on the Travis linux host.
With this change I am added one single linux/amd64 build, which used the `GOOS=` and `GOARCH=` environment variables, to run the tests with i386 32bit binaries.

And indeed this test fails with very similar errors to what can be seen in the failing Debian/Ubuntu 32bit builds (https://github.com/dgraph-io/badger/issues/1384), i.e. `Error=cannot allocate memory` tracing down to `/home/travis/.gimme/versions/go1.14.linux.amd64/src/runtime/asm_386.s` and should thus resolve https://github.com/dgraph-io/badger/issues/1385

```
=== RUN   TestRotate
badger 2020/06/30 16:00:14 INFO: All 0 tables opened in 0s
badger 2020/06/30 16:00:14 INFO: Got compaction priority: {level:0 score:1.73 dropPrefixes:[]}
badger 2020/06/30 16:00:14 INFO: All 0 tables opened in 0s
badger 2020/06/30 16:00:14 INFO: Replaying file id: 0 at offset: 0
badger 2020/06/30 16:00:14 INFO: Replay took: 2.962µs
badger 2020/06/30 16:00:14 INFO: Got compaction priority: {level:0 score:1.73 dropPrefixes:[]}
badger 2020/06/30 16:00:14 INFO: All 0 tables opened in 0s
badger 2020/06/30 16:00:14 INFO: Replaying file id: 0 at offset: 0
badger 2020/06/30 16:00:14 INFO: Replay took: 2.936µs
badger 2020/06/30 16:00:14 INFO: Got compaction priority: {level:0 score:1.73 dropPrefixes:[]}
badger 2020/06/30 16:00:14 INFO: All 0 tables opened in 0s
badger 2020/06/30 16:00:14 INFO: Replaying file id: 0 at offset: 0
badger 2020/06/30 16:00:14 INFO: Replay took: 3.116µs
    TestRotate: rotate_test.go:91: 
        	Error Trace:	rotate_test.go:91
        	Error:      	Received unexpected error:
        	            	Map log file. Path=/tmp/badger-test181776523/000001.vlog. Error=cannot allocate memory
        	            	During db.vlog.open
        	            	github.com/dgraph-io/badger/v2/y.Wrapf
        	            		/home/travis/gopath/src/github.com/slyon/badger/y/error.go:82
        	            	github.com/dgraph-io/badger/v2.Open
        	            		/home/travis/gopath/src/github.com/slyon/badger/db.go:390
        	            	github.com/dgraph-io/badger/v2/badger/cmd.TestRotate
        	            		/home/travis/gopath/src/github.com/slyon/badger/badger/cmd/rotate_test.go:90
        	            	testing.tRunner
        	            		/home/travis/.gimme/versions/go1.14.linux.amd64/src/testing/testing.go:992
        	            	runtime.goexit
        	            		/home/travis/.gimme/versions/go1.14.linux.amd64/src/runtime/asm_386.s:1337
        	Test:       	TestRotate
--- FAIL: TestRotate (0.13s)
```

Reference build i386 on amd64: https://travis-ci.com/github/slyon/badger/builds/173676484
Reference build arm on arm64: https://travis-ci.com/github/slyon/badger/builds/173679498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1392)
<!-- Reviewable:end -->
