### PR TITLE
fix(build): Fix nocgo builds.

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/DataDog/zstd"
 	"github.com/dgryski/go-farm"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
@@ -507,7 +506,7 @@ func (b *Builder) compressData(data []byte) ([]byte, error) {
 		dst := z.Calloc(sz)
 		return snappy.Encode(dst, data), nil
 	case options.ZSTD:
-		sz := zstd.CompressBound(len(data))
+		sz := y.ZSTDCompressBound(len(data))
 		dst := z.Calloc(sz)
 		return y.ZSTDCompress(dst, data, b.opt.ZSTDCompressionLevel)
 	}

--- a/y/zstd_cgo.go
+++ b/y/zstd_cgo.go
@@ -34,3 +34,8 @@ func ZSTDDecompress(dst, src []byte) ([]byte, error) {
 func ZSTDCompress(dst, src []byte, compressionLevel int) ([]byte, error) {
 	return zstd.CompressLevel(dst, src, compressionLevel)
 }
+
+// ZSTDCompressBound returns the worst case size needed for a destination buffer.
+func ZSTDCompressBound(srcSize int) int {
+	return zstd.CompressBound(srcSize)
+}

--- a/y/zstd_nocgo.go
+++ b/y/zstd_nocgo.go
@@ -30,3 +30,8 @@ func ZSTDDecompress(dst, src []byte) ([]byte, error) {
 func ZSTDCompress(dst, src []byte, compressionLevel int) ([]byte, error) {
 	return nil, ErrZstdCgo
 }
+
+// ZSTDCompressBound returns the worst case size needed for a destination buffer.
+func ZSTDCompressBound(srcSize int) int {
+	panic("ZSTD only supported in Cgo.")
+}


### PR DESCRIPTION
Building Badger without Cgo fails because of references to Zstd in
table/builder.go introduced in #1459 .

     $ CGO_ENABLED=0 go build -v .
     github.com/DataDog/zstd
     go build github.com/DataDog/zstd: build constraints exclude all Go files in
     /home/dmai/go/pkg/mod/github.com/!data!dog/zstd@v1.4.1

Moving zstd.CompressBound to y/zstd_cgo.go and y/zstd_nocgo.go fixes non-Cgo
builds. As is already the case, non-Cgo builds with compression must use snappy,
not Zstd, or calling y.ZSTDCompressBound without Cgo will panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1493)
<!-- Reviewable:end -->
