### PR TITLE
Add a limit to the size of the batches sent over a stream.

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -275,8 +275,8 @@ func (st *Stream) streamKVs(ctx context.Context) error {
 				y.AssertTrue(kvs != nil)
 				batch.Kv = append(batch.Kv, kvs.Kv...)
 
-				// If the size of the batch exceeds maxStreamSize, break from the loop
-				// to avoid creating a batch that is so big certain limits are reached.
+				// If the size of the batch exceeds maxStreamSize, break from the loop to
+				// avoid creating a batch that is so big that certain limits are reached.
 				sz := uint64(proto.Size(batch))
 				if sz > maxStreamSize {
 					break loop

--- a/stream.go
+++ b/stream.go
@@ -313,6 +313,7 @@ outer:
 			batch = kvs
 
 			// Send the batch immediately if it already exceeds the maximum allowed size.
+			// Calling slurp on this batch will only increase the size further.
 			sz := uint64(proto.Size(batch))
 			if sz > maxStreamSize {
 				if err := sendBatch(batch); err != nil {

--- a/stream.go
+++ b/stream.go
@@ -32,7 +32,10 @@ import (
 
 const pageSize = 4 << 20 // 4MB
 
-// maxStreamSize
+// maxStreamSize is the maximum allowed size of a stream batch. This is a soft limit
+// as a single list that is still over the limit will have to be sent as is since it
+// cannot be split further. This limit prevents the framework from creating batches
+// so big that sending them causes issues (e.g running into the max size gRPC limit).
 var maxStreamSize = uint64(100 << 20) // 100MB
 
 // Stream provides a framework to concurrently iterate over a snapshot of Badger, pick up

--- a/stream_test.go
+++ b/stream_test.go
@@ -77,10 +77,8 @@ func TestStream(t *testing.T) {
 	stream := db.NewStreamAt(math.MaxUint64)
 	stream.LogPrefix = "Testing"
 	c := &collector{}
-	stream.Send = func(list *bpb.KVList) error {
-		return c.Send(list)
-	}
-
+	stream.Send = c.Send
+	
 	// Test case 1. Retrieve everything.
 	err = stream.Orchestrate(ctxb)
 	require.NoError(t, err)
@@ -186,9 +184,7 @@ func TestStreamWithThreadId(t *testing.T) {
 		return stream.ToList(key, itr)
 	}
 	c := &collector{}
-	stream.Send = func(list *bpb.KVList) error {
-		return c.Send(list)
-	}
+	stream.Send = c.Send
 
 	err = stream.Orchestrate(ctxb)
 	require.NoError(t, err)
@@ -242,9 +238,7 @@ func TestBigStream(t *testing.T) {
 	stream := db.NewStreamAt(math.MaxUint64)
 	stream.LogPrefix = "Testing"
 	c := &collector{}
-	stream.Send = func(list *bpb.KVList) error {
-		return c.Send(list)
-	}
+	stream.Send = c.Send
 
 	// Test case 1. Retrieve everything.
 	err = stream.Orchestrate(ctxb)

--- a/stream_test.go
+++ b/stream_test.go
@@ -214,7 +214,7 @@ func TestBigStream(t *testing.T) {
 	}()
 
 	testSize := int(1e6)
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := ioutil.TempDir("", "badger-big-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -78,7 +78,7 @@ func TestStream(t *testing.T) {
 	stream.LogPrefix = "Testing"
 	c := &collector{}
 	stream.Send = c.Send
-	
+
 	// Test case 1. Retrieve everything.
 	err = stream.Orchestrate(ctxb)
 	require.NoError(t, err)
@@ -222,18 +222,14 @@ func TestBigStream(t *testing.T) {
 	require.NoError(t, err)
 
 	var count int
+	wb := db.NewWriteBatchAt(5)
 	for _, prefix := range []string{"p0", "p1", "p2"} {
-		txn := db.NewTransactionAt(math.MaxUint64, true)
 		for i := 1; i <= testSize; i++ {
-			require.NoError(t, txn.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
+			require.NoError(t, wb.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
 			count++
-			if i % 1000 == 0 {
-				require.NoError(t, txn.CommitAt(5, nil))
-				txn = db.NewTransactionAt(math.MaxUint64, true)
-			}
 		}
-		require.NoError(t, txn.CommitAt(5, nil))
 	}
+	require.NoError(t, wb.Flush())
 
 	stream := db.NewStreamAt(math.MaxUint64)
 	stream.LogPrefix = "Testing"
@@ -258,4 +254,3 @@ func TestBigStream(t *testing.T) {
 	}
 	require.NoError(t, db.Close())
 }
-

--- a/stream_test.go
+++ b/stream_test.go
@@ -256,5 +256,6 @@ func TestBigStream(t *testing.T) {
 	for pred, count := range m {
 		require.Equal(t, testSize, count, "Count mismatch for pred: %s", pred)
 	}
+	require.NoError(t, db.Close())
 }
 


### PR DESCRIPTION
Currently, there's no limit to how many KVs can be included in a single
batch. This leads to issues when the size is over a hard limit. For
example, a batch of size > 2GB will cause issues if it has to be sent
over gRPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1412)
<!-- Reviewable:end -->
