### PR TITLE
Remove vlog file if bootstrap, syncDir or mmap fails

### DIFF
--- a/value.go
+++ b/value.go
@@ -1000,14 +1000,26 @@ func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 		return nil, errFile(err, lf.path, "Create value log file")
 	}
 
+	removeFile := func() {
+		// Remove the file so that we don't get an error when createVlogFile is
+		// called for the same fid, again. This could happen if there is an
+		// transient error because of which we couldn't create a new file
+		// and the second attempt to create the file succeeds.
+		os.Remove(lf.fd.Name())
+	}
+
 	if err = lf.bootstrap(); err != nil {
+		removeFile()
 		return nil, err
 	}
 
 	if err = syncDir(vlog.dirPath); err != nil {
+		removeFile()
 		return nil, errFile(err, vlog.dirPath, "Sync value log dir")
 	}
+
 	if err = lf.mmap(2 * vlog.opt.ValueLogFileSize); err != nil {
+		removeFile()
 		return nil, errFile(err, lf.path, "Mmap value log file")
 	}
 

--- a/value.go
+++ b/value.go
@@ -1005,7 +1005,7 @@ func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 		// called for the same fid, again. This could happen if there is an
 		// transient error because of which we couldn't create a new file
 		// and the second attempt to create the file succeeds.
-		os.Remove(lf.fd.Name())
+		y.Check(os.Remove(lf.fd.Name()))
 	}
 
 	if err = lf.bootstrap(); err != nil {


### PR DESCRIPTION
The `createVlogFile` function creates a new vlog file. The function apart
from creating a new file, bootstraps it, syncs it to the disk, and mmaps it.

If any of the three operations fail, we will end up with a file on the
disk but the vlog.maxFid will not be updated.

On the next attempt to create the vlog files, we will get a "File
already exists" error. This commit fixes this issue by removing the file
if `createVlogFile` encounters any error.

Fixes DGRAPH-1930

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1434)
<!-- Reviewable:end -->
