### PR TITLE
Show badger options in read/write bench

### DIFF
--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -85,7 +85,6 @@ func readBench(cmd *cobra.Command, args []string) error {
 		WithValueLogLoadingMode(mode)
 
 	fmt.Printf("Opening badger with options = %+v\n", opt)
-
 	db, err := badger.Open(opt)
 	if err != nil {
 		return y.Wrapf(err, "unable to open DB")

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -78,12 +78,15 @@ func readBench(cmd *cobra.Command, args []string) error {
 	}
 	y.AssertTrue(numGoroutines > 0)
 	mode := getLoadingMode(loadingMode)
-
-	db, err := badger.Open(badger.DefaultOptions(sstDir).
+	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
 		WithReadOnly(readOnly).
 		WithTableLoadingMode(mode).
-		WithValueLogLoadingMode(mode))
+		WithValueLogLoadingMode(mode)
+
+	fmt.Printf("Opening badger with options = %+v\n", opt)
+
+	db, err := badger.Open(opt)
 	if err != nil {
 		return y.Wrapf(err, "unable to open DB")
 	}

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -259,6 +259,7 @@ func writeBench(cmd *cobra.Command, args []string) error {
 		opt = opt.WithLogger(nil)
 	}
 
+	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.Open(opt)
 	if err != nil {
 		return err


### PR DESCRIPTION
Show badger options when running the benchmark read/write tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1437)
<!-- Reviewable:end -->
