### PR TITLE
Feature: Add a Calloc based Buffer

### DIFF
--- a/y/buffer.go
+++ b/y/buffer.go
@@ -1,5 +1,7 @@
 package y
 
+import "encoding/binary"
+
 type Buffer struct {
 	buf    []byte
 	offset int
@@ -10,6 +12,10 @@ func NewBuffer(sz int) *Buffer {
 		buf:    Calloc(sz),
 		offset: 0,
 	}
+}
+
+func (b *Buffer) Len() int {
+	return b.offset
 }
 
 func (b *Buffer) Bytes() []byte {
@@ -37,6 +43,41 @@ func (b *Buffer) Grow(n int) {
 	copy(newBuf, b.buf[:b.offset])
 	Free(b.buf)
 	b.buf = newBuf
+}
+
+// Allocate is not thread-safe. The byte slice returned MUST be used before further calls to Buffer.
+func (b *Buffer) Allocate(n int) []byte {
+	b.Grow(n)
+	off := b.offset
+	b.offset += n
+	return b.buf[off:b.offset]
+}
+
+func (b *Buffer) WriteLen(sz int) {
+	buf := b.Allocate(4)
+	binary.BigEndian.PutUint32(buf, uint32(sz))
+}
+
+func (b *Buffer) AllocateSlice(sz int) []byte {
+	b.Grow(4 + sz)
+	b.WriteLen(sz)
+	return b.Allocate(sz)
+}
+
+func (b *Buffer) SliceOffsets(offsets []int) []int {
+	start := 0
+	for start < b.offset {
+		offsets = append(offsets, start)
+		sz := binary.BigEndian.Uint32(b.buf[start:])
+		start += 4 + int(sz)
+	}
+	return offsets
+}
+
+func (b *Buffer) Slice(offset int) []byte {
+	sz := binary.BigEndian.Uint32(b.buf[offset:])
+	start := offset + 4
+	return b.buf[start : start+int(sz)]
 }
 
 func (b *Buffer) Write(p []byte) (n int, err error) {

--- a/y/buffer.go
+++ b/y/buffer.go
@@ -53,14 +53,14 @@ func (b *Buffer) Allocate(n int) []byte {
 	return b.buf[off:b.offset]
 }
 
-func (b *Buffer) WriteLen(sz int) {
+func (b *Buffer) writeLen(sz int) {
 	buf := b.Allocate(4)
 	binary.BigEndian.PutUint32(buf, uint32(sz))
 }
 
-func (b *Buffer) AllocateSlice(sz int) []byte {
+func (b *Buffer) SliceAllocate(sz int) []byte {
 	b.Grow(4 + sz)
-	b.WriteLen(sz)
+	b.writeLen(sz)
 	return b.Allocate(sz)
 }
 

--- a/y/buffer.go
+++ b/y/buffer.go
@@ -1,0 +1,55 @@
+package y
+
+type Buffer struct {
+	buf    []byte
+	offset int
+}
+
+func NewBuffer(sz int) *Buffer {
+	return &Buffer{
+		buf:    Calloc(sz),
+		offset: 0,
+	}
+}
+
+func (b *Buffer) Bytes() []byte {
+	return b.buf[0:b.offset]
+}
+
+// smallBufferSize is an initial allocation minimal capacity.
+const smallBufferSize = 64
+
+func (b *Buffer) Grow(n int) {
+	// In this case, len and cap are the same.
+	if len(b.buf) == 0 && n <= smallBufferSize {
+		b.buf = Calloc(smallBufferSize)
+		return
+	} else if b.buf == nil {
+		b.buf = Calloc(n)
+		return
+	}
+	if b.offset+n < len(b.buf) {
+		return
+	}
+
+	sz := 2*len(b.buf) + n
+	newBuf := Calloc(sz)
+	copy(newBuf, b.buf[:b.offset])
+	Free(b.buf)
+	b.buf = newBuf
+}
+
+func (b *Buffer) Write(p []byte) (n int, err error) {
+	b.Grow(len(p))
+	n = copy(b.buf[b.offset:], p)
+	b.offset += n
+	return n, nil
+}
+
+func (b *Buffer) Reset() {
+	b.offset = 0
+}
+
+func (b *Buffer) Release() {
+	Free(b.buf)
+}

--- a/y/buffer.go
+++ b/y/buffer.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package y
 
 import "encoding/binary"

--- a/y/buffer_test.go
+++ b/y/buffer_test.go
@@ -57,3 +57,30 @@ func TestCallocBufferWrite(t *testing.T) {
 		end = end * 2
 	}
 }
+
+func TestSliceAlloc(t *testing.T) {
+	var buf Buffer
+	count := 10000
+	expectedSlice := make([][]byte, 0, count)
+
+	// Create "count" number of slices.
+	for i := 0; i < count; i++ {
+		sz := rand.Intn(1000)
+		testBuf := make([]byte, sz)
+		rand.Read(testBuf)
+
+		newSlice := buf.SliceAllocate(sz)
+		require.Equal(t, sz, copy(newSlice, testBuf))
+
+		// Save testBuf for verification.
+		expectedSlice = append(expectedSlice, testBuf)
+	}
+
+	offsets := buf.SliceOffsets(nil)
+	require.Equal(t, len(expectedSlice), len(offsets))
+	for i, off := range offsets {
+		// All the slices returned by the buffer should be equal to what we
+		// inserted earlier.
+		require.Equal(t, expectedSlice[i], buf.Slice(off))
+	}
+}

--- a/y/buffer_test.go
+++ b/y/buffer_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package y
 
 import (

--- a/y/buffer_test.go
+++ b/y/buffer_test.go
@@ -1,0 +1,59 @@
+package y
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallocBuffer(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	var bytesBuffer bytes.Buffer // This is just for verifying result.
+	bytesBuffer.Grow(512)
+
+	cBuffer := NewBuffer(512)
+
+	// Writer small []byte
+	var smallBytes [256]byte
+	rand.Read(smallBytes[:])
+	var bigBytes [1024]byte
+	rand.Read(bigBytes[:])
+
+	_, err := cBuffer.Write(smallBytes[:])
+	require.NoError(t, err, "unable to write data to page buffer")
+	_, err = cBuffer.Write(bigBytes[:])
+	require.NoError(t, err, "unable to write data to page buffer")
+
+	// Write data to bytesBuffer also, just to match result.
+	bytesBuffer.Write(smallBytes[:])
+	bytesBuffer.Write(bigBytes[:])
+
+	require.True(t, bytes.Equal(cBuffer.Bytes(), bytesBuffer.Bytes()))
+}
+
+func TestCallocBufferWrite(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	var wb [128]byte
+	rand.Read(wb[:])
+
+	cb := NewBuffer(32)
+	bb := new(bytes.Buffer)
+
+	end := 32
+	for i := 0; i < 3; i++ {
+		n, err := cb.Write(wb[:end])
+		require.NoError(t, err, "unable to write bytes to buffer")
+		require.Equal(t, n, end, "length of buffer and length written should be equal")
+
+		// append to bb also for testing.
+		bb.Write(wb[:end])
+
+		require.True(t, bytes.Equal(cb.Bytes(), bb.Bytes()), "Both bytes should match")
+		end = end * 2
+	}
+}

--- a/y/y_test.go
+++ b/y/y_test.go
@@ -26,6 +26,15 @@ func BenchmarkBuffer(b *testing.B) {
 		}
 	})
 
+	b.Run("calloc-buffer", func(b *testing.B) {
+		buf := NewBuffer(pageSize)
+		defer buf.Release()
+
+		for i := 0; i < b.N; i++ {
+			buf.Write(btw[:])
+		}
+	})
+
 	b.Run("page-buffer", func(b *testing.B) {
 		b.Run(fmt.Sprintf("page-size-%d", pageSize), func(b *testing.B) {
 			pageBuffer := NewPageBuffer(pageSize)


### PR DESCRIPTION
Add a Buffer which uses Calloc for memory allocation and also provides a way to write and read byte slices with their size into a bigger buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1471)
<!-- Reviewable:end -->
