### PR TITLE
Fix StreamWriter test

### DIFF
--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -372,7 +372,7 @@ func TestStreamWriterCancel(t *testing.T) {
 		ver := 1
 		for i := range str {
 			kv := &pb.KV{
-				Key:     bytes.Repeat([]byte(str[i]), int(db.opt.MaxTableSize)),
+				Key:     bytes.Repeat([]byte(str[i]), int(db.opt.BaseTableSize)),
 				Value:   []byte("val"),
 				Version: uint64(ver),
 			}


### PR DESCRIPTION
`TestStreamWriterCancel` needs to use `opt.BaseTableSize` to work with the latest master branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1578)
<!-- Reviewable:end -->
