### PR TITLE
Use AllocatorPool in Stream and TableBuilder

### DIFF
--- a/badger/main.go
+++ b/badger/main.go
@@ -49,7 +49,6 @@ func main() {
 	z.Free(out)
 
 	cmd.Execute()
-	z.Done()
 	fmt.Printf("Num Allocated Bytes at program end: %s\n",
 		humanize.IBytes(uint64(z.NumAllocBytes())))
 	if z.NumAllocBytes() > 0 {

--- a/db_test.go
+++ b/db_test.go
@@ -533,7 +533,7 @@ func TestGetMore(t *testing.T) {
 		data := func(i int) []byte {
 			return []byte(fmt.Sprintf("%b", i))
 		}
-		n := 500000
+		n := 200000
 		m := 45 // Increasing would cause ErrTxnTooBig
 		for i := 0; i < n; i += m {
 			if (i % 10000) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20201103012257-4dcfe40a6fc0
+	github.com/dgraph-io/ristretto v0.0.4-0.20201111175458-32c298273115
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20201111175458-32c298273115
+	github.com/dgraph-io/ristretto v0.0.4-0.20201111182457-692243ca43a9
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20201105000107-750f5be31aad
+	github.com/dgraph-io/ristretto v0.0.4-0.20201103012257-4dcfe40a6fc0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20201111182457-692243ca43a9
+	github.com/dgraph-io/ristretto v0.0.4-0.20201111190620-1040b7ded521
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20201105000107-750f5be31aad h1:BN2A+lqBwLx57/l1MUv3iKLIY8XddNkZg2zZN/BFM1I=
-github.com/dgraph-io/ristretto v0.0.4-0.20201105000107-750f5be31aad/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
+github.com/dgraph-io/ristretto v0.0.4-0.20201103012257-4dcfe40a6fc0 h1:5ZtQ7aGng65gFPo1sdoZI0pTpYjJDU4t+rIFFoWUOpc=
+github.com/dgraph-io/ristretto v0.0.4-0.20201103012257-4dcfe40a6fc0/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20201103012257-4dcfe40a6fc0 h1:5ZtQ7aGng65gFPo1sdoZI0pTpYjJDU4t+rIFFoWUOpc=
-github.com/dgraph-io/ristretto v0.0.4-0.20201103012257-4dcfe40a6fc0/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111175458-32c298273115 h1:FSEbw4McFiedWRiJ2xOka2TgVQyoM/k0FLB3vjGL8Jo=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111175458-32c298273115/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20201111182457-692243ca43a9 h1:P6HMrraCgiYsNbtsi8mt9PVYZiukR69JmQV0DQCrpEA=
-github.com/dgraph-io/ristretto v0.0.4-0.20201111182457-692243ca43a9/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111190620-1040b7ded521 h1:81yY9QfuVfSVccqD7cLA/JohhMX+TQCfSjmGS7jUJCc=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111190620-1040b7ded521/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20201111175458-32c298273115 h1:FSEbw4McFiedWRiJ2xOka2TgVQyoM/k0FLB3vjGL8Jo=
-github.com/dgraph-io/ristretto v0.0.4-0.20201111175458-32c298273115/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111182457-692243ca43a9 h1:P6HMrraCgiYsNbtsi8mt9PVYZiukR69JmQV0DQCrpEA=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111182457-692243ca43a9/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/options.go
+++ b/options.go
@@ -177,6 +177,7 @@ func buildTableOptions(db *DB) table.Options {
 		ZSTDCompressionLevel: opt.ZSTDCompressionLevel,
 		BlockCache:           db.blockCache,
 		IndexCache:           db.indexCache,
+		AllocPool:            db.allocPool,
 		DataKey:              dk,
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -216,6 +216,11 @@ func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
 
 		outList := new(pb.KVList)
 		outList.AllocRef = st.newAllocator(threadId).Ref
+		defer func() {
+			// We should free up the last outList that sendIt function creates.
+			y.AssertTrue(len(outList.Kv) == 0)
+			z.AllocatorFrom(outList.AllocRef).Release()
+		}()
 
 		sendIt := func() error {
 			select {

--- a/stream.go
+++ b/stream.go
@@ -309,6 +309,13 @@ func (st *Stream) streamKVs(ctx context.Context) error {
 	defer t.Stop()
 	now := time.Now()
 
+	var allocs []*z.Allocator
+	defer func() {
+		for _, a := range allocs {
+			a.Release()
+		}
+	}()
+
 	sendBatch := func(batch *pb.KVList) error {
 		sz := uint64(proto.Size(batch))
 		bytesSent += sz
@@ -320,6 +327,10 @@ func (st *Stream) streamKVs(ctx context.Context) error {
 		st.db.opt.Infof("%s Created batch of size: %s in %s.\n",
 			st.LogPrefix, humanize.Bytes(sz), time.Since(t))
 
+		for _, a := range allocs {
+			a.Release()
+		}
+		allocs = allocs[:0]
 		return nil
 	}
 
@@ -340,6 +351,7 @@ func (st *Stream) streamKVs(ctx context.Context) error {
 				}
 				y.AssertTrue(kvs != nil)
 				batch.Kv = append(batch.Kv, kvs.Kv...)
+				allocs = append(allocs, z.AllocatorFrom(kvs.AllocRef))
 
 			default:
 				break loop
@@ -372,6 +384,7 @@ outer:
 			}
 			y.AssertTrue(kvs != nil)
 			batch = kvs
+			allocs = append(allocs, z.AllocatorFrom(kvs.AllocRef))
 
 			// Otherwise, slurp more keys into this batch.
 			if err := slurp(batch); err != nil {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -270,6 +270,7 @@ func (sw *StreamWriter) Cancel() {
 type sortedWriter struct {
 	db       *DB
 	throttle *y.Throttle
+	opts     table.Options
 
 	builder  *table.Builder
 	lastKey  []byte
@@ -286,6 +287,7 @@ func (sw *StreamWriter) newWriter(streamID uint32) (*sortedWriter, error) {
 	}
 	w := &sortedWriter{
 		db:       sw.db,
+		opts:     bopts,
 		streamID: streamID,
 		throttle: sw.throttle,
 		builder:  table.NewTableBuilder(bopts),
@@ -379,8 +381,7 @@ func (w *sortedWriter) send(done bool) error {
 		return nil
 	}
 
-	bopts := buildTableOptions(w.db)
-	w.builder = table.NewTableBuilder(bopts)
+	w.builder = table.NewTableBuilder(w.opts)
 	return nil
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -80,6 +80,8 @@ type Options struct {
 	BlockCache *ristretto.Cache
 	IndexCache *ristretto.Cache
 
+	AllocPool *z.AllocatorPool
+
 	// ZSTDCompressionLevel is the ZSTD compression level used for compressing blocks.
 	ZSTDCompressionLevel int
 }
@@ -241,12 +243,12 @@ func CreateTable(fname string, builder *Builder) (*Table, error) {
 
 	written := bd.Copy(mf.Data)
 	y.AssertTrue(written == len(mf.Data))
-	if builder.opt.SyncWrites {
+	if builder.opts.SyncWrites {
 		if err := z.Msync(mf.Data); err != nil {
 			return nil, y.Wrapf(err, "while calling msync on %s", fname)
 		}
 	}
-	return OpenTable(mf, *builder.opt)
+	return OpenTable(mf, *builder.opts)
 }
 
 // OpenTable assumes file has only one table and opens it. Takes ownership of fd upon function

--- a/test.sh
+++ b/test.sh
@@ -48,6 +48,7 @@ InstallJemalloc
 
 # Run the memory intensive tests first.
 manual() {
+  timeout="-timeout 2m"
   echo "==> Running package tests for $packages"
   set -e
   for pkg in $packages; do
@@ -60,10 +61,10 @@ manual() {
   # Run the special Truncate test.
   rm -rf p
   set -e
-  go test $tags -run='TestTruncateVlogNoClose$' --manual=true
+  go test $tags $timeout -run='TestTruncateVlogNoClose$' --manual=true
   truncate --size=4096 p/000000.vlog
-  go test $tags -run='TestTruncateVlogNoClose2$' --manual=true
-  go test $tags -run='TestTruncateVlogNoClose3$' --manual=true
+  go test $tags $timeout -run='TestTruncateVlogNoClose2$' --manual=true
+  go test $tags $timeout -run='TestTruncateVlogNoClose3$' --manual=true
   rm -rf p
 
   # TODO(ibrahim): Let's make these tests have Manual prefix.
@@ -72,14 +73,14 @@ manual() {
   # TestValueGCManaged
   # TestDropPrefix
   # TestDropAllManaged
-  go test $tags -run='TestBigKeyValuePairs$' --manual=true
-  go test $tags -run='TestPushValueLogLimit' --manual=true
-  go test $tags -run='TestKeyCount' --manual=true
-  go test $tags -run='TestIteratePrefix' --manual=true
-  go test $tags -run='TestIterateParallel' --manual=true
-  go test $tags -run='TestBigStream' --manual=true
-  go test $tags -run='TestGoroutineLeak' --manual=true
-  go test $tags -run='TestGetMore' --manual=true
+  go test $tags $timeout -run='TestBigKeyValuePairs$' --manual=true
+  go test $tags $timeout -run='TestPushValueLogLimit' --manual=true
+  go test $tags $timeout -run='TestKeyCount' --manual=true
+  go test $tags $timeout -run='TestIteratePrefix' --manual=true
+  go test $tags $timeout -run='TestIterateParallel' --manual=true
+  go test $tags $timeout -run='TestBigStream' --manual=true
+  go test $tags $timeout -run='TestGoroutineLeak' --manual=true
+  go test $tags $timeout -run='TestGetMore' --manual=true
 
   echo "==> DONE manual tests"
 }
@@ -90,7 +91,7 @@ root() {
 
   echo "==> Running root level tests."
   set -e
-  go test $tags -timeout=25m . -race -parallel 16
+  go test $tags -timeout=25m . -v -race -parallel 16
   echo "==> DONE root level tests"
 }
 
@@ -105,6 +106,7 @@ stream() {
     echo "LEAK detected in Badger stream."
     return 1
   fi
+  echo "==> DONE stream test"
   return 0
 }
 


### PR DESCRIPTION
We removed the global z.Allocator pool from z package. Instead, we now use a new z.AllocatorPool class in the places which need a pool. In this case, we brought it to TableBuilder and Stream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1593)
<!-- Reviewable:end -->
