### PR TITLE
feat(info): Show index and bloom filter size

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -245,13 +245,21 @@ func tableInfo(dir, valueDir string, db *badger.DB) {
 	fmt.Println()
 	fmt.Println("SSTable [Li, Id, Total Keys including internal keys] " +
 		"[Left Key, Version -> Right Key, Version] [Index Size] [BF Size]")
+	totalIndex := uint64(0)
+	totalBloomFilter := uint64(0)
 	for _, t := range tables {
 		lk, lt := y.ParseKey(t.Left), y.ParseTs(t.Left)
 		rk, rt := y.ParseKey(t.Right), y.ParseTs(t.Right)
 
+		totalIndex += uint64(t.IndexSz)
+		totalBloomFilter += uint64(t.BloomFilterSize)
 		fmt.Printf("SSTable [L%d, %03d, %07d] [%20X, v%d -> %20X, v%d] [%s] [%s] \n",
-			t.Level, t.ID, t.KeyCount, lk, lt, rk, rt, hbytes(int64(t.IndexSz)), hbytes(int64(t.BfSize)))
+			t.Level, t.ID, t.KeyCount, lk, lt, rk, rt, hbytes(int64(t.IndexSz)),
+			hbytes(int64(t.BloomFilterSize)))
 	}
+	fmt.Println()
+	fmt.Printf("Total Index Size: %s\n", hbytes(int64(totalIndex)))
+	fmt.Printf("Total BloomFilter Size: %s\n", hbytes(int64(totalIndex)))
 	fmt.Println()
 }
 
@@ -403,13 +411,13 @@ func printInfo(dir, valueDir string) error {
 	}
 
 	fmt.Print("\n[Summary]\n")
-	totalIndexSize := int64(0)
+	totalSSTSize := int64(0)
 	for i, sz := range levelSizes {
 		fmt.Printf("Level %d size: %12s\n", i, hbytes(sz))
-		totalIndexSize += sz
+		totalSSTSize += sz
 	}
 
-	fmt.Printf("Total index size: %8s\n", hbytes(totalIndexSize))
+	fmt.Printf("Total SST size: %8s\n", hbytes(totalSSTSize))
 	fmt.Printf("Value log size: %10s\n", hbytes(valueLogSize))
 	fmt.Println()
 	totalExtra := numExtra + numValueDirExtra

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -244,13 +244,13 @@ func tableInfo(dir, valueDir string, db *badger.DB) {
 	tables := db.Tables(true)
 	fmt.Println()
 	fmt.Println("SSTable [Li, Id, Total Keys including internal keys] " +
-		"[Left Key, Version -> Right Key, Version]" + "[Index Size]")
+		"[Left Key, Version -> Right Key, Version] [Index Size] [BF Size]")
 	for _, t := range tables {
 		lk, lt := y.ParseKey(t.Left), y.ParseTs(t.Left)
 		rk, rt := y.ParseKey(t.Right), y.ParseTs(t.Right)
 
-		fmt.Printf("SSTable [L%d, %03d, %07d] [%20X, v%d -> %20X, v%d] [%s]\n",
-			t.Level, t.ID, t.KeyCount, lk, lt, rk, rt, hbytes(int64(t.IndexSz)))
+		fmt.Printf("SSTable [L%d, %03d, %07d] [%20X, v%d -> %20X, v%d] [%s] [%s] \n",
+			t.Level, t.ID, t.KeyCount, lk, lt, rk, rt, hbytes(int64(t.IndexSz)), hbytes(int64(t.BfSize)))
 	}
 	fmt.Println()
 }

--- a/go.mod
+++ b/go.mod
@@ -5,17 +5,17 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20200906165740-41ebdbffecfd
+	github.com/dgraph-io/ristretto v0.0.4-0.20200930150433-e1609c8d4ca6
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb
+	golang.org/x/sys v0.0.0-20200918174421-af09f7315aff
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20200906165740-41ebdbffecfd h1:KoJOtZf+6wpQaDTuOWGuo61GxcPBIfhwRxRTaTWGCTc=
-github.com/dgraph-io/ristretto v0.0.4-0.20200906165740-41ebdbffecfd/go.mod h1:YylP9MpCYGVZQrly/j/diqcdUetCRRePeBB0c2VGXsA=
+github.com/dgraph-io/ristretto v0.0.4-0.20200930150433-e1609c8d4ca6 h1:maqkH6zkcUx1PP+LpbLMef2IOSz2/mLYT3RqecFcdDI=
+github.com/dgraph-io/ristretto v0.0.4-0.20200930150433-e1609c8d4ca6/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -36,8 +36,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -64,8 +64,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
-golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200918174421-af09f7315aff h1:1CPUrky56AcgSpxz/KfgzQWzfG09u5YOL8MvPYBlrL8=
+golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=

--- a/levels.go
+++ b/levels.go
@@ -1137,14 +1137,14 @@ func (s *levelsController) appendIterators(
 
 // TableInfo represents the information about a table.
 type TableInfo struct {
-	ID          uint64
-	Level       int
-	Left        []byte
-	Right       []byte
-	KeyCount    uint64 // Number of keys in the table
-	EstimatedSz uint64
-	IndexSz     int
-	BfSize      int
+	ID              uint64
+	Level           int
+	Left            []byte
+	Right           []byte
+	KeyCount        uint64 // Number of keys in the table
+	EstimatedSz     uint64
+	IndexSz         int
+	BloomFilterSize int
 }
 
 func (s *levelsController) getTableInfo(withKeysCount bool) (result []TableInfo) {
@@ -1161,14 +1161,14 @@ func (s *levelsController) getTableInfo(withKeysCount bool) (result []TableInfo)
 			}
 
 			info := TableInfo{
-				ID:          t.ID(),
-				Level:       l.level,
-				Left:        t.Smallest(),
-				Right:       t.Biggest(),
-				KeyCount:    count,
-				EstimatedSz: t.EstimatedSize(),
-				IndexSz:     t.IndexSize(),
-				BfSize:      t.BFSize(),
+				ID:              t.ID(),
+				Level:           l.level,
+				Left:            t.Smallest(),
+				Right:           t.Biggest(),
+				KeyCount:        count,
+				EstimatedSz:     t.EstimatedSize(),
+				IndexSz:         t.IndexSize(),
+				BloomFilterSize: t.BloomFilterSize(),
 			}
 			result = append(result, info)
 		}

--- a/levels.go
+++ b/levels.go
@@ -1144,6 +1144,7 @@ type TableInfo struct {
 	KeyCount    uint64 // Number of keys in the table
 	EstimatedSz uint64
 	IndexSz     int
+	BfSize      int
 }
 
 func (s *levelsController) getTableInfo(withKeysCount bool) (result []TableInfo) {
@@ -1167,6 +1168,7 @@ func (s *levelsController) getTableInfo(withKeysCount bool) (result []TableInfo)
 				KeyCount:    count,
 				EstimatedSz: t.EstimatedSize(),
 				IndexSz:     t.IndexSize(),
+				BfSize:      t.BFSize(),
 			}
 			result = append(result, info)
 		}

--- a/table/table.go
+++ b/table/table.go
@@ -654,9 +654,9 @@ func (t *Table) IndexSize() int {
 	return indexSz
 }
 
-// BFSize returns the size of the bloom filter in bytes stored in memory. The
+// BloomFilterSize returns the size of the bloom filter in bytes stored in memory. The
 // size of on-disk representation would be less than the in-memory representation.
-func (t *Table) BFSize() int {
+func (t *Table) BloomFilterSize() int {
 	return t.bf.TotalSize()
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -644,13 +644,20 @@ func (t *Table) blockOffsetsCacheKey() uint64 {
 	return t.id
 }
 
-// IndexSize is the size of table index in bytes
+// IndexSize returns the size of table index in bytes stored in the memory. The
+// size of on-disk representation would be less than the in-memory representation.
 func (t *Table) IndexSize() int {
 	indexSz := 0
 	for _, bi := range t.blockOffsets() {
 		indexSz += bi.Size()
 	}
 	return indexSz
+}
+
+// BFSize returns the size of the bloom filter in bytes stored in memory. The
+// size of on-disk representation would be less than the in-memory representation.
+func (t *Table) BFSize() int {
+	return t.bf.TotalSize()
 }
 
 // EstimatedSize returns the total size of key-values stored in this table (including the


### PR DESCRIPTION
This PR depends upon https://github.com/dgraph-io/ristretto/pull/197
`badger info` now shows index size and bloom filter size
```
>badger info --dir xxx --show-tables
SSTable [L3, 204, 0450361] [    00000000046B8156, v1 ->     000000000472608E, v1] [433 kB] [1.0 MB] 
SSTable [L3, 205, 0450360] [    00000000011132C7, v1 ->     00000000011811FE, v1] [433 kB] [1.0 MB] 
SSTable [L3, 206, 0450360] [    00000000028EAB05, v1 ->     0000000002958A3C, v1] [433 kB] [1.0 MB] 
SSTable [L3, 207, 0450361] [    0000000003ACC537, v1 ->     0000000003B3A46F, v1] [433 kB] [1.0 MB] 
SSTable [L3, 208, 0450361] [    0000000005E8F995, v1 ->     0000000005EFD8CD, v1] [433 kB] [1.0 MB] 
SSTable [L3, 209, 0395313] [    000000000472608F, v1 ->     00000000047868BF, v1] [380 kB] [524 kB] 
SSTable [L3, 210, 0395313] [    00000000011811FF, v1 ->     00000000011E1A2F, v1] [380 kB] [524 kB] 

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1543)
<!-- Reviewable:end -->
