### PR TITLE
release/v20.07 - Fix(cleanup): Avoid truncating in vlog.Open on error (#1465)

### DIFF
--- a/db.go
+++ b/db.go
@@ -446,7 +446,10 @@ func (db *DB) cleanup() {
 	}
 
 	db.orc.Stop()
-	db.vlog.Close()
+
+	// Do not use vlog.Close() here. vlog.Close truncates the files. We don't
+	// want to truncate files unless the user has specified the truncate flag.
+	db.vlog.stopFlushDiscardStats()
 }
 
 // BlockCacheMetrics returns the metrics for the underlying block cache.


### PR DESCRIPTION
The vlog.Open() function can return an error denoting that the open was
unsuccessful but we have `db.cleanup` which will be called to stop all
the running go routines in case badger couldn't start. The db.cleanup
function calls vlog.Close() which will truncate the maxFid vlog file
based on the vlog.writableLogOffset. The vlog.writableLogOffset was not
being updated in case open failed. As a result of this, we will end up
truncating the vlog file to lenght 0 if open fails.

This PR fixes this by using vlog.stopDiscardStatFlush() instead of vlog.close.

(cherry picked from commit ed3b219a7c096ab6a7cdaec631bab47eb3542b78)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1489)
<!-- Reviewable:end -->
