### PR TITLE
levels: Cleanup builder resources on building an empty table

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -663,6 +663,9 @@ nextTable:
 			return tbl, errors.Wrapf(err, "Unable to open table: %q", fd.Name())
 		}
 		if builder.Empty() {
+			// Cleanup builder resources:
+			builder.Finish()
+			builder.Close()
 			continue
 		}
 		numBuilds++


### PR DESCRIPTION
The compaction process can leak `*table.Builder` instances if the table built is empty.

This used to be a big problem: before #1409 it would leak out the block compression/encryption goroutines (that are all blocked on reading from the `b.blockChan`, and because of that it would leak the builder too.

Since #1409 this is now a simple question of correctness. Take it or leave it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1414)
<!-- Reviewable:end -->
