### PR TITLE
perf: Reduce memory usage by better struct packing

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -140,13 +140,13 @@ func (h *header) DecodeFrom(reader *hashReader) (int, error) {
 type Entry struct {
 	Key       []byte
 	Value     []byte
-	UserMeta  byte
 	ExpiresAt uint64 // time.Unix
-	meta      byte
 	version   uint64
+	offset    uint32 // offset is an internal field.
+	UserMeta  byte
+	meta      byte
 
 	// Fields maintained internally.
-	offset   uint32
 	skipVlog bool
 	hlen     int // Length of the header.
 }


### PR DESCRIPTION
Badger uses a bunch of short-lived structs such as Txn, Item, Entry,
etc. If the members of these structs are not aligned properly, the
compiler will add padding to make them self-aligning. This PR reorders
the struct members to reduce memory footprint and improve performance.
```
Size of Txn on Master  : 136
Size of Txn on this PR : 120 (11.7% less)

Size of Item on Master  : 168
Size of Item on this PR : 144 (14.2% less)

Size of Entry on Master  : 96
Size of Entry on this PR : 80 (16.7% less)

Size of IteratorOptions on Master  : 56
Size of IteratorOptions on this PR : 40 (28.5% less)
```
The sizes were calculated using
```go
func TestAlignment(t *testing.T) {
	t.Run("Txn", func(t *testing.T) {
		t.Logf("Sizeof Txn = %+v\n", unsafe.Sizeof(Txn{}))
	})
	t.Run("Item", func(t *testing.T) {
		t.Logf("Sizeof Item = %+v\n", unsafe.Sizeof(Item{}))
	})
	t.Run("Entry", func(t *testing.T) {
		t.Logf("Sizeof Entry = %+v\n", unsafe.Sizeof(Entry{}))
	})
	t.Run("IteratorOptions", func(t *testing.T) {
		t.Logf("Sizeof IteratorOption = %+v\n", unsafe.Sizeof(IteratorOptions{}))
	})
}
```
This PR also removed the `db` from `item` struct since `item.txn` already has access to the `db` object.

Read http://www.catb.org/esr/structure-packing/ to understand struct packing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1528)
<!-- Reviewable:end -->
