### PR TITLE
fix(tests): Writebatch, Stream, Vlog tests

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -364,7 +364,8 @@ func runTest(cmd *cobra.Command, args []string) error {
 		WithNumVersionsToKeep(int(math.MaxInt32)).
 		WithValueThreshold(1). // Make all values go to value log
 		WithCompression(options.ZSTD).
-		WithBlockCacheSize(10 << 20)
+		WithBlockCacheSize(10 << 20).
+		WithIndexCacheSize(10 << 20)
 
 	if verbose {
 		opts = opts.WithLoggingLevel(badger.DEBUG)

--- a/db.go
+++ b/db.go
@@ -251,7 +251,7 @@ func Open(opt Options) (*DB, error) {
 
 	if opt.IndexCacheSize > 0 {
 		// Index size is around 5% of the table size.
-		indexSz := int64(float64(opt.BaseTableSize) * 0.05)
+		indexSz := int64(float64(opt.MemTableSize) * 0.05)
 		numInCache := opt.IndexCacheSize / indexSz
 		if numInCache == 0 {
 			// Make the value of this variable at least one since the cache requires

--- a/db_test.go
+++ b/db_test.go
@@ -67,6 +67,7 @@ func (s *DB) validate() error { return s.lc.validate() }
 
 func getTestOptions(dir string) Options {
 	opt := DefaultOptions(dir).
+		WithMemTableSize(1 << 15).
 		WithBaseTableSize(1 << 15). // Force more compaction.
 		WithBaseLevelSize(4 << 15). // Force more compaction.
 		WithSyncWrites(false)

--- a/levels_test.go
+++ b/levels_test.go
@@ -55,8 +55,10 @@ func createAndOpen(db *DB, td []keyValVersion, level int) {
 	}); err != nil {
 		panic(err)
 	}
+	db.lc.levels[level].Lock()
 	// Add table to the given level.
 	db.lc.levels[level].tables = append(db.lc.levels[level].tables, tab)
+	db.lc.levels[level].Unlock()
 }
 
 type keyValVersion struct {

--- a/memtable.go
+++ b/memtable.go
@@ -88,6 +88,7 @@ func (db *DB) openMemTables(opt Options) error {
 		// If this memtable is empty we don't need to add it. This is a
 		// memtable that was completely truncated.
 		if mt.sl.Empty() {
+			mt.DecrRef()
 			continue
 		}
 		// These should no longer be written to. So, make them part of the imm.

--- a/memtable.go
+++ b/memtable.go
@@ -85,6 +85,11 @@ func (db *DB) openMemTables(opt Options) error {
 		if err != nil {
 			return y.Wrapf(err, "while opening fid: %d", fid)
 		}
+		// If this memtable is empty we don't need to add it. This is a
+		// memtable that was completely truncated.
+		if mt.sl.Empty() {
+			continue
+		}
 		// These should no longer be written to. So, make them part of the imm.
 		db.imm = append(db.imm, mt)
 	}

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -354,10 +354,8 @@ func TestStreamWriter6(t *testing.T) {
 		tables := db.Tables()
 		require.Equal(t, 3, len(tables), "Count of tables not matching")
 		for _, tab := range tables {
-			if tab.Level > 0 {
-				require.Equal(t, keyCount, int(tab.KeyCount),
-					fmt.Sprintf("failed for level: %d", tab.Level))
-			}
+			require.Equal(t, keyCount, int(tab.KeyCount),
+				fmt.Sprintf("failed for level: %d", tab.Level))
 		}
 		require.NoError(t, db.Close())
 		db, err := Open(db.opt)

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -325,16 +325,23 @@ func TestStreamWriter5(t *testing.T) {
 func TestStreamWriter6(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
 		list := &pb.KVList{}
-		str := []string{"a", "a", "b", "b", "c", "c"}
-		ver := 1
+		str := []string{"a", "b", "c"}
+		ver := uint64(0)
+		// The baseTable size is 32 KB (1<<15) and the max table size for level
+		// 6 table is 1 mb (look at newWrite function). Since all the tables
+		// will be written to level 6, we need to insert at least 1 mb of data.
+		// Setting keycount below 32 would cause this test to fail.
+		keyCount := 40
 		for i := range str {
-			kv := &pb.KV{
-				Key:     bytes.Repeat([]byte(str[i]), int(db.opt.BaseTableSize)),
-				Value:   []byte("val"),
-				Version: uint64(ver),
+			for j := 0; j < keyCount; j++ {
+				ver++
+				kv := &pb.KV{
+					Key:     bytes.Repeat([]byte(str[i]), int(db.opt.BaseTableSize)),
+					Value:   []byte("val"),
+					Version: uint64(keyCount - j),
+				}
+				list.Kv = append(list.Kv, kv)
 			}
-			list.Kv = append(list.Kv, kv)
-			ver = (ver + 1) % 2
 		}
 
 		// list has 3 pairs for equal keys. Since each Key has size equal to MaxTableSize
@@ -348,10 +355,8 @@ func TestStreamWriter6(t *testing.T) {
 		require.Equal(t, 3, len(tables), "Count of tables not matching")
 		for _, tab := range tables {
 			if tab.Level > 0 {
-				require.Equal(t, 2, int(tab.KeyCount),
+				require.Equal(t, keyCount, int(tab.KeyCount),
 					fmt.Sprintf("failed for level: %d", tab.Level))
-			} else {
-				require.Equal(t, 1, int(tab.KeyCount)) // level 0 table will have head key
 			}
 		}
 		require.NoError(t, db.Close())

--- a/value.go
+++ b/value.go
@@ -798,9 +798,9 @@ func (vlog *valueLog) write(reqs []*request) error {
 
 		n := uint32(buf.Len())
 		endOffset := atomic.AddUint32(&vlog.writableLogOffset, n)
+		// Increase the file size if we cannot accommodate this entry.
 		if int(endOffset) >= len(curlf.Data) {
 			curlf.Truncate(int64(endOffset))
-			// return y.Wrapf(ErrTxnTooBig, "endOffset: %d len: %d\n", endOffset, len(curlf.Data))
 		}
 
 		start := int(endOffset - n)

--- a/value.go
+++ b/value.go
@@ -850,7 +850,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 			var p valuePointer
 
 			p.Fid = curlf.fid
-			p.Offset = vlog.woffset()
+			p.Offset = vlog.woffset() + uint32(buf.Len())
 
 			// We should not store transaction marks in the vlog file because it will never have all
 			// the entries in a transaction. If we store entries with transaction marks then value

--- a/value.go
+++ b/value.go
@@ -842,7 +842,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 			var p valuePointer
 
 			p.Fid = curlf.fid
-			p.Offset = vlog.woffset() + uint32(buf.Len())
+			p.Offset = vlog.woffset()
 
 			// We should not store transaction marks in the vlog file because it will never have all
 			// the entries in a transaction. If we store entries with transaction marks then value

--- a/value.go
+++ b/value.go
@@ -791,9 +791,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 		}
 	}()
 
-	var buf bytes.Buffer
-	var numEntriesToWrite uint32
-	write := func() error {
+	write := func(buf *bytes.Buffer) error {
 		if buf.Len() == 0 {
 			return nil
 		}
@@ -807,41 +805,44 @@ func (vlog *valueLog) write(reqs []*request) error {
 		start := int(endOffset - n)
 		y.AssertTrue(copy(curlf.Data[start:], buf.Bytes()) == int(n))
 
-		y.NumWrites.Add(int64(numEntriesToWrite))
-		y.NumBytesWritten.Add(int64(buf.Len()))
-
-		vlog.numEntriesWritten += uint32(numEntriesToWrite)
 		atomic.StoreUint32(&curlf.size, endOffset)
-		buf.Reset()
 		return nil
 	}
 
-	toDisk := func() error {
-		newSize := vlog.woffset() + uint32(buf.Len())
-		newCount := vlog.numEntriesWritten + numEntriesToWrite
-		// Create a new file if the current file doesn't have enough space to write buf.
-		if newSize > uint32(vlog.opt.ValueLogFileSize) ||
-			newCount > vlog.opt.ValueLogMaxEntries {
-			if err := curlf.doneWriting(vlog.woffset()); err != nil {
-				return err
-			}
-
-			newlf, err := vlog.createVlogFile()
-			if err != nil {
-				return err
-			}
-			curlf = newlf
-		}
-		if err := write(); err != nil {
+	newLogFile := func() error {
+		if err := curlf.doneWriting(vlog.woffset()); err != nil {
 			return err
 		}
+
+		newlf, err := vlog.createVlogFile()
+		if err != nil {
+			return err
+		}
+		curlf = newlf
+		return nil
+	}
+	toDisk := func() error {
+		if vlog.woffset() > uint32(vlog.opt.ValueLogFileSize) ||
+			vlog.numEntriesWritten > vlog.opt.ValueLogMaxEntries {
+			newLogFile()
+		}
 		return nil
 	}
 
+	buf := new(bytes.Buffer)
 	for i := range reqs {
 		b := reqs[i]
 		b.Ptrs = b.Ptrs[:0]
+		var written, bytesWritten int
+		newSz := int64(estimateRequestSize(b)) + int64(vlog.woffset())
+		newCount := uint32(len(b.Entries)) + vlog.numEntriesWritten
+		// Create a new file if the next transaction cannot fit into the current log file.
+		if newSz > vlog.db.opt.ValueLogFileSize || newCount > vlog.opt.ValueLogMaxEntries {
+			newLogFile()
+		}
 		for j := range b.Entries {
+			buf.Reset()
+
 			e := b.Entries[j]
 			if vlog.db.opt.skipVlog(e) {
 				b.Ptrs = append(b.Ptrs, valuePointer{})
@@ -859,7 +860,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 			// in a temporary variable and reassign it after writing to the value log.
 			tmpMeta := e.meta
 			e.meta = e.meta &^ (bitTxn | bitFinTxn)
-			plen, err := curlf.encodeEntry(&buf, e, p.Offset) // Now encode the entry into buffer.
+			plen, err := curlf.encodeEntry(buf, e, p.Offset) // Now encode the entry into buffer.
 			if err != nil {
 				return err
 			}
@@ -868,10 +869,18 @@ func (vlog *valueLog) write(reqs []*request) error {
 
 			p.Len = uint32(plen)
 			b.Ptrs = append(b.Ptrs, p)
-			numEntriesToWrite++
+			if err := write(buf); err != nil {
+				return err
+			}
+			written++
+			bytesWritten += buf.Len()
+
 			// No need to flush anything, we write to file directly via mmap.
 		}
+		y.NumWrites.Add(int64(written))
+		y.NumBytesWritten.Add(int64(bytesWritten))
 
+		vlog.numEntriesWritten += uint32(written)
 		// We write to disk here so that all entries that are part of the same transaction are
 		// written to the same vlog file.
 		if err := toDisk(); err != nil {

--- a/value_test.go
+++ b/value_test.go
@@ -960,6 +960,7 @@ func BenchmarkReadWrite(b *testing.B) {
 }
 
 // Regression test for https://github.com/dgraph-io/badger/issues/817
+// This test verifies if fully corrupted memtables are deleted on reopen.
 func TestValueLogTruncate(t *testing.T) {
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)

--- a/value_test.go
+++ b/value_test.go
@@ -428,15 +428,14 @@ func TestValueGC4(t *testing.T) {
 }
 
 func TestPersistLFDiscardStats(t *testing.T) {
-	// TODO(ibrahim): This test is failing because compactions are not
-	// happening and so no discard stats are generated.
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
+	// Force more compaction by reducing the number of L0 tables.
 	opt.NumLevelZeroTables = 1
 	opt.ValueLogFileSize = 1 << 20
-	// avoid compaction on close, so that discard map remains same
+	// Avoid compaction on close so that the discard map remains the same.
 	opt.CompactL0OnClose = false
 
 	db, err := Open(opt)

--- a/value_test.go
+++ b/value_test.go
@@ -430,11 +430,11 @@ func TestValueGC4(t *testing.T) {
 func TestPersistLFDiscardStats(t *testing.T) {
 	// TODO(ibrahim): This test is failing because compactions are not
 	// happening and so no discard stats are generated.
-	t.Skip()
 	dir, err := ioutil.TempDir("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
+	opt.NumLevelZeroTables = 1
 	opt.ValueLogFileSize = 1 << 20
 	// avoid compaction on close, so that discard map remains same
 	opt.CompactL0OnClose = false


### PR DESCRIPTION
This PR fixes the following issues/tests
 - Deadlock in writes batch - Use atomic to set value of `writebatch.error`
 - Vlog Truncate test - Fix issues with empty memtables
 - Test options - Set memtable size.
 - Compaction tests - Acquire lock before updating level tables
 - Vlog Write - Truncate the file size if the transaction cannot fit in vlog size
 - TestPersistLFDiscardStats - Set numLevelZeroTables=1 to force compaction.

This PR also fixes the failing bank test by adding an index cache to bank test.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1577)
<!-- Reviewable:end -->
