### PR TITLE
Update Badger's docs homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Below is a list of known projects that use Badger:
 * [Cete](https://github.com/mosuka/cete) - Simple and highly available distributed key-value store built on Badger. Makes it easy bringing up a cluster of Badger with Raft consensus algorithm by hashicorp/raft. 
 * [Volument](https://volument.com/) - A new take on website analytics backed by Badger.
 * [KVdb](https://kvdb.io/) - Hosted key-value store and serverless platform built on top of Badger.
-* [Terminotes] (https://gitlab.com/asad-awadia/terminotes) - Self hosted notes storage and search server - storage powered by BadgerDB
+* [Terminotes](https://gitlab.com/asad-awadia/terminotes) - Self hosted notes storage and search server - storage powered by BadgerDB
 
 If you are using Badger in a project please send a pull request to add it to the list.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,22 @@
 # Badger Docs
 
-If you are looking for Badger documentation, you might find https://dgraph.io/docs/badger much more readable.
+If you are looking for Badger's documentation, you might find https://dgraph.io/docs/badger much more readable.
 
-## Contributing
+## Getting Started
 
 We use [Hugo](https://gohugo.io/) for our documentation.
 
 ### Running locally
 
- Download and install the latest patch of hugo version v0.69.x from [here](https://github.com/gohugoio/hugo/releases/).
+1. Download and install the latest patch of Hugo version v0.69.x from [here](https://github.com/gohugoio/hugo/releases/).
+2. Run `hugo server` within the `docs` folder.
+3. Visit http://localhost:1313 to see the documentation site.
 
-From within the docs folder, run the command below to get the theme.
+## Contributing
 
-cd themes && git clone https://github.com/dgraph-io/hugo-docs
+If you're interested in contributing to Badger, please review our [guidelines](../CONTRIBUTING.md).
 
-Run hugo server within the docs folder and visit http://localhost:1313 to see the documentation site.
+## Contact
+
+- Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, and discussions.
+- Follow us on Twitter [@dgraphlabs](https://twitter.com/dgraphlabs).

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -31,8 +31,8 @@ noClasses = false
   weight = 3
 
 [[menu.main]]
-  name = "Project Using Badger"
-  url = "/project-using-badger/"
+  name = "Projects using Badger"
+  url = "/projects-using-badger/"
   identifier = "project-using-badger"
   weight = 4
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -6,31 +6,147 @@ draft: false
 
 ![Badger mascot](/images/diggy-shadow.png)
 
+**Welcome to the official Badger documentation.**
+
 BadgerDB is an embeddable, persistent and fast key-value (KV) database written
 in pure Go. It is the underlying database for [Dgraph](https://dgraph.io), a
 fast, distributed graph database. It's meant to be a performant alternative to
 non-Go-based key-value stores like RocksDB.
 
-## Project Status [March 24, 2020]
+## Table of Contents
 
-Badger is stable and is being used to serve data sets worth hundreds of
-terabytes. Badger supports concurrent ACID transactions with serializable
-snapshot isolation (SSI) guarantees. A Jepsen-style bank test runs nightly for
-8h, with `--race` flag and ensures the maintenance of transactional guarantees.
-Badger has also been tested to work with filesystem level anomalies, to ensure
-persistence and consistency. Badger is being used by a number of projects which
-includes Dgraph, Jaeger Tracing, UsenetExpress, and many more.
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "get-started/_index.md">}}">
+              Quickstart Guide
+            </a>
+          </div>
+          <p class="section-desc">
+            A single page quickstart guide to get started with BadgerDB
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "resources/_index.md">}}">
+              Resources
+            </a>
+          </div>
+          <p class="section-desc">
+            Additional resources and information
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "design/_index.md">}}">
+              Design
+            </a>
+          </div>
+          <p class="section-desc">
+            Design goals behind BadgerDB
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "projects-using-badger/_index.md">}}">
+              Projects using Badger
+            </a>
+          </div>
+          <p class="section-desc">
+            A list of known projects that use BadgerDB
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="/faq">
+              FAQ
+            </a>
+          </div>
+          <p class="section-desc">
+            Frequently asked questions
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://dgraph.io/badger">
+              Badger
+            </a>
+          </div>
+          <p class="section-desc">
+            Embeddable, persistent and fast key-value database that powers Dgraph
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 
-The list of projects using Badger can be found [here]({{<relref "projects-using-badger/index.md" >}}).
-
-Badger v1.0 was released in Nov 2017, and the latest version that is data-compatible
-with v1.0 is v1.6.0.
-
-Badger v2.0 was released in Nov 2019 with a new storage format which won't
-be compatible with all of the v1.x. Badger v2.0 supports compression, encryption and uses a cache to speed up lookup.
+## Changelog
 
 The [Changelog] is kept fairly up-to-date.
+
+- Badger v1.0 was released in Nov 2017, and the latest version that is data-compatible
+with v1.0 is v1.6.0.
+- Badger v2.0 was released in Nov 2019 with a new storage format which won't
+be compatible with all of the v1.x. Badger v2.0 supports compression, encryption and uses a cache to speed up lookup.
 
 For more details on our version naming schema please read [Choosing a version]({{< relref "get-started/index.md#choosing-a-version" >}}).
 
 [Changelog]:https://github.com/dgraph-io/badger/blob/master/CHANGELOG.md
+
+## Contribute
+
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://github.com/dgraph-io/badger/blob/master/CONTRIBUTING.md">
+              Contribute to Badger
+            </a>
+          </div>
+          <p class="section-desc">
+            Get started with contributing fixes and enhancements to Badger and related software.
+          </p>
+        </div>
+      </div>
+      </div>
+  </div>
+</section>
+
+## Our Community
+
+**Badger is made better every day by the growing community and the contributors all over the world.**
+
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://discuss.dgraph.io">
+              Community
+            </a>
+          </div>
+          <p class="section-desc">
+            Discuss Badger on the official community.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/docs/themes/hugo-docs/layouts/_default/article.html
+++ b/docs/themes/hugo-docs/layouts/_default/article.html
@@ -1,7 +1,3 @@
-{{ $currentVersion := getenv "CURRENT_VERSION" }}
-{{ $versionString := getenv "VERSIONS" }}
-{{ $versions := split $versionString "," }}
-{{ $latestVersion := index $versions 0 }}
 
 <article id="{{ .Slug }}">
   {{ partial "request-edit.html" . }}

--- a/docs/themes/hugo-docs/layouts/_default/article.html
+++ b/docs/themes/hugo-docs/layouts/_default/article.html
@@ -3,16 +3,6 @@
 {{ $versions := split $versionString "," }}
 {{ $latestVersion := index $versions 0 }}
 
-{{ if (eq $currentVersion "master") }}
-  <div class="alert alert-warning">
-    <i class="fa fa-warning"></i> You are looking at the docs for the unreleased <code>master</code> branch of Badger. The latest version is <a href="{{ .Site.BaseURL }}/..">{{ $latestVersion }}</a>.
-  </div>
-{{ else if not (eq $latestVersion $currentVersion) }}
-  <div class="alert alert-warning">
-    <i class="fa fa-warning"></i> You are looking at the docs for an older version of Badger ({{ $currentVersion }}). The latest version is <a href="{{ .Site.BaseURL }}/..">{{ $latestVersion }}</a>.
-  </div>
-{{ end }}
-
 <article id="{{ .Slug }}">
   {{ partial "request-edit.html" . }}
   {{ partial "suggest-edit.html" . }}


### PR DESCRIPTION
Fixes DGRAPH-2494

This PR:
- Updates docs home-page with a table of contents
- Removes the banner message from Badger's theme:
```
You are looking at the docs for the unreleased master branch of Badger. The latest version is master.
```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1540)
<!-- Reviewable:end -->
