### PR TITLE
Add drop-prefix option in write benchmark

### DIFF
--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -79,10 +79,11 @@ var (
 	vlogCount        uint32
 	files            []string
 
-	dropAllPeriod  string
-	gcPeriod       string
-	gcDiscardRatio float64
-	gcSuccess      uint64
+	dropAllPeriod    string
+	dropPrefixPeriod string
+	gcPeriod         string
+	gcDiscardRatio   float64
+	gcSuccess        uint64
 )
 
 const (
@@ -123,6 +124,8 @@ func init() {
 		"If true, the report will include the directory contents")
 	writeBenchCmd.Flags().StringVar(&dropAllPeriod, "dropall", "0s",
 		"Period of dropping all. If 0, doesn't drops all.")
+	writeBenchCmd.Flags().StringVar(&dropPrefixPeriod, "drop-prefix", "0s",
+		"Period of dropping by random prefixes. If 0, doesn't drops by prefix.")
 	writeBenchCmd.Flags().StringVar(&ttlDuration, "entry-ttl", "0s",
 		"TTL duration in seconds for the entries, 0 means without TTL")
 	writeBenchCmd.Flags().StringVarP(&gcPeriod, "gc-every", "g", "5m", "GC Period.")
@@ -275,9 +278,10 @@ func writeBench(cmd *cobra.Command, args []string) error {
 
 	startTime = time.Now()
 	num := uint64(numKeys * mil)
-	c := y.NewCloser(3)
+	c := y.NewCloser(4)
 	go reportStats(c, db)
 	go dropAll(c, db)
+	go dropPrefix(c, db)
 	go runGC(c, db)
 
 	if sorted {
@@ -411,6 +415,41 @@ func dropAll(c *y.Closer, db *badger.DB) {
 				fmt.Println("[DropAll] Failed")
 			} else {
 				fmt.Println("[DropAll] Successful")
+			}
+		}
+	}
+}
+
+func dropPrefix(c *y.Closer, db *badger.DB) {
+	defer c.Done()
+
+	dropPeriod, err := time.ParseDuration(dropPrefixPeriod)
+	y.Check(err)
+	if dropPeriod == 0 {
+		return
+		log.Println("Exit from drop prefix")
+	}
+
+	t := time.NewTicker(dropPeriod)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.HasBeenClosed():
+			return
+		case <-t.C:
+			fmt.Println("[DropPrefix] Started")
+			err := db.DropAll()
+			for err == badger.ErrBlockedWrites {
+				prefix := make([]byte, 1+int(float64(keySz)*0.1))
+				rand.Read(prefix)
+				err = db.DropPrefix(prefix)
+				time.Sleep(time.Millisecond * 300)
+			}
+
+			if err != nil {
+				fmt.Println("[DropPrefix] Failed")
+			} else {
+				fmt.Println("[DropPrefix] Successful")
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds the drop-prefix option in write benchmark. The current size of prefix is taken as `1 + 0.1*keySize`, I would request your comments on this.