### PR TITLE
chore(vlog): remove replay closer while opening vlog

### DIFF
--- a/db.go
+++ b/db.go
@@ -334,14 +334,9 @@ func Open(opt Options) (*DB, error) {
 	db.orc.nextTxnTs = db.MaxVersion()
 	db.opt.Infof("Set nextTxnTs to %d", db.orc.nextTxnTs)
 
-	replayCloser := z.NewCloser(1)
-	go db.doWrites(replayCloser)
-
 	if err = db.vlog.open(db); err != nil {
-		replayCloser.SignalAndWait()
 		return db, y.Wrapf(err, "During db.vlog.open")
 	}
-	replayCloser.SignalAndWait() // Wait for replay to be applied first.
 
 	// Let's advance nextTxnTs to one more than whatever we observed via
 	// replaying the logs.


### PR DESCRIPTION
We do not replay the vlog files now, and hence do not write anything while opening vlog. This PR removes that unnecessary code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1568)
<!-- Reviewable:end -->
