### PR TITLE
release/v2.2007 - Refactor estimatedSize of table (#1524)

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -381,7 +381,14 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 		return nil, err
 	}
 
-	t.estimatedSize = index.EstimatedSize
+	if t.opt.Compression == options.None {
+		t.estimatedSize = index.EstimatedSize
+	} else {
+		// Due to compression the real size on disk is much
+		// smaller than what we estimate from index.EstimatedSize.
+		t.estimatedSize = uint64(t.tableSize)
+	}
+	t.hasBloomFilter = len(index.BloomFilter) > 0
 	t.noOfBlocks = len(index.Offsets)
 
 	// No cache

--- a/table/table.go
+++ b/table/table.go
@@ -388,7 +388,6 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 		// smaller than what we estimate from index.EstimatedSize.
 		t.estimatedSize = uint64(t.tableSize)
 	}
-	t.hasBloomFilter = len(index.BloomFilter) > 0
 	t.noOfBlocks = len(index.Offsets)
 
 	// No cache

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -930,13 +930,30 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpenKVSize(t *testing.T) {
-	opts := getTestTableOptions()
-	table, err := OpenTable(buildTestTable(t, "foo", 1, opts), opts)
-	require.NoError(t, err)
+	t.Run("compression", func(t *testing.T) {
+		// When compression is on
+		opts := getTestTableOptions()
+		opts.Compression = options.ZSTD
+		table, err := OpenTable(buildTestTable(t, "foo", 1000, opts), opts)
+		defer table.Close()
+		require.NoError(t, err)
 
-	// The following values might change if the table/header structure is changed.
-	var entrySize uint64 = 15 /* DiffKey len */ + 4 /* Header Size */ + 4 /* Encoded vp */
-	require.Equal(t, entrySize, table.EstimatedSize())
+		// The estimated size is same as table size in case compression is enabled.
+		require.Equal(t, uint64(table.tableSize), table.EstimatedSize())
+	})
+
+	t.Run("no compressin", func(t *testing.T) {
+		// When compression is off
+		opts := getTestTableOptions()
+		opts.Compression = options.None
+		table, err := OpenTable(buildTestTable(t, "foo", 1, opts), opts)
+		require.NoError(t, err)
+		defer table.Close()
+
+		stat, err := table.fd.Stat()
+		require.NoError(t, err)
+		require.Less(t, table.EstimatedSize(), uint64(stat.Size()))
+	})
 }
 
 // Run this test with command "go test -race -run TestDoesNotHaveRace"


### PR DESCRIPTION
Users reported mismatch between size of data on disk and size reported by dgraph. Due to compression, the real size of data on disk is much smaller than what we estimate from index.EstimatedSize.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1538)
<!-- Reviewable:end -->
