### PR TITLE
release/v1.6 - fix(replay) - Update head for LSM entires also (#1456)

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1761,8 +1761,9 @@ func TestNoCrash(t *testing.T) {
 	}
 
 	db.Lock()
-	// make head to point to first file
-	db.vhead = valuePointer{0, 0, 0}
+	// make head to point to second file. We cannot make it point to the first
+	// vlog file because we cannot push a zero head pointer.
+	db.vhead = valuePointer{1, 0, 0}
 	db.Unlock()
 	db.Close()
 


### PR DESCRIPTION
https://github.com/dgraph-io/badger/pull/1372 tried to fix the `replay from
start` issue but it partially fixed the issue. The head was not being updated
in case all the entries are inserted only in the LSM tree.
This commit fixes it.

(cherry picked from commit 4c8fe7fd63e36f9e39b788c084e18e293413a71d)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1516)
<!-- Reviewable:end -->
