### PR TITLE
Fix(cleanup): Avoid truncating in value.Open on error

### DIFF
--- a/db.go
+++ b/db.go
@@ -447,7 +447,10 @@ func (db *DB) cleanup() {
 	}
 
 	db.orc.Stop()
-	db.vlog.Close()
+
+	// Do not use vlog.Close() here. vlog.Close truncates the files. We don't
+	// want to truncate files unless the user has specified the truncate flag.
+	db.vlog.stopFlushDiscardStats()
 }
 
 // BlockCacheMetrics returns the metrics for the underlying block cache.

--- a/value.go
+++ b/value.go
@@ -1232,7 +1232,9 @@ func (lf *logFile) init() error {
 }
 
 func (vlog *valueLog) stopFlushDiscardStats() {
-	vlog.lfDiscardStats.closer.Signal()
+	if vlog.lfDiscardStats != nil {
+		vlog.lfDiscardStats.closer.Signal()
+	}
 }
 
 func (vlog *valueLog) Close() error {

--- a/value.go
+++ b/value.go
@@ -1237,6 +1237,10 @@ func (lf *logFile) init() error {
 	return nil
 }
 
+func (vlog *valueLog) stopFlushDiscardStats() {
+	vlog.lfDiscardStats.closer.Signal()
+}
+
 func (vlog *valueLog) Close() error {
 	if vlog == nil || vlog.db == nil || vlog.db.opt.InMemory {
 		return nil

--- a/value.go
+++ b/value.go
@@ -1044,12 +1044,6 @@ func (vlog *valueLog) replayLog(lf *logFile, offset uint32, replayFn logEntry) e
 		return nil
 	}
 
-	// Store endoffset in the writableLogOffset if this file is the file with
-	// maxFid. If we don't set the writableLogOffset here, vlog.Close() will
-	// truncate the file to zero since writableLogOffset is set to zero.
-	if lf.fid == atomic.LoadUint32(&vlog.maxFid) {
-		atomic.StoreUint32(&vlog.writableLogOffset, endOffset)
-	}
 	// End offset is different from file size. So, we should truncate the file
 	// to that size.
 	if !vlog.opt.Truncate {


### PR DESCRIPTION
The vlog.Open() function can return an error denoting that the open was
unsuccessful but we have `db.cleanup` which will be called to stop all
the running goroutines in case badger couldn't start. The db.cleanup
function calls vlog.Close() which will truncate the maxFid vlog file
based on the vlog.writableLogOffset. The vlog.writableLogOffset was not
being updated in case open failed. As a result of this, we will end up
truncating the vlog file to length 0 if open fails.

This PR fixes this by using `vlog.stopDiscardStatFlush()` instead of `vlog.close`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1465)
<!-- Reviewable:end -->
