### PR TITLE
Add a limit to the size of the batches sent over a stream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [20.07.0-rc2] - 2020-07-14
+
+### Fixed
+- Add a limit to the size of the batches sent over a stream. (#1412)
+
 ## [20.07.0-rc1] - 2020-07-11
 
 ### Fixed


### PR DESCRIPTION
Currently, there's no limit to how many KVs can be included in a single
batch. This leads to issues when the size is over a hard limit. For
example, a batch of size > 2GB will cause issues if it has to be sent
over gRPC.

Fixes DGRAPH-1899

Co-authored-by: Ibrahim Jarif <ibrahim@dgraph.io>
(cherry picked from commit c892251e4e787ecd111798a76703c4ebbd6af04e)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1430)
<!-- Reviewable:end -->
