### PR TITLE
fix(getHead): Use forward iteration and add tests

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -18,6 +18,7 @@ package badger
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -70,6 +71,14 @@ func TestWriteBatch(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
+
+		// Test getHead as well.
+		headKey := y.KeyWithTs(head, math.MaxUint64)
+		vs, err := db.get(headKey)
+		require.NoError(t, err)
+		_, ver := db.getHead()
+		require.NoError(t, err)
+		require.Equal(t, vs.Version, ver)
 	}
 	t.Run("disk mode", func(t *testing.T) {
 		opt := getTestOptions("")

--- a/db_test.go
+++ b/db_test.go
@@ -2094,6 +2094,11 @@ func TestForceFlushMemtable(t *testing.T) {
 	require.NoError(t, err)
 	var vptr valuePointer
 	vptr.Decode(vs.Value)
+
+	// Check if getHead also returns the same head.
+	_, ver := db.getHead()
+	require.NoError(t, err)
+	require.Equal(t, vs.Version, ver)
 	// Since we are inserting 3 entries and ValueLogMaxEntries is 1, there will be 3 rotation. For
 	// 1st and 2nd time head flushed with memtable will have fid as 0 and last time it will be 1.
 	require.True(t, vptr.Fid == 1, fmt.Sprintf("expected fid: %d, actual fid: %d", 1, vptr.Fid))

--- a/levels_test.go
+++ b/levels_test.go
@@ -526,6 +526,14 @@ func TestHeadKeyCleanup(t *testing.T) {
 		require.NoError(t, db.lc.runCompactDef(0, cdef))
 		// foo version 2 should be dropped after compaction.
 		getAllAndCheck(t, db, []keyValVersion{{string(head), "foo", 5, 0}})
+
+		// Test getHead as well.
+		headKey := y.KeyWithTs(head, math.MaxUint64)
+		vs, err := db.get(headKey)
+		require.NoError(t, err)
+		_, ver := db.getHead()
+		require.NoError(t, err)
+		require.Equal(t, vs.Version, ver)
 	})
 }
 


### PR DESCRIPTION
getHead is using reverse iteration and there have been issues with
reverse iteration (see https://dgraph.io/docs/badger/faq/#reverse-iteration-doesn-t-give-me-the-right-results).
This PR uses forward iteration to find the head key.
This PR doesn't change any functionality, it only changes the direction
of iteration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1530)
<!-- Reviewable:end -->
