### PR TITLE
(release/v1.6) Compaction: Expired keys and delete markers are never purged (#1354)

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -547,19 +547,24 @@ func (s *levelsController) compactBuildTables(
 				lastValidVersion := vs.Meta&bitDiscardEarlierVersions > 0 ||
 					numVersions == s.kv.opt.NumVersionsToKeep
 
-				if isDeletedOrExpired(vs.Meta, vs.ExpiresAt) || lastValidVersion {
+				isExpired := isDeletedOrExpired(vs.Meta, vs.ExpiresAt)
+
+				if isExpired || lastValidVersion {
 					// If this version of the key is deleted or expired, skip all the rest of the
 					// versions. Ensure that we're only removing versions below readTs.
 					skipKey = y.SafeCopy(skipKey, it.Key())
 
-					if lastValidVersion {
+					switch {
+					// Add the key to the table only if it has not expired.
+					// We don't want to add the deleted/expired keys.
+					case !isExpired && lastValidVersion:
 						// Add this key. We have set skipKey, so the following key versions
 						// would be skipped.
-					} else if hasOverlap {
+					case hasOverlap:
 						// If this key range has overlap with lower levels, then keep the deletion
 						// marker with the latest version, discarding the rest. We have set skipKey,
 						// so the following key versions would be skipped.
-					} else {
+					default:
 						// If no overlap, we can skip all the versions, by continuing here.
 						numSkips++
 						updateStats(vs)


### PR DESCRIPTION
The compaction process accidentally keeps one more version of
expired keys and delete markers than it should, because of
logic error in *levelsController.compactBuildTables(). When
NumVersionsToKeep is 1, it means that expired keys and delete
markers are never actually purged from the LSM tables.

Co-authored-by: Julian Hegler <julian.hegler@tanium.com>
Co-authored-by: Ibrahim Jarif <ibrahim@dgraph.io>
(cherry picked from commit fd8989493b52f39957e89ff3a7679bc45ea92674)

**This cherry-pick PR had conflicts.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1510)
<!-- Reviewable:end -->
