### PR TITLE
chore(options): Log warning if blockcache is missing

### DIFF
--- a/db.go
+++ b/db.go
@@ -193,43 +193,42 @@ func (db *DB) replayFunction() func(Entry, valuePointer) error {
 	}
 }
 
-// Open returns a new DB object.
-func Open(opt Options) (db *DB, err error) {
+func checkAndSetOptions(opt *Options) error {
 	// It's okay to have zero compactors which will disable all compactions but
 	// we cannot have just one compactor otherwise we will end up with all data
 	// on level 2.
 	if opt.NumCompactors == 1 {
-		return nil, errors.New("Cannot have 1 compactor. Need at least 2")
+		return errors.New("Cannot have 1 compactor. Need at least 2")
 	}
 	if opt.InMemory && (opt.Dir != "" || opt.ValueDir != "") {
-		return nil, errors.New("Cannot use badger in Disk-less mode with Dir or ValueDir set")
+		return errors.New("Cannot use badger in Disk-less mode with Dir or ValueDir set")
 	}
 	opt.maxBatchSize = (15 * opt.MaxTableSize) / 100
 	opt.maxBatchCount = opt.maxBatchSize / int64(skl.MaxNodeSize)
 
 	// We are limiting opt.ValueThreshold to maxValueThreshold for now.
 	if opt.ValueThreshold > maxValueThreshold {
-		return nil, errors.Errorf("Invalid ValueThreshold, must be less or equal to %d",
+		return errors.Errorf("Invalid ValueThreshold, must be less or equal to %d",
 			maxValueThreshold)
 	}
 
 	// If ValueThreshold is greater than opt.maxBatchSize, we won't be able to push any data using
 	// the transaction APIs. Transaction batches entries into batches of size opt.maxBatchSize.
 	if int64(opt.ValueThreshold) > opt.maxBatchSize {
-		return nil, errors.Errorf("Valuethreshold greater than max batch size of %d. Either "+
+		return errors.Errorf("Valuethreshold greater than max batch size of %d. Either "+
 			"reduce opt.ValueThreshold or increase opt.MaxTableSize.", opt.maxBatchSize)
 	}
 	if !(opt.ValueLogFileSize <= 2<<30 && opt.ValueLogFileSize >= 1<<20) {
-		return nil, ErrValueLogSize
+		return ErrValueLogSize
 	}
 	if !(opt.ValueLogLoadingMode == options.FileIO ||
 		opt.ValueLogLoadingMode == options.MemoryMap) {
-		return nil, ErrInvalidLoadingMode
+		return ErrInvalidLoadingMode
 	}
 
 	// Return error if badger is built without cgo and compression is set to ZSTD.
 	if opt.Compression == options.ZSTD && !y.CgoEnabled {
-		return nil, y.ErrZstdCgo
+		return y.ErrZstdCgo
 	}
 	// Keep L0 in memory if either KeepL0InMemory is set or if InMemory is set.
 	opt.KeepL0InMemory = opt.KeepL0InMemory || opt.InMemory
@@ -243,6 +242,20 @@ func Open(opt Options) (db *DB, err error) {
 		opt.Truncate = false
 		// Do not perform compaction in read only mode.
 		opt.CompactL0OnClose = false
+	}
+
+	needCache := (opt.Compression != options.None) || (len(opt.EncryptionKey) > 0)
+	if needCache && opt.BlockCacheSize == 0 {
+		opt.Logger.Warningf("BlockCacheSize should be set " +
+			"since compression/encryption are enabled")
+	}
+	return nil
+}
+
+// Open returns a new DB object.
+func Open(opt Options) (db *DB, err error) {
+	if err := checkAndSetOptions(&opt); err != nil {
+		return nil, err
 	}
 	var dirLockGuard, valueDirLockGuard *directoryLockGuard
 


### PR DESCRIPTION
It is recommended to use block cache when compression/encryption are
enabled. With this PR, we'll log a warning message if the cache is
missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1522)
<!-- Reviewable:end -->
