### PR TITLE
fix(cleanup): Do not close cache before compaction

### DIFF
--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -114,6 +114,8 @@ func init() {
 		"If it is true, badger will encrypt all the data stored on the disk.")
 	writeBenchCmd.Flags().StringVar(&loadingMode, "loading-mode", "mmap",
 		"Mode for accessing SSTables")
+	infoCmd.Flags().BoolVar(&opt.truncate, "truncate", false, "If set to true, it allows "+
+		"truncation of value log files if they have corrupt data.")
 	writeBenchCmd.Flags().BoolVar(&loadBloomsOnOpen, "load-blooms", true,
 		"Load Bloom filter on DB open.")
 	writeBenchCmd.Flags().BoolVar(&detectConflicts, "conficts", true,

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -114,8 +114,6 @@ func init() {
 		"If it is true, badger will encrypt all the data stored on the disk.")
 	writeBenchCmd.Flags().StringVar(&loadingMode, "loading-mode", "mmap",
 		"Mode for accessing SSTables")
-	infoCmd.Flags().BoolVar(&opt.truncate, "truncate", false, "If set to true, it allows "+
-		"truncation of value log files if they have corrupt data.")
 	writeBenchCmd.Flags().BoolVar(&loadBloomsOnOpen, "load-blooms", true,
 		"Load Bloom filter on DB open.")
 	writeBenchCmd.Flags().BoolVar(&detectConflicts, "conficts", true,

--- a/db.go
+++ b/db.go
@@ -420,11 +420,11 @@ func Open(opt Options) (db *DB, err error) {
 // cleanup stops all the goroutines started by badger. This is used in open to
 // cleanup goroutines in case of an error.
 func (db *DB) cleanup() {
-	db.blockCache.Close()
-	db.bfCache.Close()
 	db.stopMemoryFlush()
 	db.stopCompactions()
 
+	db.blockCache.Close()
+	db.bfCache.Close()
 	if db.closers.updateSize != nil {
 		db.closers.updateSize.Signal()
 	}
@@ -1006,7 +1006,7 @@ func (db *DB) pushHead(ft flushTask) error {
 	}
 
 	// Store badger head even if vptr is zero, need it for readTs
-	db.opt.Debugf("Storing value log head: %+v\n", ft.vptr)
+	db.opt.Infof("Storing value log head: %+v\n", ft.vptr)
 	val := ft.vptr.Encode()
 
 	// Pick the max commit ts, so in case of crash, our read ts would be higher than all the


### PR DESCRIPTION
This PR fixes a panic that could happen in case `vlog.Open` returns an error.
The `db.Cleanup` would close the cache before compaction would finish and as a result of that we will end up with `send of closed channel panic`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1464)
<!-- Reviewable:end -->
