### PR TITLE
Revert "add assert to check integer overflow for table size (#1402)"

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -327,9 +327,6 @@ func (b *Builder) shouldFinishBlock(key []byte, value y.ValueStruct) bool {
 		// So, size of IV is added to estimatedSize.
 		estimatedSize += aes.BlockSize
 	}
-	// Integer overflow check for table size.
-	y.AssertTrue(uint64(b.sz)+uint64(estimatedSize) < math.MaxUint32)
-
 	return estimatedSize > uint32(b.opt.BlockSize)
 }
 


### PR DESCRIPTION
This reverts commit 7f4e4b560aabb5521f3591972ab5fdc1aec6801b. This revert is necessary because b.sz won't exist after builder changes are reverted and that assert is no longer valid.

The commit mentioned above is being reverted because we have seen some crashes which could be caused by these changes. We haven't been able to reproduce the crashes yet.

Related to #1389, #1388, #1387
Also see https://discuss.dgraph.io/t/current-state-of-badger-crashes/7602

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1406)
<!-- Reviewable:end -->
