### PR TITLE
Fix ever existing iterator and transaction in write benchmark

### DIFF
--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -71,6 +71,7 @@ var (
 	compression         bool
 	showDir             bool
 	ttlDuration         string
+	showKeysCount       bool
 
 	internalKeyCount uint32
 	moveKeyCount     uint32
@@ -133,6 +134,8 @@ func init() {
 		"TTL duration in seconds for the entries, 0 means without TTL")
 	writeBenchCmd.Flags().StringVarP(&gcPeriod, "gc-every", "g", "5m", "GC Period.")
 	writeBenchCmd.Flags().Float64VarP(&gcDiscardRatio, "gc-ratio", "r", 0.5, "GC discard ratio.")
+	writeBenchCmd.Flags().BoolVar(&showKeysCount, "show-keys", false,
+		"If true, the report will include the keys statistics")
 }
 
 func writeRandom(db *badger.DB, num uint64) error {
@@ -309,28 +312,35 @@ func reportStats(c *y.Closer, db *badger.DB) {
 		case <-c.HasBeenClosed():
 			return
 		case <-t.C:
-			txn := db.NewTransaction(false)
-			defer txn.Discard()
+			if showKeysCount {
+				func() {
+					txn := db.NewTransaction(false)
+					defer txn.Discard()
 
-			iopt := badger.DefaultIteratorOptions
-			iopt.AllVersions = true
-			iopt.InternalAccess = true
+					iopt := badger.DefaultIteratorOptions
+					iopt.AllVersions = true
+					iopt.InternalAccess = true
+					it := txn.NewIterator(iopt)
+					defer it.Close()
 
-			it := txn.NewIterator(iopt)
-			defer it.Close()
-			for it.Rewind(); it.Valid(); it.Next() {
-				i := it.Item()
-				if bytes.HasPrefix(i.Key(), []byte("!badger!")) {
-					internalKeyCount++
-				}
-				if bytes.HasPrefix(i.Key(), []byte("!badger!Move")) {
-					moveKeyCount++
-				}
-				if i.IsDeletedOrExpired() {
-					invalidKeyCount++
-				} else {
-					validKeyCount++
-				}
+					for it.Rewind(); it.Valid(); it.Next() {
+						i := it.Item()
+						if bytes.HasPrefix(i.Key(), []byte("!badger!")) {
+							internalKeyCount++
+						}
+						if bytes.HasPrefix(i.Key(), []byte("!badger!Move")) {
+							moveKeyCount++
+						}
+						if i.IsDeletedOrExpired() {
+							invalidKeyCount++
+						} else {
+							validKeyCount++
+						}
+					}
+				}()
+				fmt.Printf("Valid Keys Count: %d\nInvalid Keys Count: %d\nMove Keys Count:"+
+					"%d\nInternal Keys Count: %d\n", validKeyCount, invalidKeyCount,
+					moveKeyCount, internalKeyCount)
 			}
 
 			// fetch directory contents
@@ -365,9 +375,6 @@ func reportStats(c *y.Closer, db *badger.DB) {
 			fmt.Printf("Time elapsed: %s, bytes written: %s, speed: %s/sec, "+
 				"entries written: %d, speed: %d/sec, gcSuccess: %d\n", y.FixedDuration(time.Since(startTime)),
 				humanize.Bytes(sz), humanize.Bytes(bytesRate), entries, entriesRate, gcSuccess)
-			fmt.Printf("Valid Keys Count: %d\nInvalid Keys Count: %d\nMove Keys Count: %d\n"+
-				"Internal Keys Count: %d\n", validKeyCount, invalidKeyCount, moveKeyCount,
-				internalKeyCount)
 		}
 	}
 }

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -73,13 +73,9 @@ var (
 	ttlDuration         string
 	showKeysCount       bool
 
-	internalKeyCount uint32
-	moveKeyCount     uint32
-	invalidKeyCount  uint32
-	validKeyCount    uint32
-	sstCount         uint32
-	vlogCount        uint32
-	files            []string
+	sstCount  uint32
+	vlogCount uint32
+	files     []string
 
 	dropAllPeriod    string
 	dropPrefixPeriod string
@@ -301,7 +297,14 @@ func writeBench(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func updateKeysStats(db *badger.DB) {
+func showKeysStats(db *badger.DB) {
+	var (
+		internalKeyCount uint32
+		moveKeyCount     uint32
+		invalidKeyCount  uint32
+		validKeyCount    uint32
+	)
+
 	txn := db.NewTransaction(false)
 	defer txn.Discard()
 
@@ -325,6 +328,9 @@ func updateKeysStats(db *badger.DB) {
 			validKeyCount++
 		}
 	}
+	fmt.Printf("Valid Keys: %d Invalid Keys: %d Move Keys:"+
+		" %d Internal Keys: %d\n", validKeyCount, invalidKeyCount,
+		moveKeyCount, internalKeyCount)
 }
 
 func reportStats(c *y.Closer, db *badger.DB) {
@@ -339,10 +345,7 @@ func reportStats(c *y.Closer, db *badger.DB) {
 			return
 		case <-t.C:
 			if showKeysCount {
-				updateKeysStats(db)
-				fmt.Printf("Valid Keys Count: %d Invalid Keys Count: %d Move Keys Count:"+
-					" %d Internal Keys Count: %d\n", validKeyCount, invalidKeyCount,
-					moveKeyCount, internalKeyCount)
+				showKeysStats(db)
 			}
 
 			// fetch directory contents


### PR DESCRIPTION
This PR adds an option to enable showing keys statistics in the write benchmark. The introduced flag is `--show-keys` and is disabled by default. This PR also fixes the ever existing iterators in the `reportStats()` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1457)
<!-- Reviewable:end -->
