### PR TITLE
Add options to enable cache in benchmark read

### DIFF
--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -77,6 +77,7 @@ func fullScanDB(db *badger.DB) {
 	txn := db.NewTransaction(false)
 	defer txn.Discard()
 
+	startTime = time.Now()
 	// Print the stats
 	c := y.NewCloser(0)
 	c.AddRunning(1)
@@ -84,7 +85,6 @@ func fullScanDB(db *badger.DB) {
 
 	it := txn.NewIterator(badger.DefaultIteratorOptions)
 	defer it.Close()
-	startTime = time.Now()
 	for it.Rewind(); it.Valid(); it.Next() {
 		i := it.Item()
 		atomic.AddUint64(&entriesRead, 1)

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -102,13 +102,13 @@ func init() {
 	writeBenchCmd.Flags().BoolVarP(&showLogs, "logs", "l", false, "Show Badger logs.")
 	writeBenchCmd.Flags().IntVarP(&valueThreshold, "value-th", "t", 1<<10, "Value threshold")
 	writeBenchCmd.Flags().IntVarP(&numVersions, "num-version", "n", 1, "Number of versions to keep")
-	writeBenchCmd.Flags().Int64VarP(&maxCacheSize, "max-cache", "C", 0, "Max size of cache")
+	writeBenchCmd.Flags().Int64VarP(&maxCacheSize, "max-cache", "C", 0, "Max size of cache in MB")
 	writeBenchCmd.Flags().BoolVarP(&keepBlockIdxInCache, "keep-bidx", "b", false,
 		"Keep block indices in cache")
 	writeBenchCmd.Flags().BoolVarP(&keepBlocksInCache, "keep-blocks", "B", false,
 		"Keep blocks in cache")
 	writeBenchCmd.Flags().Int64VarP(&maxBfCacheSize, "max-bf-cache", "c", 0,
-		"Maximum Bloom Filter Cache Size")
+		"Maximum Bloom Filter Cache Size in MB")
 	writeBenchCmd.Flags().Uint32Var(&vlogMaxEntries, "vlog-maxe", 1000000, "Value log Max Entries")
 	writeBenchCmd.Flags().StringVarP(&encryptionKey, "encryption-key", "e", "",
 		"If it is true, badger will encrypt all the data stored on the disk.")
@@ -249,10 +249,10 @@ func writeBench(cmd *cobra.Command, args []string) error {
 		WithCompactL0OnClose(force).
 		WithValueThreshold(valueThreshold).
 		WithNumVersionsToKeep(numVersions).
-		WithMaxCacheSize(maxCacheSize).
+		WithMaxCacheSize(maxCacheSize << 20).
 		WithKeepBlockIndicesInCache(keepBlockIdxInCache).
 		WithKeepBlocksInCache(keepBlocksInCache).
-		WithMaxBfCacheSize(maxBfCacheSize).
+		WithMaxBfCacheSize(maxBfCacheSize << 20).
 		WithValueLogMaxEntries(vlogMaxEntries).
 		WithTableLoadingMode(mode).
 		WithEncryptionKey([]byte(encryptionKey)).


### PR DESCRIPTION
This PR adds options in `benchmark read` to enable cache for blocks and block indices. It also includes addition of `--full-scan` option to iterate over the whole DB using iterators. 

Fixes the `max-cache` and `max-bf-cache` options in benchmark write to accept size value in MB instead of Bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1461)
<!-- Reviewable:end -->
