### PR TITLE
release/v2.2007-Fix comment about LoadBloomsOnOpen (#1478)

### DIFF
--- a/options.go
+++ b/options.go
@@ -613,11 +613,10 @@ func (opt Options) WithBypassLockGuard(b bool) Options {
 // WithLoadBloomsOnOpen returns a new Options value with LoadBloomsOnOpen set to the given value.
 //
 // Badger uses bloom filters to speed up key lookups. When LoadBloomsOnOpen is set
-// to false, all bloom filters will be loaded on DB open. This is supposed to
-// improve the read speed but it will affect the time taken to open the DB. Set
-// this option to true to reduce the time taken to open the DB.
+// to false, bloom filters will be loaded lazily and not on DB open. Set this
+// option to false to reduce the time taken to open the DB.
 //
-// The default value of LoadBloomsOnOpen is false.
+// The default value of LoadBloomsOnOpen is true.
 func (opt Options) WithLoadBloomsOnOpen(b bool) Options {
 	opt.LoadBloomsOnOpen = b
 	return opt

--- a/table/table.go
+++ b/table/table.go
@@ -82,8 +82,8 @@ type Options struct {
 	// ZSTDCompressionLevel is the ZSTD compression level used for compressing blocks.
 	ZSTDCompressionLevel int
 
-	// When LoadBloomsOnOpen is set, bloom filters will be read only when they are accessed.
-	// Otherwise they will be loaded on table open.
+	// When LoadBloomsOnOpen is set, bloom filters will be loaded while opening
+	// the table. Otherwise, they will be loaded lazily when they're accessed.
 	LoadBloomsOnOpen bool
 }
 


### PR DESCRIPTION
The comment about LoadBloomsOnOpen was incorrect.
This PR fixes it.

(cherry picked from commit 431aee10ac7c415f93a4ca77f649896736e1315a)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1479)
<!-- Reviewable:end -->
