### PR TITLE
Add missing WithMaxCacheSize to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - DataCacheMetrics (#1473)
   - BfCacheMetrics (#1473)
 - Badger.Option
+  - WithMaxCacheSize (#1473)
+  - WithMaxBfCacheSize (#1473)
   - WithKeepBlockIndicesInCache (#1473)
   - WithKeepBlocksInCache (#1473)
 


### PR DESCRIPTION
The changelog was missing `WithMaxCacheSize` and `WithMaxBfCacheSize`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1484)
<!-- Reviewable:end -->
