### PR TITLE
Fix build on arm32

### DIFF
--- a/value.go
+++ b/value.go
@@ -47,7 +47,7 @@ import (
 
 // maxVlogFileSize is the maximum size of the vlog file which can be created. Vlog Offset is of
 // uint32, so limiting at max uint32.
-var maxVlogFileSize = math.MaxUint32
+var maxVlogFileSize = uint32(math.MaxUint32)
 
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.


### PR DESCRIPTION
Without this change ```go build``` fails to build badger on arm32.
```
# github.com/dgraph-io/badger/v2
/home/ld86/gowork/pkg/mod/github.com/dgraph-io/badger/v2@v2.2007.1/value.go:50:5: constant 4294967295 overflows int
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1494)
<!-- Reviewable:end -->
