### PR TITLE
fix 32 bit build & remove dependency on zstd when cgo is disabled

### DIFF
--- a/value.go
+++ b/value.go
@@ -47,7 +47,7 @@ import (
 
 // maxVlogFileSize is the maximum size of the vlog file which can be created. Vlog Offset is of
 // uint32, so limiting at max uint32.
-var maxVlogFileSize = math.MaxUint32
+var maxVlogFileSize uint32 = math.MaxUint32
 
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.


### PR DESCRIPTION
1. Fix 32bit builds by explicitly setting the maxVlogFileSize to uint32.
2. Remove dependency on zstd when cgo is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1477)
<!-- Reviewable:end -->
