### PR TITLE
feat(cmd/flatten): Add encryption-key-file flag.

### DIFF
--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -61,6 +61,8 @@ func flatten(cmd *cobra.Command, args []string) error {
 		WithValueDir(vlogDir).
 		WithNumVersionsToKeep(numVersions).
 		WithNumCompactors(0).
+		WithBlockCacheSize(100 << 20).
+		WithIndexCacheSize(200 << 20).
 		WithEncryptionKey(encKey)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.Open(opt)

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -33,6 +33,7 @@ This command would compact all the LSM tables into one level.
 	RunE: flatten,
 }
 
+var keyPath string
 var numWorkers int
 
 func init() {
@@ -43,6 +44,8 @@ func init() {
 	flattenCmd.Flags().IntVarP(&numVersions, "num_versions", "", 1,
 		"Option to configure the maximum number of versions per key. "+
 			"Values <= 0 will be considered to have the max number of versions.")
+	flattenCmd.Flags().StringVar(&keyPath, "encryption-key-file", "",
+		"Path of the encryption key file.")
 }
 
 func flatten(cmd *cobra.Command, args []string) error {
@@ -50,10 +53,15 @@ func flatten(cmd *cobra.Command, args []string) error {
 		// Keep all versions.
 		numVersions = math.MaxInt32
 	}
+	encKey, err := getKey(keyPath)
+	if err != nil {
+		return err
+	}
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
 		WithNumVersionsToKeep(numVersions).
-		WithNumCompactors(0)
+		WithNumCompactors(0).
+		WithEncryptionKey(encKey)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.Open(opt)
 	if err != nil {


### PR DESCRIPTION
Add an `--encryption-key-file` flag to the `badger flatten` tool to support encrypted databases.

Changes:
* Add --encryption-key-file flag
* Set block and index cache sizes to fix panic when running flatten.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1560)
<!-- Reviewable:end -->
