### PR TITLE
add checks when db is opened in read-only mode

### DIFF
--- a/db.go
+++ b/db.go
@@ -304,9 +304,11 @@ func Open(opt Options) (*DB, error) {
 		return nil, y.Wrapf(err, "while opening memtables")
 	}
 
-	db.mt, err = db.newMemTable()
-	if err != nil {
-		return nil, y.Wrapf(err, "cannot create memtable")
+	if !db.opt.ReadOnly {
+		db.mt, err = db.newMemTable()
+		if err != nil {
+			return nil, y.Wrapf(err, "cannot create memtable")
+		}
 	}
 
 	// newLevelsController potentially loads files in directory.

--- a/db.go
+++ b/db.go
@@ -619,6 +619,7 @@ func (db *DB) getMemTables() ([]*memTable, func()) {
 
 	var tables []*memTable
 
+	// Mutable memtable does not exist in read-only mode.
 	if !db.opt.ReadOnly {
 		// Get mutable memtable.
 		tables = append(tables, db.mt)

--- a/db.go
+++ b/db.go
@@ -371,6 +371,7 @@ func Open(opt Options) (*DB, error) {
 }
 
 func (db *DB) MaxVersion() uint64 {
+	return 0
 	var maxVersion uint64
 	update := func(a uint64) {
 		if a > maxVersion {
@@ -541,6 +542,10 @@ func (db *DB) close() (err error) {
 	}
 	db.stopMemoryFlush()
 	db.stopCompactions()
+
+	if db.mt != nil {
+		db.mt.DecrRef()
+	}
 
 	// Force Compact L0
 	// We don't need to care about cstatus since no parallel compaction is running.

--- a/db.go
+++ b/db.go
@@ -367,7 +367,10 @@ func (db *DB) MaxVersion() uint64 {
 		}
 	}
 	db.Lock()
-	update(db.mt.maxVersion)
+	// In read only mode, we do not create new mem table.
+	if !db.opt.ReadOnly {
+		update(db.mt.maxVersion)
+	}
 	for _, mt := range db.imm {
 		update(mt.maxVersion)
 	}

--- a/db.go
+++ b/db.go
@@ -299,8 +299,7 @@ func Open(opt Options) (*DB, error) {
 	}
 
 	if !db.opt.ReadOnly {
-		db.mt, err = db.newMemTable()
-		if err != nil {
+		if db.mt, err = db.newMemTable(); err != nil {
 			return nil, y.Wrapf(err, "cannot create memtable")
 		}
 	}
@@ -1359,7 +1358,7 @@ func (db *DB) KeySplits(prefix []byte) []string {
 		for _, mt := range memTables {
 			mtSplits(mt)
 		}
-		if !db.opt.ReadOnly {
+		if db.mt != nil {
 			mtSplits(db.mt)
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -360,7 +360,6 @@ func Open(opt Options) (*DB, error) {
 }
 
 func (db *DB) MaxVersion() uint64 {
-	return 0
 	var maxVersion uint64
 	update := func(a uint64) {
 		if a > maxVersion {

--- a/db.go
+++ b/db.go
@@ -509,7 +509,7 @@ func (db *DB) close() (err error) {
 	// and remove them completely, while the block / memtable writer is still
 	// trying to push stuff into the memtable. This will also resolve the value
 	// offset problem: as we push into memtable, we update value offsets there.
-	if !db.mt.sl.Empty() {
+	if !db.opt.ReadOnly && !db.mt.sl.Empty() {
 		db.opt.Debugf("Flushing memtable")
 		for {
 			pushedFlushTask := func() bool {
@@ -538,6 +538,7 @@ func (db *DB) close() (err error) {
 	db.stopMemoryFlush()
 	db.stopCompactions()
 
+	// Delete the mem table if not already deleted.
 	if db.mt != nil {
 		db.mt.DecrRef()
 	}

--- a/db.go
+++ b/db.go
@@ -1359,7 +1359,9 @@ func (db *DB) KeySplits(prefix []byte) []string {
 		for _, mt := range memTables {
 			mtSplits(mt)
 		}
-		mtSplits(db.mt)
+		if !db.opt.ReadOnly {
+			mtSplits(db.mt)
+		}
 	}
 
 	sort.Strings(splits)

--- a/db_test.go
+++ b/db_test.go
@@ -2232,7 +2232,6 @@ func TestOpenDBReadOnly(t *testing.T) {
 					require.Equal(t, mp[string(item.Key())], val)
 					return nil
 				}))
-				// require.Equal(t, item.Value(nil), mp[string(item.Key())])
 				count++
 			}
 			return nil

--- a/db_test.go
+++ b/db_test.go
@@ -2199,7 +2199,7 @@ func TestOpenDBReadOnly(t *testing.T) {
 	ops := getTestOptions(dir)
 	ops.ReadOnly = false
 	db, err := Open(ops)
-
+	require.NoError(t, err)
 	// Add bunch of entries that go into value log.
 	require.NoError(t, db.Update(func(txn *Txn) error {
 		val := make([]byte, db.opt.ValueThreshold+10)
@@ -2211,7 +2211,6 @@ func TestOpenDBReadOnly(t *testing.T) {
 		}
 		return nil
 	}))
-	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
 	ops.ReadOnly = true

--- a/db_test.go
+++ b/db_test.go
@@ -2187,3 +2187,24 @@ func TestUpdateMaxCost(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(4<<20), cost)
 }
+
+func TestOpenDB(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ops := getTestOptions(dir)
+	ops.ReadOnly = false
+	db, err := Open(ops)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	ops.ReadOnly = true
+	db, err = Open(ops)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db, err = Open(ops)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/go.sum
+++ b/go.sum
@@ -15,10 +15,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20201020115802-f071429c1049 h1:lT8vahI6E7R84KeSsXvj3QST/OusCP8g5rEctzsjUIA=
-github.com/dgraph-io/ristretto v0.0.4-0.20201020115802-f071429c1049/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
-github.com/dgraph-io/ristretto v0.0.4-0.20201022105248-f32a01612740 h1:TzbxnxH3PoFUWx5024RX1+uqLnUVbfdHANjrHMb5Xnc=
-github.com/dgraph-io/ristretto v0.0.4-0.20201022105248-f32a01612740/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
+github.com/dgraph-io/ristretto v0.0.4-0.20201023213945-72c2139ec27f h1:YPDUnM9Rkd0V41Ie43v/QoNgz5NNGcZv05UnYEnQgo4=
+github.com/dgraph-io/ristretto v0.0.4-0.20201023213945-72c2139ec27f/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -66,7 +64,6 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/value.go
+++ b/value.go
@@ -561,7 +561,7 @@ func (vlog *valueLog) open(db *DB) error {
 		return err
 	}
 	// If no files are found, then create a new file.
-	if len(vlog.filesMap) == 0 {
+	if len(vlog.filesMap) == 0 && !vlog.opt.ReadOnly {
 		_, err := vlog.createVlogFile()
 		return y.Wrapf(err, "Error while creating log file in valueLog.open")
 	}
@@ -584,6 +584,9 @@ func (vlog *valueLog) open(db *DB) error {
 		}
 	}
 
+	if vlog.opt.ReadOnly {
+		return nil
+	}
 	// Now we can read the latest value log file, and see if it needs truncation. We could
 	// technically do this over all the value log files, but that would mean slowing down the value
 	// log open.

--- a/value.go
+++ b/value.go
@@ -897,7 +897,7 @@ func (vlog *valueLog) getFileRLocked(vp valuePointer) (*logFile, error) {
 
 	// Check for valid offset if we are reading from writable log.
 	maxFid := vlog.maxFid
-	if vp.Fid == maxFid {
+	if vp.Fid == maxFid && !vlog.opt.ReadOnly {
 		currentOffset := vlog.woffset()
 		if vp.Offset >= currentOffset {
 			return nil, errors.Errorf(

--- a/value_test.go
+++ b/value_test.go
@@ -663,7 +663,7 @@ func TestReadOnlyOpenWithPartialAppendToWAL(t *testing.T) {
 		{Key: k2, Value: v2},
 	})
 	buf = buf[:offset-6]
-	require.NoError(t, ioutil.WriteFile(vlogFilePath(dir, 1), buf, 0777))
+	require.NoError(t, ioutil.WriteFile(kv.mtFilePath(1), buf, 0777))
 
 	opts.ReadOnly = true
 	// Badger should fail a read-only open with values to replay


### PR DESCRIPTION
When db is opened in read-only mode, we should not create/truncate memtables or wal files. This PR addresses that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1565)
<!-- Reviewable:end -->
