### PR TITLE
update function description for DB.Backup() and Stream.Backup()

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -34,9 +34,16 @@ import (
 // than the maxBatchSize.
 const flushThreshold = 100 << 20
 
-// Backup is a wrapper function over Stream.Backup to generate full and incremental backups of the
-// DB. For more control over how many goroutines are used to generate the backup, or if you wish to
-// backup only a certain range of keys, use Stream.Backup directly.
+// Backup dumps a protobuf-encoded list of all entries in the database into the
+// given writer, that are newer than or equal to the specified version. It
+// returns a timestamp (version) indicating the version of last entry that is
+// dumped, which after incrementing by 1 can be passed into later invocation to
+// generate incremental backup, of entries that have been added/modified since
+// the last invocation of DB.Backup().
+// DB.Backup is a wrapper function over Stream.Backup to generate full and
+// incremental backups of the DB. For more control over how many goroutines are
+// used to generate the backup, or if you wish to backup only a certain range
+// of keys, use Stream.Backup directly.
 func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 	stream := db.NewStream()
 	stream.LogPrefix = "DB.Backup"
@@ -44,10 +51,11 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 }
 
 // Backup dumps a protobuf-encoded list of all entries in the database into the
-// given writer, that are newer than the specified version. It returns a
-// timestamp indicating when the entries were dumped which can be passed into a
-// later invocation to generate an incremental dump, of entries that have been
-// added/modified since the last invocation of Stream.Backup().
+// given writer, that are newer than or equal to the specified version. It returns a
+// timestamp(version) indicating the version of last entry that was dumped, which
+// after incrementing by 1 can be passed into a later invocation to generate an
+// incremental dump, of entries that have been added/modified since the last
+// invocation of Stream.Backup().
 //
 // This can be used to backup the data in a database at a given point in time.
 func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {

--- a/backup.go
+++ b/backup.go
@@ -38,7 +38,7 @@ const flushThreshold = 100 << 20
 // given writer, that are newer than or equal to the specified version. It
 // returns a timestamp (version) indicating the version of last entry that is
 // dumped, which after incrementing by 1 can be passed into later invocation to
-// generate incremental backup, of entries that have been added/modified since
+// generate incremental backup of entries that have been added/modified since
 // the last invocation of DB.Backup().
 // DB.Backup is a wrapper function over Stream.Backup to generate full and
 // incremental backups of the DB. For more control over how many goroutines are
@@ -54,7 +54,7 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 // given writer, that are newer than or equal to the specified version. It returns a
 // timestamp(version) indicating the version of last entry that was dumped, which
 // after incrementing by 1 can be passed into a later invocation to generate an
-// incremental dump, of entries that have been added/modified since the last
+// incremental dump of entries that have been added/modified since the last
 // invocation of Stream.Backup().
 //
 // This can be used to backup the data in a database at a given point in time.


### PR DESCRIPTION
1. Addresses #1351 (https://discuss.dgraph.io/t/db-backup-stream-backup-may-duplicate-entries-in-incremental-backups-if-used-naively/8738)
2. Closes Dgraph-2085.

Updates the description of Backup() to show that user needs to increment the return value to pass to later
invocation to create an incremental backup. Also, copies the description from Stream.Backup()  ->
DB.Backup().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1443)
<!-- Reviewable:end -->
