### PR TITLE
Refactor estimatedSize of table

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -446,7 +446,9 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 		return nil, err
 	}
 
-	t.estimatedSize = index.EstimatedSize
+	// Due to compression the real size on disk is much
+	// smaller than what we estimate from index.EstimatedSize.
+	t.estimatedSize = uint64(t.tableSize)
 	t.hasBloomFilter = len(index.BloomFilter) > 0
 	t.noOfBlocks = len(index.Offsets)
 

--- a/table/table.go
+++ b/table/table.go
@@ -446,9 +446,13 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 		return nil, err
 	}
 
-	// Due to compression the real size on disk is much
-	// smaller than what we estimate from index.EstimatedSize.
-	t.estimatedSize = uint64(t.tableSize)
+	if t.opt.Compression == options.None {
+		t.estimatedSize = index.EstimatedSize
+	} else {
+		// Due to compression the real size on disk is much
+		// smaller than what we estimate from index.EstimatedSize.
+		t.estimatedSize = uint64(t.tableSize)
+	}
 	t.hasBloomFilter = len(index.BloomFilter) > 0
 	t.noOfBlocks = len(index.Offsets)
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -927,9 +927,7 @@ func TestOpenKVSize(t *testing.T) {
 	table, err := OpenTable(buildTestTable(t, "foo", 1, opts), opts)
 	require.NoError(t, err)
 
-	// The following values might change if the table/header structure is changed.
-	var entrySize uint64 = 15 /* DiffKey len */ + 4 /* Header Size */ + 4 /* Encoded vp */
-	require.Equal(t, entrySize, table.EstimatedSize())
+	require.Equal(t, uint64(table.tableSize), table.EstimatedSize())
 }
 
 // Run this test with command "go test -race -run TestDoesNotHaveRace"

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -923,11 +923,23 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpenKVSize(t *testing.T) {
+	// When compression is on
 	opts := getTestTableOptions()
 	table, err := OpenTable(buildTestTable(t, "foo", 1, opts), opts)
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(table.tableSize), table.EstimatedSize())
+
+	// When compression is off
+	opts = getTestTableOptions()
+	opts.Compression = options.None
+	table, err = OpenTable(buildTestTable(t, "foo", 1, opts), opts)
+	require.NoError(t, err)
+
+	// The following values might change if the table/header structure is changed.
+	var entrySize uint64 = 15 /* DiffKey len */ + 4 /* Header Size */ + 4 /* Encoded vp */
+	require.Equal(t, entrySize, table.EstimatedSize())
+
 }
 
 // Run this test with command "go test -race -run TestDoesNotHaveRace"

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -922,18 +922,20 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestOpenKVSize(t *testing.T) {
+func TestOpenKVSizeWithCompression(t *testing.T) {
 	// When compression is on
 	opts := getTestTableOptions()
 	table, err := OpenTable(buildTestTable(t, "foo", 1, opts), opts)
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(table.tableSize), table.EstimatedSize())
+}
 
+func TestOpenKVSizeWithoutCompression(t *testing.T) {
 	// When compression is off
-	opts = getTestTableOptions()
+	opts := getTestTableOptions()
 	opts.Compression = options.None
-	table, err = OpenTable(buildTestTable(t, "foo", 1, opts), opts)
+	table, err := OpenTable(buildTestTable(t, "foo", 1, opts), opts)
 	require.NoError(t, err)
 
 	// The following values might change if the table/header structure is changed.


### PR DESCRIPTION
Users reported mismatch between size of data on disk and size reported by dgraph. Due to compression, the real size of data on disk is much smaller than what we estimate from index.EstimatedSize.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1524)
<!-- Reviewable:end -->
