### PR TITLE
chore(cmd/info): Fix printed spacing of summary.

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -99,6 +99,8 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 	db, err := badger.Open(badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
 		WithReadOnly(opt.readOnly).
+		WithBlockCacheSize(100 << 20).
+		WithIndexCacheSize(200 << 20).
 		WithEncryptionKey([]byte(opt.encryptionKey)))
 	if err != nil {
 		return y.Wrap(err, "failed to open database")

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -434,7 +434,7 @@ func printInfo(dir, valueDir string) error {
 		totalSSTSize += sz
 	}
 
-	fmt.Printf("Total SST size: %8s\n", hbytes(totalSSTSize))
+	fmt.Printf("Total SST size: %10s\n", hbytes(totalSSTSize))
 	fmt.Printf("Value log size: %10s\n", hbytes(valueLogSize))
 	fmt.Println()
 	totalExtra := numExtra + numValueDirExtra


### PR DESCRIPTION
Column-aligns the output for the Summary section:

Before:

    [Summary]
    Level 0 size:          0 B
    Level 1 size:       2.3 kB
    Total SST size:   2.3 kB
    Value log size:       20 B

After:

    [Summary]
    Level 0 size:          0 B
    Level 1 size:       2.3 kB
    Total SST size:     2.3 kB
    Value log size:       20 B

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1559)
<!-- Reviewable:end -->
