### PR TITLE
fix(options): Do not implicitly enable cache

### DIFF
--- a/db.go
+++ b/db.go
@@ -204,6 +204,12 @@ func Open(opt Options) (db *DB, err error) {
 			maxValueThreshold)
 	}
 
+	// We need a cache if KeepBlocksInCache or KeepBlockIndices is set to true.
+	if (opt.KeepBlocksInCache || opt.KeepBlockIndicesInCache) && opt.MaxCacheSize <= 0 {
+		return nil, errors.New("Cannot use MaxCacheSize=0 with KeepBlocksInCache " +
+			"or KeepBlockIndicesInCache set.")
+	}
+
 	// If ValueThreshold is greater than opt.maxBatchSize, we won't be able to push any data using
 	// the transaction APIs. Transaction batches entries into batches of size opt.maxBatchSize.
 	if int64(opt.ValueThreshold) > opt.maxBatchSize {

--- a/options.go
+++ b/options.go
@@ -668,17 +668,13 @@ func (opt Options) WithDetectConflicts(b bool) Options {
 // given value.
 //
 // When this option is set badger will store the block offsets in a cache along with the blocks.
-// The size of the cache is determined by the MaxCacheSize option.If the MaxCacheSize is set to
-// zero, then MaxCacheSize is set to 100 mb. When indices are stored in the cache, the read
-// performance might be affected but the cache limits the amount of memory used by the indices.
+// The size of the cache is determined by the MaxCacheSize option. When indices
+// are stored in the cache, the read performance might be affected but the
+// cache limits the amount of memory used by the indices.
 //
 // The default value of KeepBlockOffsetInCache is false.
 func (opt Options) WithKeepBlockIndicesInCache(val bool) Options {
 	opt.KeepBlockIndicesInCache = val
-
-	if val && opt.MaxCacheSize == 0 {
-		opt.MaxCacheSize = 100 << 20
-	}
 	return opt
 }
 

--- a/options.go
+++ b/options.go
@@ -681,16 +681,13 @@ func (opt Options) WithKeepBlockIndicesInCache(val bool) Options {
 // WithKeepBlocksInCache returns a new Option value with KeepBlocksInCache set to the
 // given value.
 //
-// When this option is set badger will store the block in the cache. The size of the cache is
-// determined by the MaxCacheSize option.If the MaxCacheSize is set to zero,
-// then MaxCacheSize is set to 100 mb.
+// When this option is set badger will store table blocks in the cache. The
+// size of the cache is determined by the MaxCacheSize option. It is not
+// recommended to enable this option if you're not using compression or
+// encryption in badger.
 //
 // The default value of KeepBlocksInCache is false.
 func (opt Options) WithKeepBlocksInCache(val bool) Options {
 	opt.KeepBlocksInCache = val
-
-	if val && opt.MaxCacheSize == 0 {
-		opt.MaxCacheSize = 100 << 20
-	}
 	return opt
 }


### PR DESCRIPTION
We enable a 100 mb cache implicitly when `KeepBlocksInCache` or `KeepBlocIndicesInCache` in set to true. We should not do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1458)
<!-- Reviewable:end -->
