### PR TITLE
fix(writeBatch): Avoid deadlock in commit callback

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -82,6 +82,7 @@ func (wb *WriteBatch) Cancel() {
 	wb.txn.Discard()
 }
 
+// The caller of this callback must hold the lock.
 func (wb *WriteBatch) callback(err error) {
 	// sync.WaitGroup is thread-safe, so it doesn't need to be run inside wb.Lock.
 	defer wb.throttle.Done(err)
@@ -89,8 +90,6 @@ func (wb *WriteBatch) callback(err error) {
 		return
 	}
 
-	wb.Lock()
-	defer wb.Unlock()
 	if wb.err != nil {
 		return
 	}

--- a/batch_test.go
+++ b/batch_test.go
@@ -18,6 +18,7 @@ package badger
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -143,4 +144,18 @@ func TestFlushPanic(t *testing.T) {
 			require.Error(t, y.ErrCommitAfterFinish, wb.Flush())
 		})
 	})
+}
+
+func TestBatchErrDeadlock(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	opt := DefaultOptions(dir)
+	db, err := OpenManaged(opt)
+	require.NoError(t, err)
+
+	wb := db.NewManagedWriteBatch()
+	require.NoError(t, wb.SetEntryAt(&Entry{Key: []byte("foo")}, 0))
+	require.Error(t, wb.Flush())
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -158,4 +158,5 @@ func TestBatchErrDeadlock(t *testing.T) {
 	wb := db.NewManagedWriteBatch()
 	require.NoError(t, wb.SetEntryAt(&Entry{Key: []byte("foo")}, 0))
 	require.Error(t, wb.Flush())
+	require.NoError(t, db.Close())
 }


### PR DESCRIPTION
`wb.Flush()` would call `wb.commit()` while holding lock which would call
`wb.callback` in case of an error while committing.

`wb.callback` would try to acquire the lock `wb.Flush` is holding and this
would lead to a deadlock. This PR fixes it.

The test in this PR fails on master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1529)
<!-- Reviewable:end -->
