### PR TITLE
chore(cmd/bank): Clean up Badger options.

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/dgraph-io/badger/v2/options"
 	"github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/badger/v2/y"
 	"github.com/spf13/cobra"
@@ -355,15 +354,10 @@ func runTest(cmd *cobra.Command, args []string) error {
 	// Open DB
 	opts := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithBaseTableSize(4 << 20). // Force more compactions.
-		WithNumLevelZeroTables(2).
-		WithNumMemtables(2).
-		// Do not GC any versions, because we need them for the disect..
+		// Do not GC any versions, because we need them for the disect.
 		WithNumVersionsToKeep(int(math.MaxInt32)).
-		WithValueThreshold(1). // Make all values go to value log
-		WithCompression(options.ZSTD).
-		WithBlockCacheSize(10 << 20).
-		WithIndexCacheSize(10 << 20)
+		WithBlockCacheSize(1 << 30).
+		WithIndexCacheSize(1 << 30)
 
 	if verbose {
 		opts = opts.WithLoggingLevel(badger.DEBUG)


### PR DESCRIPTION
* No need to set most of these options
* Remove Compression setting (use Snappy compression by default)
* Set BlockCache and IndexCache to 1 GB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1584)
<!-- Reviewable:end -->
