### PR TITLE
Add Cancel() to StreamWriter

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -282,7 +282,7 @@ func (sw *StreamWriter) Cancel() {
 
 	for _, writer := range sw.writers {
 		if writer != nil {
-			writer.closer.Signal()
+			writer.closer.SignalAndWait()
 		}
 	}
 }

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -269,7 +269,9 @@ func (sw *StreamWriter) Flush() error {
 	return sw.db.lc.validate()
 }
 
-// Cancel signals all goroutines to exit.
+// Cancel signals all goroutines to exit. Calling defer sw.Cancel() immediately after creating a new StreamWriter
+// ensures that writes are unblocked even upon early return. Note that dropAll() is not called here, so any
+// partially written data will not be erased until a new StreamWriter is initialized.
 func (sw *StreamWriter) Cancel() {
 	sw.writeLock.Lock()
 	defer sw.writeLock.Unlock()

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -279,6 +279,15 @@ func (sw *StreamWriter) Cancel() {
 			writer.closer.Signal()
 		}
 	}
+	for _, writer := range sw.writers {
+		if writer != nil {
+			writer.closer.Wait()
+		}
+	}
+
+	if err := sw.throttle.Finish(); err != nil {
+		sw.db.opt.Errorf("error in throttle.Finish: %+v", err)
+	}
 
 	// Handle Cancel() being called before Prepare().
 	if sw.done != nil {

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -379,7 +379,7 @@ func TestStreamWriterCancel(t *testing.T) {
 
 		sw := db.NewStreamWriter()
 		require.NoError(t, sw.Prepare(), "sw.Prepare() failed")
-		require.NoError(t, sw.Write(nil), "sw.Write() failed")
+		require.NoError(t, sw.Write(list), "sw.Write() failed")
 		sw.Cancel()
 
 		// Use the API incorrectly.

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -377,21 +377,17 @@ func TestStreamWriterCancel(t *testing.T) {
 			ver = (ver + 1) % 2
 		}
 
-		func() {
-			sw := db.NewStreamWriter()
-			defer sw.Cancel()
+		sw := db.NewStreamWriter()
+		require.NoError(t, sw.Prepare(), "sw.Prepare() failed")
+		require.NoError(t, sw.Write(nil), "sw.Write() failed")
+		sw.Cancel()
 
-			require.NoError(t, sw.Prepare(), "sw.Prepare() failed")
-			require.NoError(t, sw.Write(list), "sw.Write() failed")
-		}()
-
-		tables := db.Tables(true)
-		require.Equal(t, 0, len(tables), "Count of tables not matching")
-		require.NoError(t, db.Close())
-
-		db, err := Open(db.opt)
-		require.NoError(t, err)
-		require.NoError(t, db.Close())
+		// Use the API incorrectly.
+		sw1 := db.NewStreamWriter()
+		defer sw1.Cancel()
+		require.NoError(t, sw1.Prepare())
+		defer sw1.Cancel()
+		sw1.Flush()
 	})
 }
 


### PR DESCRIPTION
I've added a `Cancel()` method to `StreamWriter` which calls `done()` and signals all writer goroutines to exit. Additionally, calling `done()` more than once will no longer panic, so it should be safe to do the following:

```go
sw := db.NewStreamWriter()
defer sw.Cancel()

sw.Prepare()
sw.Write(list)
sw.Flush()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1550)
<!-- Reviewable:end -->
