### PR TITLE
release/v20.07: Various bug fixes: Break up list and run DropAll func (#1439)

### DIFF
--- a/db.go
+++ b/db.go
@@ -1557,11 +1557,10 @@ func (db *DB) prepareToDrop() (func(), error) {
 // writes are paused before running DropAll, and resumed after it is finished.
 func (db *DB) DropAll() error {
 	f, err := db.dropAll()
-	if err != nil {
-		return err
+	if f != nil {
+		f()
 	}
-	defer f()
-	return nil
+	return err
 }
 
 func (db *DB) dropAll() (func(), error) {


### PR DESCRIPTION
* Run the returned func even on error, if the func is not nil.

* Break up keys from a single list output to avoid sending a 
HUGE batch which can exceed Grpc limits.

(cherry picked from commit 1ccf3a875dd704e62dd4141afa3fcc01d79097b5)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1440)
<!-- Reviewable:end -->
