### PR TITLE
Add --enc-key flag in badger info tool

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -48,6 +48,7 @@ type flagOptions struct {
 	showInternal  bool
 	readOnly      bool
 	truncate      bool
+	encryptionKey string
 }
 
 var (
@@ -74,6 +75,7 @@ func init() {
 		"to open DB.")
 	infoCmd.Flags().BoolVar(&opt.truncate, "truncate", false, "If set to true, it allows "+
 		"truncation of value log files if they have corrupt data.")
+	infoCmd.Flags().StringVar(&opt.encryptionKey, "enc-key", "", "Use the provided encryption key")
 }
 
 var infoCmd = &cobra.Command{
@@ -98,7 +100,8 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 		WithValueDir(vlogDir).
 		WithReadOnly(opt.readOnly).
 		WithTruncate(opt.truncate).
-		WithTableLoadingMode(options.MemoryMap))
+		WithTableLoadingMode(options.MemoryMap).
+		WithEncryptionKey([]byte(opt.encryptionKey)))
 	if err != nil {
 		return errors.Wrap(err, "failed to open database")
 	}


### PR DESCRIPTION
Add `--enc-key` flag in info tool to support opening an encrypted badger directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1441)
<!-- Reviewable:end -->
