### PR TITLE
Fix segmentation fault when cache sizes are small.

### DIFF
--- a/db.go
+++ b/db.go
@@ -332,6 +332,11 @@ func Open(opt Options) (db *DB, err error) {
 
 	if opt.BlockCacheSize > 0 {
 		numInCache := opt.BlockCacheSize / int64(opt.BlockSize)
+		if numInCache == 0 {
+			// Make the value of this variable at least one since the cache requires
+			// the number of counters to be greater than zero.
+			numInCache = 1
+		}
 
 		config := ristretto.Config{
 			NumCounters: numInCache * 8,
@@ -350,6 +355,11 @@ func Open(opt Options) (db *DB, err error) {
 		// Index size is around 5% of the table size.
 		indexSz := int64(float64(opt.MaxTableSize) * 0.05)
 		numInCache := opt.IndexCacheSize / indexSz
+		if numInCache == 0 {
+			// Make the value of this variable at least one since the cache requires
+			// the number of counters to be greater than zero.
+			numInCache = 1
+		}
 
 		config := ristretto.Config{
 			NumCounters: numInCache * 8,

--- a/db_test.go
+++ b/db_test.go
@@ -2184,3 +2184,16 @@ func TestWriteInemory(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestMinCacheSize(t *testing.T) {
+	opt := DefaultOptions("").
+		WithInMemory(true).
+		WithIndexCacheSize(16).
+		WithBlockCacheSize(16)
+	db, err := Open(opt)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+}


### PR DESCRIPTION
If you open a DB with small cache sizes, a segmentation fault happens
because the number of counters in the cache is set to zero, which is not
allowed by Ristretto. Making the value of the variable numInCache to be
at least one fixes the issue.

The stack trace for the segmentation fault is below.

```
--- FAIL: TestMinCacheSize (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference
[recovered]
        panic: runtime error: invalid memory address or nil pointer
dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x777e66]

goroutine 6 [running]:
testing.tRunner.func1.1(0x93dc80, 0xc90c60)
        /usr/lib/go/src/testing/testing.go:1076 +0x30d
testing.tRunner.func1(0xc000001b00)
        /usr/lib/go/src/testing/testing.go:1079 +0x41a
panic(0x93dc80, 0xc90c60)
        /usr/lib/go/src/runtime/panic.go:969 +0x175
github.com/dgraph-io/badger/v2.(*DB).stopMemoryFlush(...)
        /home/martinmr/go/src/github.com/dgraph-io/badger/db.go:1561
github.com/dgraph-io/badger/v2.(*DB).cleanup(0x0)
        /home/martinmr/go/src/github.com/dgraph-io/badger/db.go:501
+0x26
github.com/dgraph-io/badger/v2.Open.func4(0xc000157a18, 0xc0000100f0)
        /home/martinmr/go/src/github.com/dgraph-io/badger/db.go:328
+0x45
github.com/dgraph-io/badger/v2.Open(0x0, 0x0, 0x0, 0x0, 0x1, 0x2, 0x2,
0x1, 0x0, 0xa4c760, ...)
        /home/martinmr/go/src/github.com/dgraph-io/badger/db.go:350
+0x1268
github.com/dgraph-io/badger/v2.TestMinCacheSize(0xc000001b00)
        /home/martinmr/go/src/github.com/dgraph-io/badger/db_test.go:2193
+0x1b8
testing.tRunner(0xc000001b00, 0x9d4950)
        /usr/lib/go/src/testing/testing.go:1127 +0xef
created by testing.(*T).Run
        /usr/lib/go/src/testing/testing.go:1178 +0x386
FAIL    github.com/dgraph-io/badger/v2  0.008s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1552)
<!-- Reviewable:end -->
