### PR TITLE
release/v2.2007- fix(cleanup): Do not close cache before compaction (#1464)

### DIFF
--- a/db.go
+++ b/db.go
@@ -427,11 +427,11 @@ func Open(opt Options) (db *DB, err error) {
 // cleanup stops all the goroutines started by badger. This is used in open to
 // cleanup goroutines in case of an error.
 func (db *DB) cleanup() {
-	db.blockCache.Close()
-	db.indexCache.Close()
 	db.stopMemoryFlush()
 	db.stopCompactions()
 
+	db.blockCache.Close()
+	db.indexCache.Close()
 	if db.closers.updateSize != nil {
 		db.closers.updateSize.Signal()
 	}
@@ -1024,7 +1024,7 @@ func (db *DB) pushHead(ft flushTask) error {
 	}
 
 	// Store badger head even if vptr is zero, need it for readTs
-	db.opt.Debugf("Storing value log head: %+v\n", ft.vptr)
+	db.opt.Infof("Storing value log head: %+v\n", ft.vptr)
 	val := ft.vptr.Encode()
 
 	// Pick the max commit ts, so in case of crash, our read ts would be higher than all the


### PR DESCRIPTION
This PR fixes a panic that could happen in case `vlog.Open` returns an error.
The `db.Cleanup` would close the cache before compaction would finish and
as a result of that we will end up with `send of closed channel panic` in ristretto.

(cherry picked from commit edbc3801a1f618441f0045fd3546523ee4fa4de1)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1488)
<!-- Reviewable:end -->
