### PR TITLE
fix(test): Run tests in sub-packages also

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,8 @@ go version
 
 # Run `go list` BEFORE setting GOFLAGS so that the output is in the right
 # format for grep.
-packages=$(go list ./... | grep github.com/dgraph-io/badger/v2/)
+# export packages because the test will run in a sub process.
+export packages=$(go list ./... | grep "github.com/dgraph-io/badger/v2/")
 
 if [[ ! -z "$TEAMCITY_VERSION" ]]; then
   export GOFLAGS="-json"


### PR DESCRIPTION
The parallel command runs in function in a sub process and the `packages`
variable declared at the start of the file wouldn't be visible to the sub process unless exported.

This PR exports the `packages` variable so that it's visible to the child process as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1583)
<!-- Reviewable:end -->
