### PR TITLE
Avoid panic on multiple closer.Signal calls

### DIFF
--- a/y/y.go
+++ b/y/y.go
@@ -191,8 +191,9 @@ func FixedDuration(d time.Duration) string {
 // to tell the goroutine to shut down, and a WaitGroup with which to wait for it to finish shutting
 // down.
 type Closer struct {
-	closed  chan struct{}
-	waiting sync.WaitGroup
+	closed    chan struct{}
+	waiting   sync.WaitGroup
+	closeOnce sync.Once
 }
 
 // NewCloser constructs a new Closer, with an initial count on the WaitGroup.
@@ -209,7 +210,9 @@ func (lc *Closer) AddRunning(delta int) {
 
 // Signal signals the HasBeenClosed signal.
 func (lc *Closer) Signal() {
-	close(lc.closed)
+	lc.closeOnce.Do(func() {
+		close(lc.closed)
+	})
 }
 
 // HasBeenClosed gets signaled when Signal() is called.

--- a/y/y.go
+++ b/y/y.go
@@ -210,6 +210,7 @@ func (lc *Closer) AddRunning(delta int) {
 
 // Signal signals the HasBeenClosed signal.
 func (lc *Closer) Signal() {
+	// Todo(ibrahim): Change Signal to return error on next badger breaking change.
 	lc.closeOnce.Do(func() {
 		close(lc.closed)
 	})

--- a/y/y_test.go
+++ b/y/y_test.go
@@ -254,3 +254,20 @@ func TestPagebufferReader4(t *testing.T) {
 	require.Equal(t, err, io.EOF, "should return EOF")
 	require.Equal(t, n, 0)
 }
+
+func TestMulipleSignals(t *testing.T) {
+	closer := NewCloser(0)
+	require.NotPanics(t, func() { closer.Signal() })
+	// Should not panic.
+	require.NotPanics(t, func() { closer.Signal() })
+	require.NotPanics(t, func() { closer.SignalAndWait() })
+
+	// Attempt 2.
+	closer = NewCloser(1)
+	require.NotPanics(t, func() { closer.Done() })
+
+	require.NotPanics(t, func() { closer.SignalAndWait() })
+	// Should not panic.
+	require.NotPanics(t, func() { closer.SignalAndWait() })
+	require.NotPanics(t, func() { closer.Signal() })
+}


### PR DESCRIPTION
The closer.Signal function closes a channel and multiple calls to the
closing the same channel would cause a "channel already closed". This PR
avoids the panic by using a sync.Once while closing the channel.

Multiple calls to closer.Signal would be no-op with this commit.

Fixes DGRAPH-1581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1401)
<!-- Reviewable:end -->
