### PR TITLE
Expose NumAlloc metrics via expvar

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -701,9 +701,9 @@ nextTable:
 			mu.Lock()
 			newTables = append(newTables, tbl)
 			num := atomic.LoadInt32(&table.NumBlocks)
-			allocs := float64(atomic.LoadInt64(&y.NumAllocs)) / float64((1 << 20))
-			s.kv.opt.Debugf("Num Blocks: %d. Num Allocs (MB): %.2f\n", num, allocs)
 			mu.Unlock()
+
+			s.kv.opt.Debugf("Num Blocks: %d. Num Allocs (MB): %.2f\n", num, y.NumAllocsMB.Value())
 		}(builder)
 	}
 

--- a/levels.go
+++ b/levels.go
@@ -703,7 +703,7 @@ nextTable:
 			num := atomic.LoadInt32(&table.NumBlocks)
 			mu.Unlock()
 
-			s.kv.opt.Debugf("Num Blocks: %d. Num Allocs (MB): %.2f\n", num, y.NumAllocsMB.Value())
+			s.kv.opt.Debugf("Num Blocks: %d. Num Allocs (MB): %.2f\n", num, y.NumAllocs.Value())
 		}(builder)
 	}
 

--- a/y/calloc.go
+++ b/y/calloc.go
@@ -46,7 +46,7 @@ func Calloc(n int) []byte {
 		// it cannot allocate memory.
 		throw("out of memory")
 	}
-	NumAllocsMB.Add(float64(n) / (1 << 20))
+	NumAllocs.Add(n)
 	// Interpret the C pointer as a pointer to a Go array, then slice.
 	return (*[MaxArrayLen]byte)(unsafe.Pointer(ptr))[:n:n]
 }
@@ -59,6 +59,6 @@ func Free(b []byte) {
 		}
 		ptr := unsafe.Pointer(&b[0])
 		C.free(ptr)
-		NumAllocsMB.Add(float64(-sz) / (1 << 20))
+		NumAllocs.Add(-sz)
 	}
 }

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -48,8 +48,8 @@ var (
 	NumBlockedPuts *expvar.Int
 	// NumMemtableGets is number of memtable gets
 	NumMemtableGets *expvar.Int
-	// NumAllocsMB is the number of megabytes manually allocated by badger
-	NumAllocsMB *expvar.Float
+	// NumAllocs is the number of bytes manually allocated by badger
+	NumAllocs *expvar.Int
 )
 
 // These variables are global and have cumulative values for all kv stores.
@@ -67,5 +67,5 @@ func init() {
 	LSMSize = expvar.NewMap("badger_v2_lsm_size_bytes")
 	VlogSize = expvar.NewMap("badger_v2_vlog_size_bytes")
 	PendingWrites = expvar.NewMap("badger_v2_pending_writes_total")
-	NumAllocsMB = expvar.NewFloat("badger_v2_num_allocs_mb")
+	NumAllocs = expvar.Int("badger_v2_num_allocs")
 }

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -48,6 +48,8 @@ var (
 	NumBlockedPuts *expvar.Int
 	// NumMemtableGets is number of memtable gets
 	NumMemtableGets *expvar.Int
+	// NumAllocsMB is the number of megabytes manually allocated by badger
+	NumAllocsMB *expvar.Float
 )
 
 // These variables are global and have cumulative values for all kv stores.
@@ -65,4 +67,5 @@ func init() {
 	LSMSize = expvar.NewMap("badger_v2_lsm_size_bytes")
 	VlogSize = expvar.NewMap("badger_v2_vlog_size_bytes")
 	PendingWrites = expvar.NewMap("badger_v2_pending_writes_total")
+	NumAllocsMB = expvar.NewFloat("badger_v2_num_allocs_mb")
 }


### PR DESCRIPTION
This PR exposes `NumAllocMB` metric that can be used to keep track of the memory manually managed by badger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1470)
<!-- Reviewable:end -->
