### PR TITLE
fix: Disable CompactL0OnClose by default

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -342,7 +342,8 @@ func TestForceCompactL0(t *testing.T) {
 	require.NoError(t, err)
 	defer removeDir(dir)
 
-	opts := getTestOptions(dir)
+	// This test relies on CompactL0OnClose
+	opts := getTestOptions(dir).WithCompactL0OnClose(true)
 	opts.ValueLogFileSize = 15 << 20
 	opts.managedTxns = true
 	db, err := Open(opts)

--- a/merge_test.go
+++ b/merge_test.go
@@ -115,7 +115,8 @@ func TestGetMergeOperator(t *testing.T) {
 		require.NoError(t, err)
 		defer removeDir(dir)
 
-		opts := getTestOptions(dir)
+		// This test relies on CompactL0OnClose
+		opts := getTestOptions(dir).WithCompactL0OnClose(true)
 		db, err := Open(opts)
 		require.NoError(t, err)
 		mergeKey := []byte("foo")

--- a/options.go
+++ b/options.go
@@ -130,7 +130,7 @@ func DefaultOptions(path string) Options {
 		BlockSize:               4 * 1024,
 		SyncWrites:              false,
 		NumVersionsToKeep:       1,
-		CompactL0OnClose:        true,
+		CompactL0OnClose:        false,
 		VerifyValueChecksum:     false,
 		Compression:             options.Snappy,
 		BlockCacheSize:          256 << 20,
@@ -425,10 +425,9 @@ func (opt Options) WithNumCompactors(val int) Options {
 }
 
 // WithCompactL0OnClose determines whether Level 0 should be compacted before closing the DB.  This
-// ensures that both reads and writes are efficient when the DB is opened later.  CompactL0OnClose
-// is set to true if KeepL0InMemory is set to true.
+// ensures that both reads and writes are efficient when the DB is opened later.
 //
-// The default value of CompactL0OnClose is true.
+// The default value of CompactL0OnClose is false.
 func (opt Options) WithCompactL0OnClose(val bool) Options {
 	opt.CompactL0OnClose = val
 	return opt


### PR DESCRIPTION
`CompactL0OnClose` was messing up the in-memory tree structure, so this PR disables it by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1586)
<!-- Reviewable:end -->
