### PR TITLE
perf(GC): Remove move keys

### DIFF
--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -292,7 +292,6 @@ func writeBench(cmd *cobra.Command, args []string) error {
 func showKeysStats(db *badger.DB) {
 	var (
 		internalKeyCount uint32
-		moveKeyCount     uint32
 		invalidKeyCount  uint32
 		validKeyCount    uint32
 	)
@@ -311,18 +310,14 @@ func showKeysStats(db *badger.DB) {
 		if bytes.HasPrefix(i.Key(), []byte("!badger!")) {
 			internalKeyCount++
 		}
-		if bytes.HasPrefix(i.Key(), []byte("!badger!Move")) {
-			moveKeyCount++
-		}
 		if i.IsDeletedOrExpired() {
 			invalidKeyCount++
 		} else {
 			validKeyCount++
 		}
 	}
-	fmt.Printf("Valid Keys: %d Invalid Keys: %d Move Keys:"+
-		" %d Internal Keys: %d\n", validKeyCount, invalidKeyCount,
-		moveKeyCount, internalKeyCount)
+	fmt.Printf("Valid Keys: %d Invalid Keys: %d Internal Keys: %d\n",
+		validKeyCount, invalidKeyCount, internalKeyCount)
 }
 
 func reportStats(c *z.Closer, db *badger.DB) {

--- a/errors.go
+++ b/errors.go
@@ -55,11 +55,6 @@ var (
 	// reserved for internal usage.
 	ErrInvalidKey = errors.New("Key is using a reserved !badger! prefix")
 
-	// ErrRetry is returned when a log file containing the value is not found.
-	// This usually indicates that it may have been garbage collected, and the
-	// operation needs to be retried.
-	ErrRetry = errors.New("Unable to find log file. Please retry")
-
 	// ErrThresholdZero is returned if threshold is set to zero, and value log GC is called.
 	// In such a case, GC can't be run.
 	ErrThresholdZero = errors.New(

--- a/levels_test.go
+++ b/levels_test.go
@@ -838,29 +838,24 @@ func TestLevelGet(t *testing.T) {
 			createAndOpen(db, v, level)
 		}
 	}
-	type tableData struct {
+	type testData struct {
 		name string
 		// Keys on each level. keyValVersion[0] is the first table and so on.
-		levelKey map[int][][]keyValVersion
-		// want     []struct {
-		// 	key     string
-		// 	version uint64
-		// }
-		expect []keyValVersion
+		levelData map[int][][]keyValVersion
+		expect    []keyValVersion
 	}
-	test := func(t *testing.T, ti tableData, db *DB) {
-		for level, data := range ti.levelKey {
+	test := func(t *testing.T, ti testData, db *DB) {
+		for level, data := range ti.levelData {
 			createLevel(db, level, data)
 		}
 		for _, item := range ti.expect {
 			key := y.KeyWithTs([]byte(item.key), uint64(item.version))
 			vs, err := db.get(key)
 			require.NoError(t, err)
-
 			require.Equal(t, item.val, string(vs.Value), "key:%s ver:%d", item.key, item.version)
 		}
 	}
-	tt := []tableData{
+	tt := []testData{
 		{
 			"Normal",
 			map[int][][]keyValVersion{

--- a/levels_test.go
+++ b/levels_test.go
@@ -829,9 +829,6 @@ func TestL0Stall(t *testing.T) {
 	})
 }
 
-func stringKeyWithTs(s string, ts uint64) []byte {
-	return y.KeyWithTs([]byte(s), ts)
-}
 func TestLevelGet(t *testing.T) {
 	createLevel := func(db *DB, level int, data [][]keyValVersion) {
 		for _, v := range data {

--- a/value.go
+++ b/value.go
@@ -1468,8 +1468,8 @@ func (vlog *valueLog) getFileRLocked(vp valuePointer) (*logFile, error) {
 	defer vlog.filesLock.RUnlock()
 	ret, ok := vlog.filesMap[vp.Fid]
 	if !ok {
-		// log file has gone away, will need to retry the operation.
-		return nil, errors.New("file not found")
+		// log file has gone away, we can't do anything. Return.
+		return nil, errors.Errorf("file with ID: %d not found", vp.Fid)
 	}
 
 	// Check for valid offset if we are reading from writable log.
@@ -1896,7 +1896,7 @@ func (vlog *valueLog) populateDiscardStats() error {
 		}
 		// Entry stored in LSM tree.
 		if vs.Meta&bitValuePointer == 0 {
-			return y.SafeCopy(nil, vs.Value), err
+			return y.SafeCopy(nil, vs.Value), nil
 		}
 		var vp valuePointer
 		vp.Decode(vs.Value)


### PR DESCRIPTION
Move keys are used to fix the invalid value pointers when vlog GC runs.
This PR removes the move keys. To ensure we return the correct results
for Get calls, we will search all the levels of the LSM tree to find the
correct entry. Earlier, we used to return the first entry whose version
was less than or equal to the required version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1539)
<!-- Reviewable:end -->
