### PR TITLE
Added fuzzer for KeySplits

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,26 @@
+package badger
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// FuzzKeySplits implements the fuzzer
+func FuzzKeySplits(data []byte) int {
+	// We first do initial setup
+	dir, err := ioutil.TempDir(".", "badger-test")
+	defer os.RemoveAll(dir)
+	if err != nil {
+		return -1
+	}
+	opts := DefaultOptions("").WithInMemory(true).WithLoggingLevel(ERROR)
+	db, err := Open(opts)
+	defer db.Close()
+	if err != nil {
+		return -1
+	}
+
+	// Here we fuzz KeySplits
+	_ = db.KeySplits(data)
+	return 1
+}


### PR DESCRIPTION
I have written a fuzzer for `KeySplits `and thought I would see if fuzzing is something that would be desirable to have in the upstream repo.

If it is, I would be happy to contribute more work on fuzzing badger. In case you have had any troubled areas in the code or you consider some parts to be valuable to fuzz, I ask you kindly to let me know, and I will look into it.

If you would like to proceed with fuzzing, a possibility is also to setup continuous fuzzing to make sure that the fuzzers run periodically and to make sure new code gets fuzzed as well. I would not recommend fuzzing only `KeySplits` continuously, as I estimate there is not enough to get from it alone. Rather, fuzzing it manually on occasion and building up a corpus for later use would be a good first step.

Again, I will happily look into fuzzing other parts of badger as well as work on setting up continuous fuzzing.

Some things to consider at this point are:
- Is documentation needed for fuzzing? For example how to run the fuzzer locally. If so, where should that be? Adding it as comments in `fuzz.go` is an option.
- Should the fuzzer be placed in the root directory or something along the lines of `/fuzzing/fuzz.go`. I recommend placing all the fuzzers in `fuzz.go` for now, as it will take some time before so many fuzzers get written that they need to get distributed into different directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1567)
<!-- Reviewable:end -->
