### PR TITLE
[Do not review] Revert Background compression and Block Pool fix

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -125,7 +125,7 @@ func toSlice(bal uint64) []byte {
 }
 
 func getBalance(txn *badger.Txn, account int) (uint64, error) {
-	item, err := get(txn, key(account))
+	item, err := txn.Get(key(account))
 	if err != nil {
 		return 0, err
 	}
@@ -197,25 +197,6 @@ func diff(a, b []account) string {
 
 var errFailure = errors.New("test failed due to balance mismatch")
 
-// get function will fetch the value for the key "k" either by using the
-// txn.Get API or the iterator.Seek API.
-func get(txn *badger.Txn, k []byte) (*badger.Item, error) {
-	if rand.Int()%2 == 0 {
-		return txn.Get(k)
-	}
-
-	iopt := badger.DefaultIteratorOptions
-	// PrefectValues is expensive. We don't need it here.
-	iopt.PrefetchValues = false
-	it := txn.NewIterator(iopt)
-	defer it.Close()
-	it.Seek(k)
-	if it.Valid() {
-		return it.Item(), nil
-	}
-	return nil, badger.ErrKeyNotFound
-}
-
 // seekTotal retrives the total of all accounts by seeking for each account key.
 func seekTotal(txn *badger.Txn) ([]account, error) {
 	expected := uint64(numAccounts) * uint64(initialBal)
@@ -223,7 +204,7 @@ func seekTotal(txn *badger.Txn) ([]account, error) {
 
 	var total uint64
 	for i := 0; i < numAccounts; i++ {
-		item, err := get(txn, key(i))
+		item, err := txn.Get(key(i))
 		if err != nil {
 			log.Printf("Error for account: %d. err=%v. key=%q\n", i, err, key(i))
 			return accounts, err
@@ -362,11 +343,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 		WithNumMemtables(2).
 		// Do not GC any versions, because we need them for the disect..
 		WithNumVersionsToKeep(int(math.MaxInt32)).
-		WithValueThreshold(1). // Make all values go to value log
-		WithCompression(options.ZSTD).
-		WithKeepL0InMemory(false).
-		WithMaxCacheSize(10 << 20)
-
+		WithValueThreshold(1) // Make all values go to value log
 	if mmap {
 		opts = opts.WithTableLoadingMode(options.MemoryMap)
 	}

--- a/db.go
+++ b/db.go
@@ -312,9 +312,6 @@ func Open(opt Options) (db *DB, err error) {
 			MaxCost:     int64(float64(opt.MaxCacheSize) * 0.95),
 			BufferItems: 64,
 			Metrics:     true,
-			OnEvict: func(_, _ uint64, value interface{}, _ int64) {
-				table.BlockEvictHandler(value)
-			},
 		}
 		db.blockCache, err = ristretto.NewCache(&config)
 		if err != nil {

--- a/db2_test.go
+++ b/db2_test.go
@@ -670,13 +670,16 @@ func TestL0GCBug(t *testing.T) {
 	// Simulate a crash by not closing db1 but releasing the locks.
 	if db1.dirLockGuard != nil {
 		require.NoError(t, db1.dirLockGuard.release())
-		db1.dirLockGuard = nil
 	}
 	if db1.valueDirGuard != nil {
 		require.NoError(t, db1.valueDirGuard.release())
-		db1.valueDirGuard = nil
 	}
-	require.NoError(t, db1.Close())
+	for _, f := range db1.vlog.filesMap {
+		require.NoError(t, f.fd.Close())
+	}
+	require.NoError(t, db1.registry.Close())
+	require.NoError(t, db1.lc.close())
+	require.NoError(t, db1.manifest.close())
 
 	db2, err := Open(opts)
 	require.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -176,7 +176,6 @@ func DefaultOptions(path string) Options {
 
 func buildTableOptions(opt Options) table.Options {
 	return table.Options{
-		TableSize:               uint64(opt.MaxTableSize),
 		BlockSize:               opt.BlockSize,
 		BloomFalsePositive:      opt.BloomFalsePositive,
 		LoadBloomsOnOpen:        opt.LoadBloomsOnOpen,

--- a/table/builder.go
+++ b/table/builder.go
@@ -17,10 +17,9 @@
 package table
 
 import (
+	"bytes"
 	"crypto/aes"
 	"math"
-	"runtime"
-	"sync"
 	"unsafe"
 
 	"github.com/dgryski/go-farm"
@@ -34,14 +33,11 @@ import (
 	"github.com/dgraph-io/ristretto/z"
 )
 
-const (
-	KB = 1024
-	MB = KB * 1024
-
-	// When a block is encrypted, it's length increases. We add 200 bytes of padding to
-	// handle cases when block size increases. This is an approximate number.
-	padding = 200
-)
+func newBuffer(sz int) *bytes.Buffer {
+	b := new(bytes.Buffer)
+	b.Grow(sz)
+	return b
+}
 
 type header struct {
 	overlap uint16 // Overlap with base key.
@@ -65,18 +61,10 @@ func (h *header) Decode(buf []byte) {
 	copy(((*[headerSize]byte)(unsafe.Pointer(h))[:]), buf[:headerSize])
 }
 
-type bblock struct {
-	data  []byte
-	start uint32 // Points to the starting offset of the block.
-	end   uint32 // Points to the end offset of the block.
-}
-
 // Builder is used in building a table.
 type Builder struct {
 	// Typically tens or hundreds of meg. This is for one single file.
-	buf     []byte
-	sz      uint32
-	bufLock sync.Mutex // This lock guards the buf. We acquire lock when we resize the buf.
+	buf *bytes.Buffer
 
 	baseKey      []byte   // Base key for the current block.
 	baseOffset   uint32   // Offset for the current block.
@@ -84,91 +72,15 @@ type Builder struct {
 	tableIndex   *pb.TableIndex
 	keyHashes    []uint64 // Used for building the bloomfilter.
 	opt          *Options
-
-	// Used to concurrently compress/encrypt blocks.
-	wg        sync.WaitGroup
-	blockChan chan *bblock
-	blockList []*bblock
 }
 
 // NewTableBuilder makes a new TableBuilder.
 func NewTableBuilder(opts Options) *Builder {
-	b := &Builder{
-		// Additional 5 MB to store index (approximate).
-		// We trim the additional space in table.Finish().
-		buf:        make([]byte, opts.TableSize+5*MB),
+	return &Builder{
+		buf:        newBuffer(1 << 20),
 		tableIndex: &pb.TableIndex{},
 		keyHashes:  make([]uint64, 0, 1024), // Avoid some malloc calls.
 		opt:        &opts,
-	}
-
-	// If encryption or compression is not enabled, do not start compression/encryption goroutines
-	// and write directly to the buffer.
-	if b.opt.Compression == options.None && b.opt.DataKey == nil {
-		return b
-	}
-
-	count := 2 * runtime.NumCPU()
-	b.blockChan = make(chan *bblock, count*2)
-
-	b.wg.Add(count)
-	for i := 0; i < count; i++ {
-		go b.handleBlock()
-	}
-	return b
-}
-
-var slicePool = sync.Pool{
-	New: func() interface{} {
-		// Make 4 KB blocks for reuse.
-		b := make([]byte, 0, 4<<10)
-		return &b
-	},
-}
-
-func (b *Builder) handleBlock() {
-	defer b.wg.Done()
-	for item := range b.blockChan {
-		// Extract the block.
-		blockBuf := item.data[item.start:item.end]
-		var dst *[]byte
-		// Compress the block.
-		if b.opt.Compression != options.None {
-			var err error
-
-			dst = slicePool.Get().(*[]byte)
-			*dst = (*dst)[:0]
-
-			blockBuf, err = b.compressData(*dst, blockBuf)
-			y.Check(err)
-		}
-		if b.shouldEncrypt() {
-			eBlock, err := b.encrypt(blockBuf)
-			y.Check(y.Wrapf(err, "Error while encrypting block in table builder."))
-			blockBuf = eBlock
-		}
-
-		// BlockBuf should always less than or equal to allocated space. If the blockBuf is greater
-		// than allocated space that means the data from this block cannot be stored in its
-		// existing location and trying to copy it over would mean we would over-write some data
-		// of the next block.
-		allocatedSpace := (item.end - item.start) + padding + 1
-		y.AssertTruef(uint32(len(blockBuf)) <= allocatedSpace, "newend: %d oldend: %d padding: %d",
-			item.start+uint32(len(blockBuf)), item.end, padding)
-
-		// Acquire the buflock here. The builder.grow function might change
-		// the b.buf while this goroutine was running.
-		b.bufLock.Lock()
-		// Copy over compressed/encrypted data back to the main buffer.
-		copy(b.buf[item.start:], blockBuf)
-		b.bufLock.Unlock()
-
-		// Fix the boundary of the block.
-		item.end = item.start + uint32(len(blockBuf))
-
-		if dst != nil {
-			slicePool.Put(dst)
-		}
 	}
 }
 
@@ -176,7 +88,7 @@ func (b *Builder) handleBlock() {
 func (b *Builder) Close() {}
 
 // Empty returns whether it's empty.
-func (b *Builder) Empty() bool { return b.sz == 0 }
+func (b *Builder) Empty() bool { return b.buf.Len() == 0 }
 
 // keyDiff returns a suffix of newKey that is different from b.baseKey.
 func (b *Builder) keyDiff(newKey []byte) []byte {
@@ -212,50 +124,18 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct, vpLen uint64) {
 	}
 
 	// store current entry's offset
-	y.AssertTrue(b.sz < math.MaxUint32)
-	b.entryOffsets = append(b.entryOffsets, b.sz-b.baseOffset)
+	y.AssertTrue(uint32(b.buf.Len()) < math.MaxUint32)
+	b.entryOffsets = append(b.entryOffsets, uint32(b.buf.Len())-b.baseOffset)
 
 	// Layout: header, diffKey, value.
-	b.append(h.Encode())
-	b.append(diffKey)
+	b.buf.Write(h.Encode())
+	b.buf.Write(diffKey) // We only need to store the key difference.
 
-	if uint32(len(b.buf)) < b.sz+v.EncodedSize() {
-		b.grow(v.EncodedSize())
-	}
-	b.sz += v.Encode(b.buf[b.sz:])
-
+	v.EncodeTo(b.buf)
 	// Size of KV on SST.
 	sstSz := uint64(uint32(headerSize) + uint32(len(diffKey)) + v.EncodedSize())
 	// Total estimated size = size on SST + size on vlog (length of value pointer).
 	b.tableIndex.EstimatedSize += (sstSz + vpLen)
-}
-
-// grow increases the size of b.buf by atleast 50%.
-func (b *Builder) grow(n uint32) {
-	l := uint32(len(b.buf))
-	if n < l/2 {
-		n = l / 2
-	}
-	b.bufLock.Lock()
-	newBuf := make([]byte, l+n)
-	copy(newBuf, b.buf)
-	b.buf = newBuf
-	b.bufLock.Unlock()
-}
-func (b *Builder) append(data []byte) {
-	// Ensure we have enough space to store new data.
-	if uint32(len(b.buf)) < b.sz+uint32(len(data)) {
-		b.grow(uint32(len(data)))
-	}
-	copy(b.buf[b.sz:], data)
-	b.sz += uint32(len(data))
-}
-
-func (b *Builder) addPadding(sz uint32) {
-	if uint32(len(b.buf)) < b.sz+sz {
-		b.grow(sz)
-	}
-	b.sz += sz
 }
 
 /*
@@ -271,36 +151,41 @@ Structure of Block.
 */
 // In case the data is encrypted, the "IV" is added to the end of the block.
 func (b *Builder) finishBlock() {
-	b.append(y.U32SliceToBytes(b.entryOffsets))
-	b.append(y.U32ToBytes(uint32(len(b.entryOffsets))))
+	b.buf.Write(y.U32SliceToBytes(b.entryOffsets))
+	b.buf.Write(y.U32ToBytes(uint32(len(b.entryOffsets))))
 
-	b.writeChecksum(b.buf[b.baseOffset:b.sz])
+	blockBuf := b.buf.Bytes()[b.baseOffset:] // Store checksum for current block.
+	b.writeChecksum(blockBuf)
 
-	// If compression/encryption is disabled, no need to send the block to the blockChan.
-	// There's nothing to be done.
-	if b.blockChan == nil {
-		b.addBlockToIndex()
-		return
+	// Compress the block.
+	if b.opt.Compression != options.None {
+		var err error
+		// TODO: Find a way to reuse buffers. Current implementation creates a
+		// new buffer for each compressData call.
+		blockBuf, err = b.compressData(b.buf.Bytes()[b.baseOffset:])
+		y.Check(err)
+		// Truncate already written data.
+		b.buf.Truncate(int(b.baseOffset))
+		// Write compressed data.
+		b.buf.Write(blockBuf)
+	}
+	if b.shouldEncrypt() {
+		block := b.buf.Bytes()[b.baseOffset:]
+		eBlock, err := b.encrypt(block)
+		y.Check(y.Wrapf(err, "Error while encrypting block in table builder."))
+		// We're rewriting the block, after encrypting.
+		b.buf.Truncate(int(b.baseOffset))
+		b.buf.Write(eBlock)
 	}
 
-	b.addPadding(padding)
+	// TODO(Ashish):Add padding: If we want to make block as multiple of OS pages, we can
+	// implement padding. This might be useful while using direct I/O.
 
-	// Block end is the actual end of the block ignoring the padding.
-	block := &bblock{start: b.baseOffset, end: uint32(b.sz - padding), data: b.buf}
-	b.blockList = append(b.blockList, block)
-
-	b.addBlockToIndex()
-	// Push to the block handler.
-	b.blockChan <- block
-}
-
-func (b *Builder) addBlockToIndex() {
-	blockBuf := b.buf[b.baseOffset:b.sz]
-	// Add key to the block index.
+	// Add key to the block index
 	bo := &pb.BlockOffset{
 		Key:    y.Copy(b.baseKey),
 		Offset: b.baseOffset,
-		Len:    uint32(len(blockBuf)),
+		Len:    uint32(b.buf.Len()) - b.baseOffset,
 	}
 	b.tableIndex.Offsets = append(b.tableIndex.Offsets, bo)
 }
@@ -318,7 +203,7 @@ func (b *Builder) shouldFinishBlock(key []byte, value y.ValueStruct) bool {
 		4 + // size of list
 		8 + // Sum64 in checksum proto
 		4) // checksum length
-	estimatedSize := uint32(b.sz) - b.baseOffset + uint32(6 /*header size for entry*/) +
+	estimatedSize := uint32(b.buf.Len()) - b.baseOffset + uint32(6 /*header size for entry*/) +
 		uint32(len(key)) + uint32(value.EncodedSize()) + entriesOffsetsSize
 
 	if b.shouldEncrypt() {
@@ -338,8 +223,8 @@ func (b *Builder) Add(key []byte, value y.ValueStruct, valueLen uint32) {
 		b.finishBlock()
 		// Start a new block. Initialize the block.
 		b.baseKey = []byte{}
-		y.AssertTrue(uint32(b.sz) < math.MaxUint32)
-		b.baseOffset = uint32((b.sz))
+		y.AssertTrue(uint32(b.buf.Len()) < math.MaxUint32)
+		b.baseOffset = uint32(b.buf.Len())
 		b.entryOffsets = b.entryOffsets[:0]
 	}
 	b.addHelper(key, value, uint64(valueLen))
@@ -353,14 +238,14 @@ func (b *Builder) Add(key []byte, value y.ValueStruct, valueLen uint32) {
 
 // ReachedCapacity returns true if we... roughly (?) reached capacity?
 func (b *Builder) ReachedCapacity(cap int64) bool {
-	blocksSize := b.sz + // length of current buffer
-		uint32(len(b.entryOffsets)*4) + // all entry offsets size
+	blocksSize := b.buf.Len() + // length of current buffer
+		len(b.entryOffsets)*4 + // all entry offsets size
 		4 + // count of all entry offsets
 		8 + // checksum bytes
 		4 // checksum length
 	estimateSz := blocksSize +
 		4 + // Index length
-		5*(uint32(len(b.tableIndex.Offsets))) // approximate index size
+		5*(len(b.tableIndex.Offsets)) // approximate index size
 
 	return int64(estimateSz) > cap
 }
@@ -387,35 +272,6 @@ func (b *Builder) Finish() []byte {
 
 	b.finishBlock() // This will never start a new block.
 
-	if b.blockChan != nil {
-		close(b.blockChan)
-	}
-	// Wait for block handler to finish.
-	b.wg.Wait()
-
-	dst := b.buf
-	// Fix block boundaries. This includes moving the blocks so that we
-	// don't have any interleaving space between them.
-	if len(b.blockList) > 0 {
-		dstLen := uint32(0)
-		for i, bl := range b.blockList {
-			off := b.tableIndex.Offsets[i]
-			// Length of the block is end minus the start.
-			off.Len = bl.end - bl.start
-			// New offset of the block is the point in the main buffer till
-			// which we have written data.
-			off.Offset = dstLen
-
-			copy(dst[dstLen:], b.buf[bl.start:bl.end])
-
-			// New length is the start of the block plus its length.
-			dstLen = off.Offset + off.Len
-		}
-		// Start writing to the buffer from the point until which we have valid data.
-		// Fix the length because append and writeChecksum also rely on it.
-		b.sz = dstLen
-	}
-
 	index, err := proto.Marshal(b.tableIndex)
 	y.Check(err)
 
@@ -423,12 +279,17 @@ func (b *Builder) Finish() []byte {
 		index, err = b.encrypt(index)
 		y.Check(err)
 	}
-	// Write index the buffer.
-	b.append(index)
-	b.append(y.U32ToBytes(uint32(len(index))))
+	// Write index the file.
+	n, err := b.buf.Write(index)
+	y.Check(err)
+
+	y.AssertTrue(uint32(n) < math.MaxUint32)
+	// Write index size.
+	_, err = b.buf.Write(y.U32ToBytes(uint32(n)))
+	y.Check(err)
 
 	b.writeChecksum(index)
-	return b.buf[:b.sz]
+	return b.buf.Bytes()
 }
 
 func (b *Builder) writeChecksum(data []byte) {
@@ -449,10 +310,13 @@ func (b *Builder) writeChecksum(data []byte) {
 	// Write checksum to the file.
 	chksum, err := proto.Marshal(&checksum)
 	y.Check(err)
-	b.append(chksum)
+	n, err := b.buf.Write(chksum)
+	y.Check(err)
 
+	y.AssertTrue(uint32(n) < math.MaxUint32)
 	// Write checksum size.
-	b.append(y.U32ToBytes(uint32(len(chksum))))
+	_, err = b.buf.Write(y.U32ToBytes(uint32(n)))
+	y.Check(err)
 }
 
 // DataKey returns datakey of the builder.
@@ -482,14 +346,14 @@ func (b *Builder) shouldEncrypt() bool {
 }
 
 // compressData compresses the given data.
-func (b *Builder) compressData(dst, data []byte) ([]byte, error) {
+func (b *Builder) compressData(data []byte) ([]byte, error) {
 	switch b.opt.Compression {
 	case options.None:
 		return data, nil
 	case options.Snappy:
-		return snappy.Encode(dst, data), nil
+		return snappy.Encode(nil, data), nil
 	case options.ZSTD:
-		return y.ZSTDCompress(dst, data, b.opt.ZSTDCompressionLevel)
+		return y.ZSTDCompress(nil, data, b.opt.ZSTDCompressionLevel)
 	}
 	return nil, errors.New("Unsupported compression type")
 }

--- a/table/builder.go
+++ b/table/builder.go
@@ -118,13 +118,10 @@ func NewTableBuilder(opts Options) *Builder {
 	return b
 }
 
-var blockPool = &sync.Pool{
+var slicePool = sync.Pool{
 	New: func() interface{} {
-		// Create 5 Kb blocks even when the default size of blocks is 4 KB. The
-		// ZSTD decompresion library increases the buffer by 2X if it's not big
-		// enough. Using a 5 KB block instead of a 4 KB one avoids the
-		// unncessary 2X allocation by the decompression library.
-		b := make([]byte, 5<<10)
+		// Make 4 KB blocks for reuse.
+		b := make([]byte, 0, 4<<10)
 		return &b
 	},
 }
@@ -138,7 +135,9 @@ func (b *Builder) handleBlock() {
 		// Compress the block.
 		if b.opt.Compression != options.None {
 			var err error
-			dst = blockPool.Get().(*[]byte)
+
+			dst = slicePool.Get().(*[]byte)
+			*dst = (*dst)[:0]
 
 			blockBuf, err = b.compressData(*dst, blockBuf)
 			y.Check(err)
@@ -168,7 +167,7 @@ func (b *Builder) handleBlock() {
 		item.end = item.start + uint32(len(blockBuf))
 
 		if dst != nil {
-			blockPool.Put(dst)
+			slicePool.Put(dst)
 		}
 	}
 }

--- a/table/builder.go
+++ b/table/builder.go
@@ -211,9 +211,6 @@ func (b *Builder) shouldFinishBlock(key []byte, value y.ValueStruct) bool {
 		// So, size of IV is added to estimatedSize.
 		estimatedSize += aes.BlockSize
 	}
-	// Integer overflow check for table size.
-	y.AssertTrue(uint64(b.sz)+uint64(estimatedSize) < math.MaxUint32)
-
 	return estimatedSize > uint32(b.opt.BlockSize)
 }
 

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -32,60 +32,30 @@ import (
 
 func TestTableIndex(t *testing.T) {
 	rand.Seed(time.Now().Unix())
-	keysCount := 100000
-	key := make([]byte, 32)
-	_, err := rand.Read(key)
-	require.NoError(t, err)
-	subTest := []struct {
-		name string
-		opts Options
-	}{
-		{
-			name: "No encyption/compression",
-			opts: Options{
-				BlockSize:          4 * 1024,
-				BloomFalsePositive: 0.01,
-				TableSize:          30 << 20,
-			},
-		},
-		{
-			// Encryption mode.
-			name: "Only encryption",
-			opts: Options{
-				BlockSize:          4 * 1024,
-				BloomFalsePositive: 0.01,
-				TableSize:          30 << 20,
-				DataKey:            &pb.DataKey{Data: key},
-			},
-		},
-		{
-			// Compression mode.
-			name: "Only compression",
-			opts: Options{
-				BlockSize:            4 * 1024,
-				BloomFalsePositive:   0.01,
-				TableSize:            30 << 20,
-				Compression:          options.ZSTD,
-				ZSTDCompressionLevel: 3,
-			},
-		},
-		{
-			// Compression mode and encryption.
-			name: "Compression and encryption",
-			opts: Options{
-				BlockSize:            4 * 1024,
-				BloomFalsePositive:   0.01,
-				TableSize:            30 << 20,
-				Compression:          options.ZSTD,
-				ZSTDCompressionLevel: 3,
-				DataKey:              &pb.DataKey{Data: key},
-			},
-		},
-	}
+	keyPrefix := "key"
+	t.Run("single key", func(t *testing.T) {
+		opts := Options{Compression: options.ZSTD}
+		f := buildTestTable(t, keyPrefix, 1, opts)
+		tbl, err := OpenTable(f, opts)
+		require.NoError(t, err)
+		require.Len(t, tbl.blockIndex, 1)
+	})
 
-	for _, tt := range subTest {
-		t.Run(tt.name, func(t *testing.T) {
-			opt := tt.opts
+	t.Run("multiple keys", func(t *testing.T) {
+		opts := []Options{}
+		// Normal mode.
+		opts = append(opts, Options{BlockSize: 4 * 1024, BloomFalsePositive: 0.01})
+		// Encryption mode.
+		key := make([]byte, 32)
+		_, err := rand.Read(key)
+		require.NoError(t, err)
+		opts = append(opts, Options{BlockSize: 4 * 1024, BloomFalsePositive: 0.01,
+			DataKey: &pb.DataKey{Data: key}})
+		// Compression mode.
+		opts = append(opts, Options{BlockSize: 4 * 1024, BloomFalsePositive: 0.01,
+			Compression: options.ZSTD})
+		keysCount := 10000
+		for _, opt := range opts {
 			builder := NewTableBuilder(opt)
 			filename := fmt.Sprintf("%s%c%d.sst", os.TempDir(), os.PathSeparator, rand.Uint32())
 			f, err := y.OpenSyncedFile(filename, true)
@@ -111,9 +81,8 @@ func TestTableIndex(t *testing.T) {
 
 			tbl, err := OpenTable(f, opt)
 			require.NoError(t, err, "unable to open table")
-
 			if opt.DataKey == nil {
-				// key id is zero if there is no datakey.
+				// key id is zero if thre is no datakey.
 				require.Equal(t, tbl.KeyID(), uint64(0))
 			}
 
@@ -124,8 +93,8 @@ func TestTableIndex(t *testing.T) {
 			}
 			f.Close()
 			require.NoError(t, os.RemoveAll(filename))
-		})
-	}
+		}
+	})
 }
 
 func TestInvalidCompression(t *testing.T) {
@@ -156,21 +125,18 @@ func BenchmarkBuilder(b *testing.B) {
 
 	keysCount := 1300000 // This number of entries consumes ~64MB of memory.
 
-	var keyList [][]byte
-	for i := 0; i < keysCount; i++ {
-		keyList = append(keyList, key(i))
-	}
 	bench := func(b *testing.B, opt *Options) {
+		// KeyCount * (keySize + ValSize)
 		b.SetBytes(int64(keysCount) * (32 + 32))
-		opt.BlockSize = 4 * 1024
-		opt.BloomFalsePositive = 0.01
-		opt.TableSize = 5 << 20
-		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
+			opt.BlockSize = 4 * 1024
+			opt.BloomFalsePositive = 0.01
 			builder := NewTableBuilder(*opt)
-			for j := 0; j < keysCount; j++ {
-				builder.Add(keyList[j], vs, 0)
+
+			for i := 0; i < keysCount; i++ {
+				builder.Add(key(i), vs, 0)
 			}
+
 			_ = builder.Finish()
 		}
 	}
@@ -178,13 +144,6 @@ func BenchmarkBuilder(b *testing.B) {
 	b.Run("no compression", func(b *testing.B) {
 		var opt Options
 		opt.Compression = options.None
-		bench(b, &opt)
-	})
-	b.Run("encryption", func(b *testing.B) {
-		var opt Options
-		key := make([]byte, 32)
-		rand.Read(key)
-		opt.DataKey = &pb.DataKey{Data: key}
 		bench(b, &opt)
 	})
 	b.Run("zstd compression", func(b *testing.B) {

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -67,7 +67,6 @@ func (itr *blockIterator) setIdx(i int) {
 		baseHeader.Decode(itr.data)
 		itr.baseKey = itr.data[headerSize : headerSize+baseHeader.diff]
 	}
-
 	var endOffset int
 	// idx points to the last entry in the block.
 	if itr.idx+1 == len(itr.entryOffsets) {

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -33,7 +33,6 @@ type blockIterator struct {
 	key          []byte
 	val          []byte
 	entryOffsets []uint32
-	block        *block
 
 	// prevOverlap stores the overlap of the previous key with the base key.
 	// This avoids unnecessary copy of base key when the overlap is same for multiple keys.
@@ -41,13 +40,6 @@ type blockIterator struct {
 }
 
 func (itr *blockIterator) setBlock(b *block) {
-	// Decrement the ref for the old block. If the old block was compressed, we
-	// might be able to reuse it.
-	itr.block.decrRef()
-	// Increment the ref for the new block.
-	b.incrRef()
-
-	itr.block = b
 	itr.err = nil
 	itr.idx = 0
 	itr.baseKey = itr.baseKey[:0]
@@ -110,9 +102,7 @@ func (itr *blockIterator) Error() error {
 	return itr.err
 }
 
-func (itr *blockIterator) Close() {
-	itr.block.decrRef()
-}
+func (itr *blockIterator) Close() {}
 
 var (
 	origin  = 0
@@ -182,7 +172,6 @@ func (t *Table) NewIterator(reversed bool) *Iterator {
 
 // Close closes the iterator (and it must be called).
 func (itr *Iterator) Close() error {
-	itr.bi.Close()
 	return itr.t.DecrRef()
 }
 

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -44,6 +44,8 @@ func (itr *blockIterator) setBlock(b *block) {
 	// Decrement the ref for the old block. If the old block was compressed, we
 	// might be able to reuse it.
 	itr.block.decrRef()
+	// Increment the ref for the new block.
+	b.incrRef()
 
 	itr.block = b
 	itr.err = nil

--- a/table/table.go
+++ b/table/table.go
@@ -202,46 +202,25 @@ type block struct {
 	ref               int32
 }
 
-// incrRef increments the ref of a block and return a bool indicating if the
-// increment was successful. A true value indicates that the block can be used.
-func (b *block) incrRef() bool {
-	for {
-		// We can't blindly add 1 to ref. We need to check whether it has
-		// reached zero first, because if it did, then we should absolutely not
-		// use this block.
-		ref := atomic.LoadInt32(&b.ref)
-		// The ref would not be equal to 0 unless the existing
-		// block get evicted before this line. If the ref is zero, it means that
-		// the block is already added the the blockPool and cannot be used
-		// anymore. The ref of a new block is 1 so the following condition will
-		// be true only if the block got reused before we could increment its
-		// ref.
-		if ref == 0 {
-			return false
-		}
-		// Increment the ref only if it is not zero and has not changed between
-		// the time we read it and we're updating it.
-		//
-		if atomic.CompareAndSwapInt32(&b.ref, ref, ref+1) {
-			return true
-		}
-	}
+func (b *block) incrRef() {
+	atomic.AddInt32(&b.ref, 1)
 }
 func (b *block) decrRef() {
 	if b == nil {
 		return
 	}
 
+	p := atomic.AddInt32(&b.ref, -1)
 	// Insert the []byte into pool only if the block is resuable. When a block
 	// is reusable a new []byte is used for decompression and this []byte can
 	// be reused.
 	// In case of an uncompressed block, the []byte is a reference to the
 	// table.mmap []byte slice. Any attempt to write data to the mmap []byte
 	// will lead to SEGFAULT.
-	if atomic.AddInt32(&b.ref, -1) == 0 && b.isReusable {
+	if p == 0 && b.isReusable {
 		blockPool.Put(&b.data)
 	}
-	y.AssertTrue(atomic.LoadInt32(&b.ref) >= 0)
+	y.AssertTrue(p >= 0)
 }
 func (b *block) size() int64 {
 	return int64(3*intSize /* Size of the offset, entriesIndexStart and chkLen */ +
@@ -499,9 +478,6 @@ func calculateOffsetsSize(offsets []*pb.BlockOffset) int64 {
 	return totalSize + 3*8
 }
 
-// block function return a new block. Each block holds a ref and the byte
-// slice stored in the block will be reused when the ref becomes zero. The
-// caller should release the block by calling block.decrRef() on it.
 func (t *Table) block(idx int) (*block, error) {
 	y.AssertTruef(idx >= 0, "idx=%d", idx)
 	if idx >= t.noOfBlocks {
@@ -511,12 +487,7 @@ func (t *Table) block(idx int) (*block, error) {
 		key := t.blockCacheKey(idx)
 		blk, ok := t.opt.Cache.Get(key)
 		if ok && blk != nil {
-			// Use the block only if the increment was successful. The block
-			// could get evicted from the cache between the Get() call and the
-			// incrRef() call.
-			if b := blk.(*block); b.incrRef() {
-				return b, nil
-			}
+			return blk.(*block), nil
 		}
 	}
 
@@ -524,7 +495,6 @@ func (t *Table) block(idx int) (*block, error) {
 	ko := t.blockOffsets()[idx]
 	blk := &block{
 		offset: int(ko.Offset),
-		ref:    1,
 	}
 	var err error
 	if blk.data, err = t.read(blk.offset, int(ko.Len)); err != nil {
@@ -581,14 +551,8 @@ func (t *Table) block(idx int) (*block, error) {
 	}
 	if t.opt.Cache != nil && t.opt.KeepBlocksInCache {
 		key := t.blockCacheKey(idx)
-		// incrRef should never return false here because we're calling it on a
-		// new block with ref=1.
-		y.AssertTrue(blk.incrRef())
-
-		// Decrement the block ref if we could not insert it in the cache.
-		if !t.opt.Cache.Set(key, blk, blk.size()) {
-			blk.decrRef()
-		}
+		blk.incrRef()
+		t.opt.Cache.Set(key, blk, blk.size())
 	}
 	return blk, nil
 }

--- a/table/table.go
+++ b/table/table.go
@@ -184,44 +184,15 @@ func (t *Table) DecrRef() error {
 	return nil
 }
 
-// BlockEvictHandler is used to reuse the byte slice stored in the block on cache eviction.
-func BlockEvictHandler(value interface{}) {
-	if b, ok := value.(*block); ok {
-		b.decrRef()
-	}
-}
-
 type block struct {
 	offset            int
 	data              []byte
 	checksum          []byte
-	entriesIndexStart int      // start index of entryOffsets list
-	entryOffsets      []uint32 // used to binary search an entry in the block.
-	chkLen            int      // checksum length.
-	isReusable        bool     // used to determine if the blocked should be reused.
-	ref               int32
+	entriesIndexStart int // start index of entryOffsets list
+	entryOffsets      []uint32
+	chkLen            int // checksum length
 }
 
-func (b *block) incrRef() {
-	atomic.AddInt32(&b.ref, 1)
-}
-func (b *block) decrRef() {
-	if b == nil {
-		return
-	}
-
-	p := atomic.AddInt32(&b.ref, -1)
-	// Insert the []byte into pool only if the block is resuable. When a block
-	// is reusable a new []byte is used for decompression and this []byte can
-	// be reused.
-	// In case of an uncompressed block, the []byte is a reference to the
-	// table.mmap []byte slice. Any attempt to write data to the mmap []byte
-	// will lead to SEGFAULT.
-	if p == 0 && b.isReusable {
-		blockPool.Put(&b.data)
-	}
-	y.AssertTrue(p >= 0)
-}
 func (b *block) size() int64 {
 	return int64(3*intSize /* Size of the offset, entriesIndexStart and chkLen */ +
 		cap(b.data) + cap(b.checksum) + cap(b.entryOffsets)*4)
@@ -509,7 +480,8 @@ func (t *Table) block(idx int) (*block, error) {
 		}
 	}
 
-	if err = t.decompress(blk); err != nil {
+	blk.data, err = t.decompressData(blk.data)
+	if err != nil {
 		return nil, errors.Wrapf(err,
 			"failed to decode compressed data in file: %s at offset: %d, len: %d",
 			t.fd.Name(), blk.offset, ko.Len)
@@ -551,7 +523,6 @@ func (t *Table) block(idx int) (*block, error) {
 	}
 	if t.opt.Cache != nil && t.opt.KeepBlocksInCache {
 		key := t.blockCacheKey(idx)
-		blk.incrRef()
 		t.opt.Cache.Set(key, blk, blk.size())
 	}
 	return blk, nil
@@ -671,8 +642,7 @@ func (t *Table) VerifyChecksum() error {
 			return y.Wrapf(err, "checksum validation failed for table: %s, block: %d, offset:%d",
 				t.Filename(), i, os.Offset)
 		}
-		b.incrRef()
-		defer b.decrRef()
+
 		// OnBlockRead or OnTableAndBlockRead, we don't need to call verify checksum
 		// on block, verification would be done while reading block itself.
 		if !(t.opt.ChkMode == options.OnBlockRead || t.opt.ChkMode == options.OnTableAndBlockRead) {
@@ -738,28 +708,15 @@ func NewFilename(id uint64, dir string) string {
 	return filepath.Join(dir, IDToFilename(id))
 }
 
-// decompress decompresses the data stored in a block.
-func (t *Table) decompress(b *block) error {
-	var err error
+// decompressData decompresses the given data.
+func (t *Table) decompressData(data []byte) ([]byte, error) {
 	switch t.opt.Compression {
 	case options.None:
-		// Nothing to be done here.
+		return data, nil
 	case options.Snappy:
-		dst := blockPool.Get().(*[]byte)
-		b.data, err = snappy.Decode(*dst, b.data)
-		if err != nil {
-			return errors.Wrap(err, "failed to decompress")
-		}
-		b.isReusable = true
+		return snappy.Decode(nil, data)
 	case options.ZSTD:
-		dst := blockPool.Get().(*[]byte)
-		b.data, err = y.ZSTDDecompress(*dst, b.data)
-		if err != nil {
-			return errors.Wrap(err, "failed to decompress")
-		}
-		b.isReusable = true
-	default:
-		return errors.New("Unsupported compression type")
+		return y.ZSTDDecompress(nil, data)
 	}
-	return nil
+	return nil, errors.New("Unsupported compression type")
 }

--- a/table/table.go
+++ b/table/table.go
@@ -56,9 +56,6 @@ const sizeOfOffsetStruct int64 = 3*8 + // key array take 3 words
 type Options struct {
 	// Options for Opening/Building Table.
 
-	// Maximum size of the table.
-	TableSize uint64
-
 	// ChkMode is the checksum verification mode for Table.
 	ChkMode options.ChecksumVerificationMode
 
@@ -494,7 +491,7 @@ func (t *Table) block(idx int) (*block, error) {
 	// Checksum length greater than block size could happen if the table was compressed and
 	// it was opened with an incorrect compression algorithm (or the data was corrupted).
 	if blk.chkLen > len(blk.data) {
-		return nil, errors.New("invalid checksum length. Either the data is " +
+		return nil, errors.New("invalid checksum length. Either the data is" +
 			"corrupted or the table options are incorrectly set")
 	}
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -37,6 +37,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	KB = 1024
+	MB = KB * 1024
+)
+
 func key(prefix string, i int) string {
 	return prefix + fmt.Sprintf("%04d", i)
 }
@@ -353,7 +358,7 @@ func TestIterateBackAndForth(t *testing.T) {
 
 	it.seekToFirst()
 	k = it.Key()
-	require.EqualValues(t, key("key", 0), string(y.ParseKey(k)))
+	require.EqualValues(t, key("key", 0), y.ParseKey(k))
 }
 
 func TestUniIterator(t *testing.T) {
@@ -698,8 +703,7 @@ func TestTableBigValues(t *testing.T) {
 	require.NoError(t, err, "unable to create file")
 
 	n := 100 // Insert 100 keys.
-	opts := Options{Compression: options.ZSTD, BlockSize: 4 * 1024, BloomFalsePositive: 0.01,
-		TableSize: uint64(n) * 1 << 20}
+	opts := Options{Compression: options.ZSTD, BlockSize: 4 * 1024, BloomFalsePositive: 0.01}
 	builder := NewTableBuilder(opts)
 	for i := 0; i < n; i++ {
 		key := y.KeyWithTs([]byte(key("", i)), 0)

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -64,12 +64,11 @@ func (v *ValueStruct) Decode(b []byte) {
 }
 
 // Encode expects a slice of length at least v.EncodedSize().
-func (v *ValueStruct) Encode(b []byte) uint32 {
+func (v *ValueStruct) Encode(b []byte) {
 	b[0] = v.Meta
 	b[1] = v.UserMeta
 	sz := binary.PutUvarint(b[2:], v.ExpiresAt)
-	n := copy(b[2+sz:], v.Value)
-	return uint32(2 + sz + n)
+	copy(b[2+sz:], v.Value)
 }
 
 // EncodeTo should be kept in sync with the Encode function above. The reason
@@ -80,7 +79,6 @@ func (v *ValueStruct) EncodeTo(buf *bytes.Buffer) {
 	buf.WriteByte(v.UserMeta)
 	var enc [binary.MaxVarintLen64]byte
 	sz := binary.PutUvarint(enc[:], v.ExpiresAt)
-
 	buf.Write(enc[:sz])
 	buf.Write(v.Value)
 }


### PR DESCRIPTION
Update- I've created separate PRs for each commit. Do not review this PR. I'll close this PR once all the smaller PRs are merged.
https://github.com/dgraph-io/badger/pull/1406
https://github.com/dgraph-io/badger/pull/1407
https://github.com/dgraph-io/badger/pull/1408
https://github.com/dgraph-io/badger/pull/1409

All the PRs mentioned above are reverted.

This PR reverts 4 commits
Background Compression/Decompression - Revert PR https://github.com/dgraph-io/badger/pull/1409
Decompression Pool - Revert PR https://github.com/dgraph-io/badger/pull/1408
Decompression Pool race fix - Revert PR https://github.com/dgraph-io/badger/pull/1407 
Builder assert fix (revert PR https://github.com/dgraph-io/badger/pull/1406) (this was reverted because `b.sz` no longer exists and that assert is no longer valid)

The commits mentioned above are being reverted because we have seen some crashes which could be caused by these changes. We haven't been able to reproduce the crashes yet.

Related to https://github.com/dgraph-io/badger/issues/1389, https://github.com/dgraph-io/badger/issues/1388, https://github.com/dgraph-io/badger/issues/1387
Also see https://discuss.dgraph.io/t/current-state-of-badger-crashes/7602
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1405)
<!-- Reviewable:end -->
