### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ values altogether. See section below on key-only iteration.
 To iterate over a key prefix, you can combine `Seek()` and `ValidForPrefix()`:
 
 ```go
-db.View(func(txn *badger.Txn) error {
+err := db.View(func(txn *badger.Txn) error {
   it := txn.NewIterator(badger.DefaultIteratorOptions)
   defer it.Close()
   prefix := []byte("1234")


### PR DESCRIPTION
This fixes a minor typo in README where in one piece of example code, the error returned from db.View() was not handled, which is inconsistent with the other examples. This also makes copy/pasting the example code a bit harder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1444)
<!-- Reviewable:end -->
