### PR TITLE
Add metric for number of tables being compacted

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -487,8 +487,9 @@ func (s *levelsController) compactBuildTables(
 	topTables := cd.top
 	botTables := cd.bot
 
-	y.NumCompactionTables.Add(int64(len(topTables) + len(botTables)))
-	defer y.NumCompactionTables.Add(int64(-(len(topTables) + len(botTables))))
+	numTables := int64(len(topTables) + len(botTables))
+	y.NumCompactionTables.Add(numTables)
+	defer y.NumCompactionTables.Add(-numTables)
 
 	// Check overlap of the top level with the levels which are not being
 	// compacted in this compaction.

--- a/levels.go
+++ b/levels.go
@@ -487,6 +487,9 @@ func (s *levelsController) compactBuildTables(
 	topTables := cd.top
 	botTables := cd.bot
 
+	y.NumCompactionTables.Add(int64(len(topTables) + len(botTables)))
+	defer y.NumCompactionTables.Add(int64(-(len(topTables) + len(botTables))))
+
 	// Check overlap of the top level with the levels which are not being
 	// compacted in this compaction.
 	hasOverlap := s.checkOverlap(cd.allTables(), cd.nextLevel.level+1)

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -48,6 +48,8 @@ var (
 	NumBlockedPuts *expvar.Int
 	// NumMemtableGets is number of memtable gets
 	NumMemtableGets *expvar.Int
+	// NumCompactionTables is the number of tables being compacted
+	NumCompactionTables *expvar.Int
 )
 
 // These variables are global and have cumulative values for all kv stores.
@@ -65,4 +67,5 @@ func init() {
 	LSMSize = expvar.NewMap("badger_v2_lsm_size_bytes")
 	VlogSize = expvar.NewMap("badger_v2_vlog_size_bytes")
 	PendingWrites = expvar.NewMap("badger_v2_pending_writes_total")
+	NumCompactionTables = expvar.NewInt("badger_v2_tables_being_compacted_total")
 }

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -67,5 +67,5 @@ func init() {
 	LSMSize = expvar.NewMap("badger_v2_lsm_size_bytes")
 	VlogSize = expvar.NewMap("badger_v2_vlog_size_bytes")
 	PendingWrites = expvar.NewMap("badger_v2_pending_writes_total")
-	NumCompactionTables = expvar.NewInt("badger_v2_tables_being_compacted_total")
+	NumCompactionTables = expvar.NewInt("badger_v2_compactions_current")
 }


### PR DESCRIPTION
This PR adds a metric for the number of tables that are being compacted at any point of time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1554)
<!-- Reviewable:end -->
