### PR TITLE
KeySplits checks tables and memtables when number of splits is small.

### DIFF
--- a/db.go
+++ b/db.go
@@ -1478,7 +1478,7 @@ func (db *DB) KeySplits(prefix []byte) []string {
 			numPerTable = 1
 		}
 		db.opt.Infof("Getting at least %d splits per table. Num tables is %d", numPerTable, len(tables))
-		splits = append(splits, db.lc.keySplits(numPerTable, prefix)...)
+		splits = db.lc.keySplits(numPerTable, prefix)
 	}
 	db.opt.Infof("Found %d splits after looking inside tables", len(splits))
 

--- a/db.go
+++ b/db.go
@@ -1470,6 +1470,14 @@ func (db *DB) KeySplits(prefix []byte) []string {
 	}
 
 	sort.Strings(splits)
+	// If splits is still zero, then look at memtables.
+	// // acquire some lock
+	// var memtables []*tbl
+	// memtables := append(memtables, db.imm...)
+	// db.mt
+	// for tables {
+	// 	generate some ranges.
+	// }
 	return splits
 }
 

--- a/db.go
+++ b/db.go
@@ -1461,7 +1461,7 @@ func (db *DB) KeySplits(prefix []byte) []string {
 		}
 	}
 
-	if len(splits) < 32 {
+	if len(splits) < 32 && len(tables) > 0 {
 		numPerTable := 32 / len(tables)
 		if numPerTable == 0 {
 			numPerTable = 1

--- a/db.go
+++ b/db.go
@@ -1477,7 +1477,8 @@ func (db *DB) KeySplits(prefix []byte) []string {
 		if numPerTable == 0 {
 			numPerTable = 1
 		}
-		splits = db.lc.keySplits(numPerTable, prefix)
+		db.opt.Infof("Getting at least %d splits per table. Num tables is %d", numPerTable, len(tables))
+		splits = append(splits, db.lc.keySplits(numPerTable, prefix)...)
 	}
 	db.opt.Infof("Found %d splits after looking inside tables", len(splits))
 

--- a/db.go
+++ b/db.go
@@ -1494,7 +1494,7 @@ func (db *DB) KeySplits(prefix []byte) []string {
 				}
 				count += 1
 			}
-			iter.Close()
+			_ = iter.Close()
 		}
 
 		db.Lock()

--- a/db.go
+++ b/db.go
@@ -49,6 +49,10 @@ var (
 	lfDiscardStatsKey = []byte("!badger!discard") // For storing lfDiscardStats
 )
 
+const (
+	maxNumSplits = 128
+)
+
 type closers struct {
 	updateSize *z.Closer
 	compactors *z.Closer
@@ -1461,23 +1465,65 @@ func (db *DB) KeySplits(prefix []byte) []string {
 		}
 	}
 
+	// If the number of splits is low, look at the offsets inside the
+	// tables to generate more splits.
 	if len(splits) < 32 && len(tables) > 0 {
 		numPerTable := 32 / len(tables)
 		if numPerTable == 0 {
 			numPerTable = 1
 		}
-		return db.lc.keySplits(numPerTable)
+		splits = db.lc.keySplits(numPerTable)
+	}
+
+	// If the number of splits is still < 32, then look at the memtables.
+	if len(splits) < 32 {
+		maxPerSplit := 10000
+		mtSplits := func(mt *skl.Skiplist) {
+			count := 0
+			iter := mt.NewIterator()
+			for iter.SeekToFirst(); iter.Valid(); iter.Next() {
+				count += 1
+				if count == maxPerSplit {
+					// Add a split every maxPerSplit keys.
+					splits = append(splits, string(iter.Key()))
+					count = 0
+				}
+			}
+			iter.Close()
+		}
+
+		db.Lock()
+		defer db.Unlock()
+		memtables := make([]*skl.Skiplist, 0)
+		memtables = append(memtables, db.imm...)
+		for _, mt := range memtables {
+			mtSplits(mt)
+		}
+		mtSplits(db.mt)
 	}
 
 	sort.Strings(splits)
-	// If splits is still zero, then look at memtables.
-	// // acquire some lock
-	// var memtables []*tbl
-	// memtables := append(memtables, db.imm...)
-	// db.mt
-	// for tables {
-	// 	generate some ranges.
-	// }
+
+	// Limit the maximum number of splits returned by this function. We check against
+	// maxNumberSplits * 2 so that the jump variable has a value of at least two.
+	// Otherwise, the entire list would be returned without any reduction in size.
+	if len(splits) > maxNumSplits*2 {
+		newSplits := make([]string, 0)
+		jump := len(splits) / maxNumSplits
+		if jump < 2 {
+			jump = 2
+		}
+
+		for i := 0; i < len(splits); i += jump {
+			if i >= len(splits) {
+				i = len(splits) - 1
+			}
+			newSplits = append(newSplits, splits[i])
+		}
+
+		splits = newSplits
+	}
+
 	return splits
 }
 

--- a/db.go
+++ b/db.go
@@ -1481,13 +1481,12 @@ func (db *DB) KeySplits(prefix []byte) []string {
 		mtSplits := func(mt *skl.Skiplist) {
 			count := 0
 			iter := mt.NewIterator()
-			for iter.SeekToLast(); iter.Valid(); iter.Prev() {
+			for iter.SeekToFirst(); iter.Valid(); iter.Next() {
 				if count%maxPerSplit == 0 {
 					// Add a split every maxPerSplit keys.
 					if bytes.HasPrefix(iter.Key(), prefix) {
 						splits = append(splits, string(iter.Key()))
 					}
-					count = 0
 				}
 				count += 1
 			}

--- a/levels.go
+++ b/levels.go
@@ -1208,7 +1208,6 @@ func (s *levelsController) keySplits(numPerTable int, prefix []byte) []string {
 		l.RLock()
 		for _, t := range l.tables {
 			tableSplits := t.KeySplits(numPerTable, prefix)
-			s.kv.opt.Infof("Got %d splits from table", len(tableSplits))
 			splits = append(splits, tableSplits...)
 		}
 		l.RUnlock()

--- a/levels.go
+++ b/levels.go
@@ -1199,3 +1199,16 @@ func (s *levelsController) verifyChecksum() error {
 
 	return nil
 }
+
+// Returns the sorted list of splits for all the levels and tables based
+// on the block offsets.
+func (s *levelsController) keySplits(numPerTable int) []string {
+	splits := make([]string, 0)
+	for _, l := range s.levels {
+		for _, t := range l.tables {
+			splits = append(splits, t.KeySplits(numPerTable)...)
+		}
+	}
+	sort.Strings(splits)
+	return splits
+}

--- a/levels.go
+++ b/levels.go
@@ -1207,7 +1207,9 @@ func (s *levelsController) keySplits(numPerTable int, prefix []byte) []string {
 	for _, l := range s.levels {
 		l.RLock()
 		for _, t := range l.tables {
-			splits = append(splits, t.KeySplits(numPerTable, prefix)...)
+			tableSplits := t.KeySplits(numPerTable, prefix)
+			s.kv.opt.Infof("Got %d splits from table", len(tableSplits))
+			splits = append(splits, tableSplits...)
 		}
 		l.RUnlock()
 	}

--- a/levels.go
+++ b/levels.go
@@ -1205,9 +1205,11 @@ func (s *levelsController) verifyChecksum() error {
 func (s *levelsController) keySplits(numPerTable int, prefix []byte) []string {
 	splits := make([]string, 0)
 	for _, l := range s.levels {
+		l.RLock()
 		for _, t := range l.tables {
 			splits = append(splits, t.KeySplits(numPerTable, prefix)...)
 		}
+		l.RUnlock()
 	}
 	sort.Strings(splits)
 	return splits

--- a/levels.go
+++ b/levels.go
@@ -1202,11 +1202,11 @@ func (s *levelsController) verifyChecksum() error {
 
 // Returns the sorted list of splits for all the levels and tables based
 // on the block offsets.
-func (s *levelsController) keySplits(numPerTable int) []string {
+func (s *levelsController) keySplits(numPerTable int, prefix []byte) []string {
 	splits := make([]string, 0)
 	for _, l := range s.levels {
 		for _, t := range l.tables {
-			splits = append(splits, t.KeySplits(numPerTable)...)
+			splits = append(splits, t.KeySplits(numPerTable, prefix)...)
 		}
 	}
 	sort.Strings(splits)

--- a/levels_test.go
+++ b/levels_test.go
@@ -940,7 +940,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 1, len(db.KeySplits(nil)))
+				require.Equal(t, 2, len(db.KeySplits(nil)))
 			})
 		})
 		t.Run("medium table", func(t *testing.T) {
@@ -950,7 +950,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 7, len(db.KeySplits(nil)))
+				require.Equal(t, 8, len(db.KeySplits(nil)))
 			})
 		})
 		t.Run("large table", func(t *testing.T) {
@@ -960,7 +960,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 61, len(db.KeySplits(nil)))
+				require.Equal(t, 62, len(db.KeySplits(nil)))
 			})
 		})
 		t.Run("prefix", func(t *testing.T) {

--- a/levels_test.go
+++ b/levels_test.go
@@ -999,7 +999,7 @@ func TestKeyVersions(t *testing.T) {
 		t.Run("prefix", func(t *testing.T) {
 			runBadgerTest(t, &inMemoryOpt, func(t *testing.T, db *DB) {
 				writer := db.newWriteBatch(false)
-				for i := 0; i < 100000; i++ {
+				for i := 0; i < 10000; i++ {
 					writer.Set([]byte(fmt.Sprintf("%05d", i)), []byte("foo"))
 				}
 				require.NoError(t, writer.Flush())

--- a/levels_test.go
+++ b/levels_test.go
@@ -976,12 +976,13 @@ func TestKeyVersions(t *testing.T) {
 	})
 
 	t.Run("in-memory", func(t *testing.T) {
-		t.Run("medium table", func(t *testing.T) {
+		t.Run("small table", func(t *testing.T) {
 			runBadgerTest(t, &inMemoryOpt, func(t *testing.T, db *DB) {
 				writer := db.newWriteBatch(false)
-				for i := 0; i < 5000; i++ {
+				for i := 0; i < 10; i++ {
 					writer.Set([]byte(fmt.Sprintf("%05d", i)), []byte("foo"))
 				}
+				require.NoError(t, writer.Flush())
 				require.Equal(t, 1, len(db.KeySplits(nil)))
 			})
 		})
@@ -991,6 +992,7 @@ func TestKeyVersions(t *testing.T) {
 				for i := 0; i < 100000; i++ {
 					writer.Set([]byte(fmt.Sprintf("%05d", i)), []byte("foo"))
 				}
+				require.NoError(t, writer.Flush())
 				require.Equal(t, 11, len(db.KeySplits(nil)))
 			})
 		})
@@ -1000,6 +1002,7 @@ func TestKeyVersions(t *testing.T) {
 				for i := 0; i < 100000; i++ {
 					writer.Set([]byte(fmt.Sprintf("%05d", i)), []byte("foo"))
 				}
+				require.NoError(t, writer.Flush())
 				require.Equal(t, 0, len(db.KeySplits([]byte("a"))))
 			})
 		})

--- a/levels_test.go
+++ b/levels_test.go
@@ -940,7 +940,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 2, len(db.KeySplits(nil)))
+				require.Equal(t, 1, len(db.KeySplits(nil)))
 			})
 		})
 		t.Run("medium table", func(t *testing.T) {
@@ -950,7 +950,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 8, len(db.KeySplits(nil)))
+				require.Equal(t, 7, len(db.KeySplits(nil)))
 			})
 		})
 		t.Run("large table", func(t *testing.T) {
@@ -960,7 +960,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 62, len(db.KeySplits(nil)))
+				require.Equal(t, 61, len(db.KeySplits(nil)))
 			})
 		})
 		t.Run("prefix", func(t *testing.T) {

--- a/levels_test.go
+++ b/levels_test.go
@@ -17,6 +17,7 @@
 package badger
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -922,4 +923,39 @@ func TestLevelGet(t *testing.T) {
 
 		})
 	}
+}
+
+func TestKeyVersions(t *testing.T) {
+	t.Run("KeyVersions", func(t *testing.T) {
+		t.Run("small table", func(t *testing.T) {
+			runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+				l0 := make([]keyValVersion, 0)
+				for i := 0; i < 10; i++ {
+					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
+				}
+				createAndOpen(db, l0, 0)
+				require.Equal(t, 1, len(db.KeySplits(nil)))
+			})
+		})
+		t.Run("medium table", func(t *testing.T) {
+			runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+				l0 := make([]keyValVersion, 0)
+				for i := 0; i < 1000; i++ {
+					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
+				}
+				createAndOpen(db, l0, 0)
+				require.Equal(t, 7, len(db.KeySplits(nil)))
+			})
+		})
+		t.Run("large table", func(t *testing.T) {
+			runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+				l0 := make([]keyValVersion, 0)
+				for i := 0; i < 10000; i++ {
+					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
+				}
+				createAndOpen(db, l0, 0)
+				require.Equal(t, 32, len(db.KeySplits(nil)))
+			})
+		})
+	})
 }

--- a/stream.go
+++ b/stream.go
@@ -30,7 +30,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-const pageSize = 4 << 20 // 4MB
+const batchSize = 16 << 20 // 16 MB
 
 // maxStreamSize is the maximum allowed size of a stream batch. This is a soft limit
 // as a single list that is still over the limit will have to be sent as is since it
@@ -218,7 +218,7 @@ func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
 				kv.StreamId = streamId
 				outList.Kv = append(outList.Kv, kv)
 
-				if size < pageSize {
+				if size < batchSize {
 					continue
 				}
 				if err := sendIt(); err != nil {

--- a/stream.go
+++ b/stream.go
@@ -123,7 +123,6 @@ func (st *Stream) ToList(key []byte, itr *Iterator) (*pb.KVList, error) {
 // end byte slices are owned by keyRange struct.
 func (st *Stream) produceRanges(ctx context.Context) {
 	splits := st.db.KeySplits(st.Prefix)
-	st.db.opt.Infof("%s Found %d key splits.\n", st.LogPrefix, len(splits))
 
 	// We don't need to create more key ranges than NumGo goroutines. This way, we will have limited
 	// number of "streams" coming out, which then helps limit the memory used by SSWriter.

--- a/stream.go
+++ b/stream.go
@@ -123,7 +123,7 @@ func (st *Stream) ToList(key []byte, itr *Iterator) (*pb.KVList, error) {
 // end byte slices are owned by keyRange struct.
 func (st *Stream) produceRanges(ctx context.Context) {
 	splits := st.db.KeySplits(st.Prefix)
-	st.db.opt.Infof("%s Found %d splits.\n", st.LogPrefix, len(splits))
+	st.db.opt.Infof("%s Found %d key splits.\n", st.LogPrefix, len(splits))
 
 	// We don't need to create more key ranges than NumGo goroutines. This way, we will have limited
 	// number of "streams" coming out, which then helps limit the memory used by SSWriter.

--- a/stream.go
+++ b/stream.go
@@ -123,6 +123,7 @@ func (st *Stream) ToList(key []byte, itr *Iterator) (*pb.KVList, error) {
 // end byte slices are owned by keyRange struct.
 func (st *Stream) produceRanges(ctx context.Context) {
 	splits := st.db.KeySplits(st.Prefix)
+	st.db.opt.Infof("%s Found %d splits.\n", st.LogPrefix, len(splits))
 
 	// We don't need to create more key ranges than NumGo goroutines. This way, we will have limited
 	// number of "streams" coming out, which then helps limit the memory used by SSWriter.

--- a/table/table.go
+++ b/table/table.go
@@ -487,15 +487,15 @@ func (t *Table) KeySplits(n int, prefix []byte) []string {
 	}
 
 	var res []string
-	offLen := len(t.blockOffset)
-	jump := offLen / n
+	offsets := t.blockOffsets()
+	jump := len(offsets) / n
 	if jump == 0 {
 		jump = 1
 	}
 
-	for i := 0; i < offLen; i += jump {
-		if i >= offLen {
-			i = offLen - 1
+	for i := 0; i < len(offsets); i += jump {
+		if i >= len(offsets) {
+			i = len(offsets) - 1
 		}
 		if bytes.HasPrefix(t.blockOffset[i].Key, prefix) {
 			res = append(res, string(t.blockOffset[i].Key))

--- a/table/table.go
+++ b/table/table.go
@@ -481,6 +481,10 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 
 // KeySplits splits the table into n ranges based on the block offsets.
 func (t *Table) KeySplits(n int) []string {
+	if n == 0 {
+		return nil
+	}
+
 	var res []string
 	offLen := len(t.blockOffset)
 	jump := offLen / n

--- a/table/table.go
+++ b/table/table.go
@@ -17,6 +17,7 @@
 package table
 
 import (
+	"bytes"
 	"crypto/aes"
 	"encoding/binary"
 	"fmt"
@@ -480,7 +481,7 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 }
 
 // KeySplits splits the table into at least n ranges based on the block offsets.
-func (t *Table) KeySplits(n int) []string {
+func (t *Table) KeySplits(n int, prefix []byte) []string {
 	if n == 0 {
 		return nil
 	}
@@ -496,7 +497,9 @@ func (t *Table) KeySplits(n int) []string {
 		if i >= offLen {
 			i = offLen - 1
 		}
-		res = append(res, string(t.blockOffset[i].Key))
+		if bytes.HasPrefix(t.blockOffset[i].Key, prefix) {
+			res = append(res, string(t.blockOffset[i].Key))
+		}
 	}
 	return res
 }

--- a/table/table.go
+++ b/table/table.go
@@ -497,9 +497,6 @@ func (t *Table) KeySplits(n int) []string {
 			i = offLen - 1
 		}
 		res = append(res, string(t.blockOffset[i].Key))
-		if len(res) == n {
-			break
-		}
 	}
 	return res
 }

--- a/table/table.go
+++ b/table/table.go
@@ -479,7 +479,7 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 	return index.Offsets[0], nil
 }
 
-// KeySplits splits the table into n ranges based on the block offsets.
+// KeySplits splits the table into at least n ranges based on the block offsets.
 func (t *Table) KeySplits(n int) []string {
 	if n == 0 {
 		return nil

--- a/table/table.go
+++ b/table/table.go
@@ -497,8 +497,8 @@ func (t *Table) KeySplits(n int, prefix []byte) []string {
 		if i >= len(offsets) {
 			i = len(offsets) - 1
 		}
-		if bytes.HasPrefix(t.blockOffset[i].Key, prefix) {
-			res = append(res, string(t.blockOffset[i].Key))
+		if bytes.HasPrefix(offsets[i].Key, prefix) {
+			res = append(res, string(offsets[i].Key))
 		}
 	}
 	return res

--- a/table/table.go
+++ b/table/table.go
@@ -479,6 +479,27 @@ func (t *Table) initIndex() (*pb.BlockOffset, error) {
 	return index.Offsets[0], nil
 }
 
+// KeySplits splits the table into n ranges based on the block offsets.
+func (t *Table) KeySplits(n int) []string {
+	var res []string
+	offLen := len(t.blockOffset)
+	jump := offLen / n
+	if jump == 0 {
+		jump = 1
+	}
+
+	for i := 0; i < offLen; i += jump {
+		if i >= offLen {
+			i = offLen - 1
+		}
+		res = append(res, string(t.blockOffset[i].Key))
+		if len(res) == n {
+			break
+		}
+	}
+	return res
+}
+
 // blockOffsets returns block offsets of this table.
 func (t *Table) blockOffsets() []*pb.BlockOffset {
 	if t.opt.IndexCache == nil {


### PR DESCRIPTION
Fixes DGRAPH-2509

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1544)
<!-- Reviewable:end -->
