### PR TITLE
Mmap value log file to options.ValueLogFileSize

### DIFF
--- a/value.go
+++ b/value.go
@@ -47,7 +47,7 @@ import (
 
 // maxVlogFileSize is the maximum size of the vlog file which can be created. Vlog Offset is of
 // uint32, so limiting at max uint32.
-var maxVlogFileSize = math.MaxUint32
+var maxVlogFileSize uint32 = math.MaxUint32
 
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.

--- a/value.go
+++ b/value.go
@@ -1007,7 +1007,7 @@ func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 		return nil, errFile(err, vlog.dirPath, "Sync value log dir")
 	}
 
-	if err = lf.mmap(2 * vlog.opt.ValueLogFileSize); err != nil {
+	if err = lf.mmap(vlog.opt.ValueLogFileSize); err != nil {
 		removeFile()
 		return nil, errFile(err, lf.path, "Mmap value log file")
 	}


### PR DESCRIPTION
Currently, we mmap the newly created value log files to
2*options.ValueLogFileSize. This isn't necessary and causes issues on 32
bit systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1496)
<!-- Reviewable:end -->
