### PR TITLE
Rework Block and Index cache

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -365,7 +365,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 		WithValueThreshold(1). // Make all values go to value log
 		WithCompression(options.ZSTD).
 		WithKeepL0InMemory(false).
-		WithMaxCacheSize(10 << 20)
+		WithBlockCacheSize(10 << 20)
 
 	if mmap {
 		opts = opts.WithTableLoadingMode(options.MemoryMap)

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -46,10 +46,8 @@ var (
 	entriesRead uint64    // will store entries read till now
 	startTime   time.Time // start time of read benchmarking
 
-	sizeMaxCache      int64
-	keepBlockIdxCache bool
-	keepBlocksCache   bool
-	sizeMaxBfCache    int64
+	blockCacheSize int64
+	indexCacheSize int64
 
 	sampleSize  int
 	loadingMode string
@@ -75,13 +73,8 @@ func init() {
 			"Valid loading modes are fileio and mmap.")
 	readBenchCmd.Flags().BoolVar(
 		&fullScan, "full-scan", false, "If true, full db will be scanned using iterators.")
-	readBenchCmd.Flags().Int64VarP(&sizeMaxCache, "max-cache", "C", 0, "Max size of cache in MB")
-	readBenchCmd.Flags().BoolVarP(&keepBlockIdxCache, "keep-bidx", "b", false,
-		"Keep block indices in cache")
-	readBenchCmd.Flags().BoolVarP(&keepBlocksCache, "keep-blocks", "B", false,
-		"Keep blocks in cache")
-	readBenchCmd.Flags().Int64VarP(&sizeMaxBfCache, "max-bf-cache", "c", 0,
-		"Maximum Bloom Filter Cache Size in MB")
+	readBenchCmd.Flags().Int64Var(&blockCacheSize, "block-cache", 0, "Max size of block cache in MB")
+	readBenchCmd.Flags().Int64Var(&indexCacheSize, "index-cache", 0, "Max size of index cache in MB")
 }
 
 // Scan the whole database using the iterators
@@ -118,8 +111,8 @@ func readBench(cmd *cobra.Command, args []string) error {
 		WithReadOnly(readOnly).
 		WithTableLoadingMode(mode).
 		WithValueLogLoadingMode(mode).
-		WithBlockCacheSize(sizeMaxCache << 20).
-		WithIndexCacheSize(sizeMaxBfCache << 20)
+		WithBlockCacheSize(blockCacheSize << 20).
+		WithIndexCacheSize(indexCacheSize << 20)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.Open(opt)
 	if err != nil {

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -118,10 +118,8 @@ func readBench(cmd *cobra.Command, args []string) error {
 		WithReadOnly(readOnly).
 		WithTableLoadingMode(mode).
 		WithValueLogLoadingMode(mode).
-		WithMaxCacheSize(sizeMaxCache << 20).
-		WithKeepBlockIndicesInCache(keepBlockIdxCache).
-		WithKeepBlocksInCache(keepBlocksCache).
-		WithMaxBfCacheSize(sizeMaxBfCache << 20)
+		WithBlockCacheSize(sizeMaxCache << 20).
+		WithIndexCacheSize(sizeMaxBfCache << 20)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.Open(opt)
 	if err != nil {

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -242,8 +242,8 @@ func writeBench(cmd *cobra.Command, args []string) error {
 		WithCompactL0OnClose(force).
 		WithValueThreshold(valueThreshold).
 		WithNumVersionsToKeep(numVersions).
-		WithBlockCacheSize(maxCacheSize << 20).
-		WithIndexCacheSize(maxBfCacheSize << 20).
+		WithBlockCacheSize(blockCacheSize << 20).
+		WithIndexCacheSize(indexCacheSize << 20).
 		WithValueLogMaxEntries(vlogMaxEntries).
 		WithTableLoadingMode(mode).
 		WithEncryptionKey([]byte(encryptionKey)).

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -59,19 +59,15 @@ var (
 	sizeWritten    uint64
 	entriesWritten uint64
 
-	valueThreshold      int
-	numVersions         int
-	maxCacheSize        int64
-	keepBlockIdxInCache bool
-	keepBlocksInCache   bool
-	maxBfCacheSize      int64
-	vlogMaxEntries      uint32
-	loadBloomsOnOpen    bool
-	detectConflicts     bool
-	compression         bool
-	showDir             bool
-	ttlDuration         string
-	showKeysCount       bool
+	valueThreshold   int
+	numVersions      int
+	vlogMaxEntries   uint32
+	loadBloomsOnOpen bool
+	detectConflicts  bool
+	compression      bool
+	showDir          bool
+	ttlDuration      string
+	showKeysCount    bool
 
 	sstCount  uint32
 	vlogCount uint32
@@ -102,13 +98,10 @@ func init() {
 	writeBenchCmd.Flags().BoolVarP(&showLogs, "logs", "l", false, "Show Badger logs.")
 	writeBenchCmd.Flags().IntVarP(&valueThreshold, "value-th", "t", 1<<10, "Value threshold")
 	writeBenchCmd.Flags().IntVarP(&numVersions, "num-version", "n", 1, "Number of versions to keep")
-	writeBenchCmd.Flags().Int64VarP(&maxCacheSize, "max-cache", "C", 0, "Max size of cache in MB")
-	writeBenchCmd.Flags().BoolVarP(&keepBlockIdxInCache, "keep-bidx", "b", false,
-		"Keep block indices in cache")
-	writeBenchCmd.Flags().BoolVarP(&keepBlocksInCache, "keep-blocks", "B", false,
-		"Keep blocks in cache")
-	writeBenchCmd.Flags().Int64VarP(&maxBfCacheSize, "max-bf-cache", "c", 0,
-		"Maximum Bloom Filter Cache Size in MB")
+	writeBenchCmd.Flags().Int64Var(&blockCacheSize, "block-cache", 0,
+		"Size of block cache in MB")
+	writeBenchCmd.Flags().Int64Var(&indexCacheSize, "index-cache", 0,
+		"Size of index cache in MB.")
 	writeBenchCmd.Flags().Uint32Var(&vlogMaxEntries, "vlog-maxe", 1000000, "Value log Max Entries")
 	writeBenchCmd.Flags().StringVarP(&encryptionKey, "encryption-key", "e", "",
 		"If it is true, badger will encrypt all the data stored on the disk.")

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -249,10 +249,8 @@ func writeBench(cmd *cobra.Command, args []string) error {
 		WithCompactL0OnClose(force).
 		WithValueThreshold(valueThreshold).
 		WithNumVersionsToKeep(numVersions).
-		WithMaxCacheSize(maxCacheSize << 20).
-		WithKeepBlockIndicesInCache(keepBlockIdxInCache).
-		WithKeepBlocksInCache(keepBlocksInCache).
-		WithMaxBfCacheSize(maxBfCacheSize << 20).
+		WithBlockCacheSize(maxCacheSize << 20).
+		WithIndexCacheSize(maxBfCacheSize << 20).
 		WithValueLogMaxEntries(vlogMaxEntries).
 		WithTableLoadingMode(mode).
 		WithEncryptionKey([]byte(encryptionKey)).

--- a/db.go
+++ b/db.go
@@ -449,16 +449,16 @@ func (db *DB) cleanup() {
 	db.vlog.Close()
 }
 
-// DataCacheMetrics returns the metrics for the underlying data cache.
-func (db *DB) DataCacheMetrics() *ristretto.Metrics {
+// BlockCacheMetrics returns the metrics for the underlying block cache.
+func (db *DB) BlockCacheMetrics() *ristretto.Metrics {
 	if db.blockCache != nil {
 		return db.blockCache.Metrics
 	}
 	return nil
 }
 
-// BfCacheMetrics returns the metrics for the underlying bloom filter cache.
-func (db *DB) BfCacheMetrics() *ristretto.Metrics {
+// IndexCacheMetrics returns the metrics for the underlying index cache.
+func (db *DB) IndexCacheMetrics() *ristretto.Metrics {
 	if db.indexCache != nil {
 		return db.indexCache.Metrics
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -287,7 +287,7 @@ func TestGet(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 	t.Run("cache disabled", func(t *testing.T) {
-		opts := DefaultOptions("").WithInMemory(true).WithMaxCacheSize(0)
+		opts := DefaultOptions("").WithInMemory(true).WithBlockCacheSize(0)
 		db, err := Open(opts)
 		require.NoError(t, err)
 		test(t, db)

--- a/db_test.go
+++ b/db_test.go
@@ -286,8 +286,8 @@ func TestGet(t *testing.T) {
 		test(t, db)
 		require.NoError(t, db.Close())
 	})
-	t.Run("cache disabled", func(t *testing.T) {
-		opts := DefaultOptions("").WithInMemory(true).WithBlockCacheSize(0)
+	t.Run("cache enabled", func(t *testing.T) {
+		opts := DefaultOptions("").WithBlockCacheSize(10 << 20)
 		db, err := Open(opts)
 		require.NoError(t, err)
 		test(t, db)

--- a/db_test.go
+++ b/db_test.go
@@ -72,8 +72,7 @@ func getTestOptions(dir string) Options {
 	opt := DefaultOptions(dir).
 		WithMaxTableSize(1 << 15). // Force more compaction.
 		WithLevelOneSize(4 << 15). // Force more compaction.
-		WithSyncWrites(false).
-		WithMaxCacheSize(10 << 20)
+		WithSyncWrites(false)
 	if !*mmap {
 		return opt.WithValueLogLoadingMode(options.FileIO)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -288,10 +288,9 @@ func TestGet(t *testing.T) {
 	})
 	t.Run("cache enabled", func(t *testing.T) {
 		opts := DefaultOptions("").WithBlockCacheSize(10 << 20)
-		db, err := Open(opts)
-		require.NoError(t, err)
-		test(t, db)
-		require.NoError(t, db.Close())
+		runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
+			test(t, db)
+		})
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/ristretto v0.0.4-0.20200820164438-623d8ef1614b
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/ristretto v0.0.4-0.20200820164438-623d8ef1614b
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -210,7 +210,7 @@ func TestIteratePrefix(t *testing.T) {
 	t.Run("With Block Offsets in Cache", func(t *testing.T) {
 		t.Parallel()
 		opts := getTestOptions("")
-		opts.BlockCacheSize = 100 << 20
+		opts.IndexCacheSize = 100 << 20
 		runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
 			testIteratorPrefix(t, db)
 		})
@@ -229,7 +229,7 @@ func TestIteratePrefix(t *testing.T) {
 	t.Run("With Blocks in Cache", func(t *testing.T) {
 		t.Parallel()
 		opts := getTestOptions("")
-		opts.IndexCacheSize = 100 << 20
+		opts.BlockCacheSize = 100 << 20
 		runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
 			testIteratorPrefix(t, db)
 		})

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -210,7 +210,7 @@ func TestIteratePrefix(t *testing.T) {
 	t.Run("With Block Offsets in Cache", func(t *testing.T) {
 		t.Parallel()
 		opts := getTestOptions("")
-		opts = opts.WithKeepBlockIndicesInCache(true)
+		opts.BlockCacheSize = 100 << 20
 		runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
 			testIteratorPrefix(t, db)
 		})
@@ -219,7 +219,8 @@ func TestIteratePrefix(t *testing.T) {
 	t.Run("With Block Offsets and Blocks in Cache", func(t *testing.T) {
 		t.Parallel()
 		opts := getTestOptions("")
-		opts = opts.WithKeepBlockIndicesInCache(true).WithKeepBlocksInCache(true)
+		opts.BlockCacheSize = 100 << 20
+		opts.IndexCacheSize = 100 << 20
 		runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
 			testIteratorPrefix(t, db)
 		})
@@ -228,7 +229,7 @@ func TestIteratePrefix(t *testing.T) {
 	t.Run("With Blocks in Cache", func(t *testing.T) {
 		t.Parallel()
 		opts := getTestOptions("")
-		opts = opts.WithKeepBlocksInCache(true)
+		opts.IndexCacheSize = 100 << 20
 		runBadgerTest(t, &opts, func(t *testing.T, db *DB) {
 			testIteratorPrefix(t, db)
 		})

--- a/levels.go
+++ b/levels.go
@@ -158,8 +158,8 @@ func newLevelsController(db *DB, mf *Manifest) (*levelsController, error) {
 			// Set compression from table manifest.
 			topt.Compression = tf.Compression
 			topt.DataKey = dk
-			topt.Cache = db.blockCache
-			topt.BfCache = db.bfCache
+			topt.BlockCache = db.blockCache
+			topt.IndexCache = db.bfCache
 			t, err := table.OpenTable(fd, topt)
 			if err != nil {
 				if strings.HasPrefix(err.Error(), "CHECKSUM_MISMATCH:") {
@@ -570,8 +570,8 @@ nextTable:
 		bopts := buildTableOptions(s.kv.opt)
 		bopts.DataKey = dk
 		// Builder does not need cache but the same options are used for opening table.
-		bopts.Cache = s.kv.blockCache
-		bopts.BfCache = s.kv.bfCache
+		bopts.BlockCache = s.kv.blockCache
+		bopts.IndexCache = s.kv.bfCache
 		builder := table.NewTableBuilder(bopts)
 		var numKeys, numSkips uint64
 		for ; it.Valid(); it.Next() {

--- a/levels.go
+++ b/levels.go
@@ -159,7 +159,7 @@ func newLevelsController(db *DB, mf *Manifest) (*levelsController, error) {
 			topt.Compression = tf.Compression
 			topt.DataKey = dk
 			topt.BlockCache = db.blockCache
-			topt.IndexCache = db.bfCache
+			topt.IndexCache = db.indexCache
 			t, err := table.OpenTable(fd, topt)
 			if err != nil {
 				if strings.HasPrefix(err.Error(), "CHECKSUM_MISMATCH:") {
@@ -571,7 +571,7 @@ nextTable:
 		bopts.DataKey = dk
 		// Builder does not need cache but the same options are used for opening table.
 		bopts.BlockCache = s.kv.blockCache
-		bopts.IndexCache = s.kv.bfCache
+		bopts.IndexCache = s.kv.indexCache
 		builder := table.NewTableBuilder(bopts)
 		var numKeys, numSkips uint64
 		for ; it.Valid(); it.Next() {

--- a/options.go
+++ b/options.go
@@ -62,8 +62,8 @@ type Options struct {
 	BlockSize          int
 	BloomFalsePositive float64
 	KeepL0InMemory     bool
-	MaxCacheSize       int64
-	MaxBfCacheSize     int64
+	BlockCacheSize     int64
+	IndexCacheSize     int64
 	LoadBloomsOnOpen   bool
 
 	NumLevelZeroTables      int
@@ -97,12 +97,6 @@ type Options struct {
 	// conflicts. The transactions can be processed at a higher rate when
 	// conflict detection is disabled.
 	DetectConflicts bool
-
-	// KeepBlockIndicesInCache decides whether to keep the block offsets in the cache or not.
-	KeepBlockIndicesInCache bool
-
-	// KeepBlocksInCache decides whether to keep the sst blocks in the cache or not.
-	KeepBlocksInCache bool
 
 	// Transaction start and commit timestamps are managed by end-user.
 	// This is only useful for databases built on top of Badger (like Dgraph).
@@ -141,9 +135,10 @@ func DefaultOptions(path string) Options {
 		KeepL0InMemory:          false,
 		VerifyValueChecksum:     false,
 		Compression:             options.None,
-		MaxCacheSize:            0,
-		MaxBfCacheSize:          0,
+		BlockCacheSize:          10 << 20,
+		IndexCacheSize:          10 << 20,
 		LoadBloomsOnOpen:        true,
+
 		// The following benchmarks were done on a 4 KB block size (default block size). The
 		// compression is ratio supposed to increase with increasing compression level but since the
 		// input for compression algorithm is small (4 KB), we don't get significant benefit at
@@ -169,23 +164,19 @@ func DefaultOptions(path string) Options {
 		EncryptionKey:                 []byte{},
 		EncryptionKeyRotationDuration: 10 * 24 * time.Hour, // Default 10 days.
 		DetectConflicts:               true,
-		KeepBlocksInCache:             false,
-		KeepBlockIndicesInCache:       false,
 	}
 }
 
 func buildTableOptions(opt Options) table.Options {
 	return table.Options{
-		TableSize:               uint64(opt.MaxTableSize),
-		BlockSize:               opt.BlockSize,
-		BloomFalsePositive:      opt.BloomFalsePositive,
-		LoadBloomsOnOpen:        opt.LoadBloomsOnOpen,
-		LoadingMode:             opt.TableLoadingMode,
-		ChkMode:                 opt.ChecksumVerificationMode,
-		Compression:             opt.Compression,
-		ZSTDCompressionLevel:    opt.ZSTDCompressionLevel,
-		KeepBlockIndicesInCache: opt.KeepBlockIndicesInCache,
-		KeepBlocksInCache:       opt.KeepBlocksInCache,
+		TableSize:            uint64(opt.MaxTableSize),
+		BlockSize:            opt.BlockSize,
+		BloomFalsePositive:   opt.BloomFalsePositive,
+		LoadBloomsOnOpen:     opt.LoadBloomsOnOpen,
+		LoadingMode:          opt.TableLoadingMode,
+		ChkMode:              opt.ChecksumVerificationMode,
+		Compression:          opt.Compression,
+		ZSTDCompressionLevel: opt.ZSTDCompressionLevel,
 	}
 }
 
@@ -503,7 +494,7 @@ func (opt Options) WithEncryptionKey(key []byte) Options {
 	return opt
 }
 
-// WithEncryptionRotationDuration returns new Options value with the duration set to
+// WithEncryptionKeyRotationDuration returns new Options value with the duration set to
 // the given value.
 //
 // Key Registry will use this duration to create new keys. If the previous generated
@@ -573,7 +564,7 @@ func (opt Options) WithChecksumVerificationMode(cvMode options.ChecksumVerificat
 //
 // Default value of MaxCacheSize is zero.
 func (opt Options) WithMaxCacheSize(size int64) Options {
-	opt.MaxCacheSize = size
+	opt.BlockCacheSize = size
 	return opt
 }
 
@@ -622,22 +613,6 @@ func (opt Options) WithBypassLockGuard(b bool) Options {
 	return opt
 }
 
-// WithMaxBfCacheSize returns a new Options value with MaxBfCacheSize set to the given value.
-//
-// This value specifies how much memory should be used by the bloom filters.
-// Badger uses bloom filters to speed up lookups. Each table has its own bloom
-// filter and each bloom filter is approximately of 5 MB.
-//
-// Zero value for BfCacheSize means all the bloom filters will be kept in
-// memory and the cache is disabled.
-//
-// The default value of MaxBfCacheSize is 0 which means all bloom filters will
-// be kept in memory.
-func (opt Options) WithMaxBfCacheSize(size int64) Options {
-	opt.MaxBfCacheSize = size
-	return opt
-}
-
 // WithLoadBloomsOnOpen returns a new Options value with LoadBloomsOnOpen set to the given value.
 //
 // Badger uses bloom filters to speed up key lookups. When LoadBloomsOnOpen is set
@@ -648,6 +623,24 @@ func (opt Options) WithMaxBfCacheSize(size int64) Options {
 // The default value of LoadBloomsOnOpen is false.
 func (opt Options) WithLoadBloomsOnOpen(b bool) Options {
 	opt.LoadBloomsOnOpen = b
+	return opt
+}
+
+// WithIndexCacheSize returns a new Options value with IndexCacheSize set to
+// the given value.
+//
+// This value specifies how much memory should be used by table indices. These
+// indices include the block offsets and the bloomfilters. Badger uses bloom
+// filters to speed up lookups. Each table has its own bloom
+// filter and each bloom filter is approximately of 5 MB.
+//
+// Zero value for IndexCacheSize means all the indices will be kept in
+// memory and the cache is disabled.
+//
+// The default value of IndexCacheSize is 0 which means all indices are kept in
+// memory.
+func (opt Options) WithIndexCacheSize(size int64) Options {
+	opt.IndexCacheSize = size
 	return opt
 }
 
@@ -662,33 +655,5 @@ func (opt Options) WithLoadBloomsOnOpen(b bool) Options {
 // The default value of Detect conflicts is True.
 func (opt Options) WithDetectConflicts(b bool) Options {
 	opt.DetectConflicts = b
-	return opt
-}
-
-// WithKeepBlockIndicesInCache returns a new Option value with KeepBlockOffsetInCache set to the
-// given value.
-//
-// When this option is set badger will store the block offsets in a cache along with the blocks.
-// The size of the cache is determined by the MaxCacheSize option. When indices
-// are stored in the cache, the read performance might be affected but the
-// cache limits the amount of memory used by the indices.
-//
-// The default value of KeepBlockOffsetInCache is false.
-func (opt Options) WithKeepBlockIndicesInCache(val bool) Options {
-	opt.KeepBlockIndicesInCache = val
-	return opt
-}
-
-// WithKeepBlocksInCache returns a new Option value with KeepBlocksInCache set to the
-// given value.
-//
-// When this option is set badger will store table blocks in the cache. The
-// size of the cache is determined by the MaxCacheSize option. It is not
-// recommended to enable this option if you're not using compression or
-// encryption in badger.
-//
-// The default value of KeepBlocksInCache is false.
-func (opt Options) WithKeepBlocksInCache(val bool) Options {
-	opt.KeepBlocksInCache = val
 	return opt
 }

--- a/options.go
+++ b/options.go
@@ -135,8 +135,8 @@ func DefaultOptions(path string) Options {
 		KeepL0InMemory:          false,
 		VerifyValueChecksum:     false,
 		Compression:             options.None,
-		BlockCacheSize:          10 << 20,
-		IndexCacheSize:          10 << 20,
+		BlockCacheSize:          0,
+		IndexCacheSize:          0,
 		LoadBloomsOnOpen:        true,
 
 		// The following benchmarks were done on a 4 KB block size (default block size). The
@@ -553,17 +553,17 @@ func (opt Options) WithChecksumVerificationMode(cvMode options.ChecksumVerificat
 	return opt
 }
 
-// WithMaxCacheSize returns a new Options value with MaxCacheSize set to the given value.
+// WithBlockCacheSize returns a new Options value with WithBlockCacheSize set to the given value.
 //
-// This value specifies how much data cache should hold in memory. A small size of cache means lower
-// memory consumption and lookups/iterations would take longer.
-// It is recommended to use a cache if you're using compression or encryption.
+// This value specifies how much data cache should hold in memory. A small size
+// of cache means lower memory consumption and lookups/iterations would take
+// longer. It is recommended to use a cache if you're using compression or encryption.
 // If compression and encryption both are disabled, adding a cache will lead to
-// unnecessary overhead which will affect the read performance. Setting size to zero disables the
-// cache altogether.
+// unnecessary overhead which will affect the read performance. Setting size to
+// zero disables the cache altogether.
 //
-// Default value of MaxCacheSize is zero.
-func (opt Options) WithMaxCacheSize(size int64) Options {
+// Default value of WithBlockCacheSize is zero.
+func (opt Options) WithBlockCacheSize(size int64) Options {
 	opt.BlockCacheSize = size
 	return opt
 }

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -418,8 +418,8 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 	fileID := w.db.lc.reserveFileID()
 	opts := buildTableOptions(w.db.opt)
 	opts.DataKey = builder.DataKey()
-	opts.Cache = w.db.blockCache
-	opts.BfCache = w.db.bfCache
+	opts.BlockCache = w.db.blockCache
+	opts.IndexCache = w.db.bfCache
 	var tbl *table.Table
 	if w.db.opt.InMemory {
 		var err error

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -419,7 +419,7 @@ func (w *sortedWriter) createTable(builder *table.Builder) error {
 	opts := buildTableOptions(w.db.opt)
 	opts.DataKey = builder.DataKey()
 	opts.BlockCache = w.db.blockCache
-	opts.IndexCache = w.db.bfCache
+	opts.IndexCache = w.db.indexCache
 	var tbl *table.Table
 	if w.db.opt.InMemory {
 		var err error

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -120,7 +120,9 @@ func TestTableIndex(t *testing.T) {
 
 			// Ensure index is built correctly
 			require.Equal(t, blockCount, tbl.noOfBlocks)
-			for i, ko := range tbl.readTableIndex().Offsets {
+			idx, err := tbl.readTableIndex()
+			require.NoError(t, err)
+			for i, ko := range idx.Offsets {
 				require.Equal(t, ko.Key, blockFirstKeys[i])
 			}
 			f.Close()

--- a/table/table.go
+++ b/table/table.go
@@ -172,7 +172,7 @@ func (t *Table) DecrRef() error {
 		for i := 0; i < t.noOfBlocks; i++ {
 			t.opt.BlockCache.Del(t.blockCacheKey(i))
 		}
-		// Delete bloom filter from the cache.
+		// Delete bloom filter and indices from the cache.
 		t.opt.IndexCache.Del(t.blockOffsetsCacheKey())
 		t.opt.IndexCache.Del(t.bfCacheKey())
 	}
@@ -455,7 +455,10 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 		// Keep blooms in memory.
 		if t.hasBloomFilter && t.opt.LoadBloomsOnOpen {
 			bf, err := z.JSONUnmarshal(index.BloomFilter)
-			y.Check(err)
+			if err != nil {
+				return nil,
+					errors.Wrapf(err, "failed to unmarshal bloomfilter for table:%d", t.id)
+			}
 
 			t.bfLock.Lock()
 			t.bf = bf

--- a/table/table.go
+++ b/table/table.go
@@ -106,8 +106,8 @@ type Table struct {
 	bfLock    sync.Mutex
 
 	blockOffset []*pb.BlockOffset
-	ref         int32 // For file garbage collection. Atomic.
-	bf          *z.Bloom
+	ref         int32    // For file garbage collection. Atomic.
+	bf          *z.Bloom // Nil if index cache in enabled.
 
 	mmap []byte // Memory mapped.
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -781,7 +781,7 @@ func BenchmarkReadAndBuild(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		func() {
 			opts := Options{Compression: options.ZSTD, BlockSize: 4 * 0124, BloomFalsePositive: 0.01}
-			opts.Cache = cache
+			opts.BlockCache = cache
 			newBuilder := NewTableBuilder(opts)
 			it := tbl.NewIterator(0)
 			defer it.Close()
@@ -807,7 +807,7 @@ func BenchmarkReadMerged(b *testing.B) {
 	for i := 0; i < m; i++ {
 		filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
 		opts := Options{Compression: options.ZSTD, BlockSize: 4 * 1024, BloomFalsePositive: 0.01}
-		opts.Cache = cache
+		opts.BlockCache = cache
 		builder := NewTableBuilder(opts)
 		f, err := y.OpenSyncedFile(filename, true)
 		y.Check(err)
@@ -899,7 +899,7 @@ func getTableForBenchmarks(b *testing.B, count int, cache *ristretto.Cache) *Tab
 		cache, err = ristretto.NewCache(&cacheConfig)
 		require.NoError(b, err)
 	}
-	opts.Cache = cache
+	opts.BlockCache = cache
 	builder := NewTableBuilder(opts)
 	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
 	f, err := y.OpenSyncedFile(filename, true)


### PR DESCRIPTION
This PR separates the block cache and the index cache. Earlier we had a mix of both the caches. 
Block Cache -> Stores block. Should be used when running badger with compression/encryption
Index Cache -> Used to limit the memory used by table indices and bloom filters. 

This PR also remove the `KeepBlocksInCache` and `KeepBlockIndicesInCache` options.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1473)
<!-- Reviewable:end -->
