### PR TITLE
Fix integer overflow error when building for 386

### DIFF
--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -55,7 +55,7 @@ func doBackup(cmd *cobra.Command, args []string) error {
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
 		WithTruncate(truncate).
-		WithNumVersionsToKeep(int(math.MaxUint32))
+		WithNumVersionsToKeep(int(math.MaxInt32))
 
 	if numVersions > 0 {
 		opt.NumVersionsToKeep = numVersions

--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -55,7 +55,7 @@ func doBackup(cmd *cobra.Command, args []string) error {
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
 		WithTruncate(truncate).
-		WithNumVersionsToKeep(math.MaxUint32)
+		WithNumVersionsToKeep(int(math.MaxUint32))
 
 	if numVersions > 0 {
 		opt.NumVersionsToKeep = numVersions

--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -55,7 +55,7 @@ func doBackup(cmd *cobra.Command, args []string) error {
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
 		WithTruncate(truncate).
-		WithNumVersionsToKeep(int(math.MaxInt32))
+		WithNumVersionsToKeep(math.MaxInt32)
 
 	if numVersions > 0 {
 		opt.NumVersionsToKeep = numVersions

--- a/badger/cmd/restore.go
+++ b/badger/cmd/restore.go
@@ -68,7 +68,7 @@ func doRestore(cmd *cobra.Command, args []string) error {
 	// Open DB
 	db, err := badger.Open(badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithNumVersionsToKeep(int(math.MaxUint32)))
+		WithNumVersionsToKeep(int(math.MaxInt32)))
 	if err != nil {
 		return err
 	}

--- a/badger/cmd/restore.go
+++ b/badger/cmd/restore.go
@@ -68,7 +68,7 @@ func doRestore(cmd *cobra.Command, args []string) error {
 	// Open DB
 	db, err := badger.Open(badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithNumVersionsToKeep(math.MaxUint32))
+		WithNumVersionsToKeep(int(math.MaxUint32)))
 	if err != nil {
 		return err
 	}

--- a/badger/cmd/restore.go
+++ b/badger/cmd/restore.go
@@ -68,7 +68,7 @@ func doRestore(cmd *cobra.Command, args []string) error {
 	// Open DB
 	db, err := badger.Open(badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithNumVersionsToKeep(int(math.MaxInt32)))
+		WithNumVersionsToKeep(math.MaxInt32))
 	if err != nil {
 		return err
 	}

--- a/value.go
+++ b/value.go
@@ -48,7 +48,7 @@ import (
 
 // maxVlogFileSize is the maximum size of the vlog file which can be created. Vlog Offset is of
 // uint32, so limiting at max uint32.
-var maxVlogFileSize = int64(math.MaxUint32)
+var maxVlogFileSize = uint32(math.MaxUint32)
 
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.

--- a/value.go
+++ b/value.go
@@ -48,7 +48,7 @@ import (
 
 // maxVlogFileSize is the maximum size of the vlog file which can be created. Vlog Offset is of
 // uint32, so limiting at max uint32.
-var maxVlogFileSize = math.MaxUint32
+var maxVlogFileSize = int64(math.MaxUint32)
 
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.

--- a/value.go
+++ b/value.go
@@ -48,7 +48,7 @@ import (
 
 // maxVlogFileSize is the maximum size of the vlog file which can be created. Vlog Offset is of
 // uint32, so limiting at max uint32.
-var maxVlogFileSize = int64(math.MaxUint32)
+var maxVlogFileSize uint32 = math.MaxUint32
 
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.

--- a/value.go
+++ b/value.go
@@ -48,7 +48,7 @@ import (
 
 // maxVlogFileSize is the maximum size of the vlog file which can be created. Vlog Offset is of
 // uint32, so limiting at max uint32.
-var maxVlogFileSize = uint32(math.MaxUint32)
+var maxVlogFileSize = int64(math.MaxUint32)
 
 // Values have their first byte being byteData or byteDelete. This helps us distinguish between
 // a key that has never been seen and a key that has been explicitly deleted.


### PR DESCRIPTION
The untyped const causes conversion to int, for which the value is too large.
Use a typed const instead that is large enough to store value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1541)
<!-- Reviewable:end -->
