### PR TITLE
change ValueLogFileSize's type from int64 to uint32

### DIFF
--- a/options.go
+++ b/options.go
@@ -70,7 +70,7 @@ type Options struct {
 	NumLevelZeroTablesStall int
 
 	LevelOneSize       int64
-	ValueLogFileSize   int64
+	ValueLogFileSize   uint32
 	ValueLogMaxEntries uint32
 
 	NumCompactors        int
@@ -429,7 +429,7 @@ func (opt Options) WithLevelOneSize(val int64) Options {
 // ValueLogFileSize sets the maximum size of a single value log file.
 //
 // The default value of ValueLogFileSize is 1GB.
-func (opt Options) WithValueLogFileSize(val int64) Options {
+func (opt Options) WithValueLogFileSize(val uint32) Options {
 	opt.ValueLogFileSize = val
 	return opt
 }

--- a/txn.go
+++ b/txn.go
@@ -375,8 +375,8 @@ func (txn *Txn) modify(e *Entry) error {
 		// keep things safe and allow badger move prefix and a timestamp suffix, let's
 		// cut it down to 65000, instead of using 65536.
 		return exceedsSize("Key", maxKeySize, e.Key)
-	case int64(len(e.Value)) > txn.db.opt.ValueLogFileSize:
-		return exceedsSize("Value", txn.db.opt.ValueLogFileSize, e.Value)
+	case uint32(len(e.Value)) > txn.db.opt.ValueLogFileSize:
+		return exceedsSize("Value", int64(txn.db.opt.ValueLogFileSize), e.Value)
 	case txn.db.opt.InMemory && len(e.Value) > txn.db.opt.ValueThreshold:
 		return exceedsSize("Value", int64(txn.db.opt.ValueThreshold), e.Value)
 	}

--- a/value.go
+++ b/value.go
@@ -1455,7 +1455,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 		if err := flushWrites(); err != nil {
 			return err
 		}
-		if vlog.woffset() > uint32(vlog.opt.ValueLogFileSize) ||
+		if vlog.woffset() > vlog.opt.ValueLogFileSize ||
 			vlog.numEntriesWritten > vlog.opt.ValueLogMaxEntries {
 			if err := curlf.doneWriting(vlog.woffset()); err != nil {
 				return err
@@ -1509,7 +1509,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 		// We write to disk here so that all entries that are part of the same transaction are
 		// written to the same vlog file.
 		writeNow :=
-			vlog.woffset()+uint32(buf.Len()) > uint32(vlog.opt.ValueLogFileSize) ||
+			vlog.woffset()+uint32(buf.Len()) > vlog.opt.ValueLogFileSize ||
 				vlog.numEntriesWritten > uint32(vlog.opt.ValueLogMaxEntries)
 		if writeNow {
 			if err := toDisk(); err != nil {

--- a/value.go
+++ b/value.go
@@ -1008,7 +1008,7 @@ func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 		return nil, errFile(err, vlog.dirPath, "Sync value log dir")
 	}
 
-	if err = lf.mmap(2 * vlog.opt.ValueLogFileSize); err != nil {
+	if err = lf.mmap(2 * int64(vlog.opt.ValueLogFileSize)); err != nil {
 		removeFile()
 		return nil, errFile(err, lf.path, "Mmap value log file")
 	}
@@ -1202,7 +1202,7 @@ func (vlog *valueLog) open(db *DB, ptr valuePointer, replayFn logEntry) error {
 	vlog.db.vhead = valuePointer{Fid: vlog.maxFid, Offset: uint32(lastOffset)}
 
 	// Map the file if needed. When we create a file, it is automatically mapped.
-	if err = last.mmap(2 * vlog.opt.ValueLogFileSize); err != nil {
+	if err = last.mmap(2 * int64(vlog.opt.ValueLogFileSize)); err != nil {
 		return errFile(err, last.path, "Map log file")
 	}
 	if err := vlog.populateDiscardStats(); err != nil {
@@ -1499,7 +1499,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 			// log (this happens when a transaction contains entries with large value sizes) and
 			// badger might run into out of memory errors. We flush the buffer here if it's size
 			// grows beyond the max value log size.
-			if int64(buf.Len()) > vlog.db.opt.ValueLogFileSize {
+			if uint32(buf.Len()) > vlog.db.opt.ValueLogFileSize {
 				if err := flushWrites(); err != nil {
 					return err
 				}

--- a/value_test.go
+++ b/value_test.go
@@ -103,9 +103,9 @@ func TestValueGCManaged(t *testing.T) {
 	require.NoError(t, err)
 	defer removeDir(dir)
 
-	N := 2
+	N := 10000
 	opt := getTestOptions(dir)
-	// opt.ValueLogMaxEntries = uint32(N / 10)
+	opt.ValueLogMaxEntries = uint32(N / 10)
 	opt.managedTxns = true
 	db, err := Open(opt)
 	require.NoError(t, err)
@@ -147,11 +147,6 @@ func TestValueGCManaged(t *testing.T) {
 	for _, fi := range files {
 		t.Logf("File: %s. Size: %s\n", fi.Name(), humanize.Bytes(uint64(fi.Size())))
 	}
-
-	db.vlog.iterate(db.vlog.filesMap[0], 0, func(e Entry, vp valuePointer) error {
-		fmt.Println(e.Key, e.meta)
-		return nil
-	})
 
 	for i := 0; i < 100; i++ {
 		// Try at max 100 times to GC even a single value log file.

--- a/value_test.go
+++ b/value_test.go
@@ -103,9 +103,9 @@ func TestValueGCManaged(t *testing.T) {
 	require.NoError(t, err)
 	defer removeDir(dir)
 
-	N := 10000
+	N := 2
 	opt := getTestOptions(dir)
-	opt.ValueLogMaxEntries = uint32(N / 10)
+	// opt.ValueLogMaxEntries = uint32(N / 10)
 	opt.managedTxns = true
 	db, err := Open(opt)
 	require.NoError(t, err)
@@ -147,6 +147,11 @@ func TestValueGCManaged(t *testing.T) {
 	for _, fi := range files {
 		t.Logf("File: %s. Size: %s\n", fi.Name(), humanize.Bytes(uint64(fi.Size())))
 	}
+
+	db.vlog.iterate(db.vlog.filesMap[0], 0, func(e Entry, vp valuePointer) error {
+		fmt.Println(e.Key, e.meta)
+		return nil
+	})
 
 	for i := 0; i < 100; i++ {
 		// Try at max 100 times to GC even a single value log file.


### PR DESCRIPTION
We don't allow `ValueLogFileSize` to go beyond `2<<30` (see [this](https://github.com/dgraph-io/badger/blob/8e06ab6e719e738b6378524a05e4cff2aad9f12d/db.go#L220)). Hence, we should
better change the type to uint32 instead of int64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1545)
<!-- Reviewable:end -->
