### PR TITLE
test: Fix tests running in CI.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,9 @@ set -e
 
 go version
 
+# Run `go list` BEFORE setting GOFLAGS so that the output is in the right
+# format for grep.
+packages=$(go list ./... | grep github.com/dgraph-io/badger/v2/)
 
 if [[ ! -z "$TEAMCITY_VERSION" ]]; then
   export GOFLAGS="-json"
@@ -43,7 +46,6 @@ InstallJemalloc
 
 # Run the memory intensive tests first.
 manual() {
-  packages=$(go list ./... | grep github.com/dgraph-io/badger/v2/)
   echo "==> Running package tests for $packages"
   set -e
   for pkg in $packages; do


### PR DESCRIPTION
Run `go list` BEFORE setting `GOFLAGS="-json"` so that the output is in the right
format for grep. Otherwise, this error happens:

    ===> Testing "github.com/dgraph-io/badger/v2/options",
    go: finding module for package "github.com/dgraph-io/badger/v2/options",
    can't load package: package "github.com/dgraph-io/badger/v2/options",: malformed module path "\"github.com/dgraph-io/badger/v2/options\",": invalid char '"'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1581)
<!-- Reviewable:end -->
