### PR TITLE
(release/v1.6) Update head while replaying value log (#1372)

### DIFF
--- a/db.go
+++ b/db.go
@@ -136,6 +136,10 @@ func (db *DB) replayFunction() func(Entry, valuePointer) error {
 			nv = make([]byte, vptrSize)
 			vp.Encode(nv)
 			meta = meta | bitValuePointer
+			// Update vhead. If the crash happens while replay was in progess
+			// and the head is not updated, we will end up replaying all the
+			// files again.
+			db.updateHead([]valuePointer{vp})
 		}
 
 		v := y.ValueStruct{
@@ -550,6 +554,8 @@ func (db *DB) get(key []byte) (y.ValueStruct, error) {
 	return db.lc.get(key, maxVs)
 }
 
+// updateHead should not be called without the db.Lock() since db.vhead is used
+// by the writer go routines and memtable flushing goroutine.
 func (db *DB) updateHead(ptrs []valuePointer) {
 	var ptr valuePointer
 	for i := len(ptrs) - 1; i >= 0; i-- {
@@ -563,8 +569,6 @@ func (db *DB) updateHead(ptrs []valuePointer) {
 		return
 	}
 
-	db.Lock()
-	defer db.Unlock()
 	y.AssertTrue(!ptr.Less(db.vhead))
 	db.vhead = ptr
 }
@@ -658,7 +662,9 @@ func (db *DB) writeRequests(reqs []*request) error {
 			done(err)
 			return errors.Wrap(err, "writeRequests")
 		}
+		db.Lock()
 		db.updateHead(b.Ptrs)
+		db.Unlock()
 	}
 	done(nil)
 	db.elog.Printf("%d entries written", count)


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/1363

The head pointer is not updated when we perform replays. The head
pointer would be updated only when the replay completes. If badger crashes
between the point when replay started and replay finished, we would end up
replaying all the value log files. This PR fixes this issue.

(cherry picked from commit 509de73a8ad1c1b8ea62ffc0cef944716435ec25)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1506)
<!-- Reviewable:end -->
