### PR TITLE
fix: Use AllocatorPool in Stream and TableBuilder

### DIFF
--- a/badger/main.go
+++ b/badger/main.go
@@ -49,7 +49,6 @@ func main() {
 	z.Free(out)
 
 	cmd.Execute()
-	z.Done()
 	fmt.Printf("Num Allocated Bytes at program end: %s\n",
 		humanize.IBytes(uint64(z.NumAllocBytes())))
 	if z.NumAllocBytes() > 0 {

--- a/db_test.go
+++ b/db_test.go
@@ -532,7 +532,7 @@ func TestGetMore(t *testing.T) {
 		data := func(i int) []byte {
 			return []byte(fmt.Sprintf("%b", i))
 		}
-		n := 500000
+		n := 200000
 		m := 45 // Increasing would cause ErrTxnTooBig
 		for i := 0; i < n; i += m {
 			if (i % 10000) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20201105000107-750f5be31aad
+	github.com/dgraph-io/ristretto v0.0.4-0.20201111190620-1040b7ded521
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20201105000107-750f5be31aad h1:BN2A+lqBwLx57/l1MUv3iKLIY8XddNkZg2zZN/BFM1I=
-github.com/dgraph-io/ristretto v0.0.4-0.20201105000107-750f5be31aad/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111190620-1040b7ded521 h1:81yY9QfuVfSVccqD7cLA/JohhMX+TQCfSjmGS7jUJCc=
+github.com/dgraph-io/ristretto v0.0.4-0.20201111190620-1040b7ded521/go.mod h1:bDI4cDaalvYSji3vBVDKrn9ouDZrwN974u8ZO/AhYXs=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/options.go
+++ b/options.go
@@ -177,6 +177,7 @@ func buildTableOptions(db *DB) table.Options {
 		ZSTDCompressionLevel: opt.ZSTDCompressionLevel,
 		BlockCache:           db.blockCache,
 		IndexCache:           db.indexCache,
+		AllocPool:            db.allocPool,
 		DataKey:              dk,
 	}
 }

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -270,6 +270,7 @@ func (sw *StreamWriter) Cancel() {
 type sortedWriter struct {
 	db       *DB
 	throttle *y.Throttle
+	opts     table.Options
 
 	builder  *table.Builder
 	lastKey  []byte
@@ -286,6 +287,7 @@ func (sw *StreamWriter) newWriter(streamID uint32) (*sortedWriter, error) {
 	}
 	w := &sortedWriter{
 		db:       sw.db,
+		opts:     bopts,
 		streamID: streamID,
 		throttle: sw.throttle,
 		builder:  table.NewTableBuilder(bopts),
@@ -379,8 +381,7 @@ func (w *sortedWriter) send(done bool) error {
 		return nil
 	}
 
-	bopts := buildTableOptions(w.db)
-	w.builder = table.NewTableBuilder(bopts)
+	w.builder = table.NewTableBuilder(w.opts)
 	return nil
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -80,6 +80,8 @@ type Options struct {
 	BlockCache *ristretto.Cache
 	IndexCache *ristretto.Cache
 
+	AllocPool *z.AllocatorPool
+
 	// ZSTDCompressionLevel is the ZSTD compression level used for compressing blocks.
 	ZSTDCompressionLevel int
 }
@@ -241,12 +243,12 @@ func CreateTable(fname string, builder *Builder) (*Table, error) {
 
 	written := bd.Copy(mf.Data)
 	y.AssertTrue(written == len(mf.Data))
-	if builder.opt.SyncWrites {
+	if builder.opts.SyncWrites {
 		if err := z.Msync(mf.Data); err != nil {
 			return nil, y.Wrapf(err, "while calling msync on %s", fname)
 		}
 	}
-	return OpenTable(mf, *builder.opt)
+	return OpenTable(mf, *builder.opts)
 }
 
 // OpenTable assumes file has only one table and opens it. Takes ownership of fd upon function

--- a/test.sh
+++ b/test.sh
@@ -36,17 +36,19 @@ function InstallJemalloc() {
   popd
 }
 
+tags="-tags=jemalloc"
+
 # Ensure that we can compile the binary.
 pushd badger
-go build -v .
+go build -v $tags .
 popd
 
-tags="-tags=jemalloc"
 # tags=""
 InstallJemalloc
 
 # Run the memory intensive tests first.
 manual() {
+  timeout="-timeout 2m"
   echo "==> Running package tests for $packages"
   set -e
   for pkg in $packages; do
@@ -59,10 +61,10 @@ manual() {
   # Run the special Truncate test.
   rm -rf p
   set -e
-  go test $tags -run='TestTruncateVlogNoClose$' --manual=true
+  go test $tags $timeout -run='TestTruncateVlogNoClose$' --manual=true
   truncate --size=4096 p/000000.vlog
-  go test $tags -run='TestTruncateVlogNoClose2$' --manual=true
-  go test $tags -run='TestTruncateVlogNoClose3$' --manual=true
+  go test $tags $timeout -run='TestTruncateVlogNoClose2$' --manual=true
+  go test $tags $timeout -run='TestTruncateVlogNoClose3$' --manual=true
   rm -rf p
 
   # TODO(ibrahim): Let's make these tests have Manual prefix.
@@ -71,14 +73,14 @@ manual() {
   # TestValueGCManaged
   # TestDropPrefix
   # TestDropAllManaged
-  go test $tags -run='TestBigKeyValuePairs$' --manual=true
-  go test $tags -run='TestPushValueLogLimit' --manual=true
-  go test $tags -run='TestKeyCount' --manual=true
-  go test $tags -run='TestIteratePrefix' --manual=true
-  go test $tags -run='TestIterateParallel' --manual=true
-  go test $tags -run='TestBigStream' --manual=true
-  go test $tags -run='TestGoroutineLeak' --manual=true
-  go test $tags -run='TestGetMore' --manual=true
+  go test $tags $timeout -run='TestBigKeyValuePairs$' --manual=true
+  go test $tags $timeout -run='TestPushValueLogLimit' --manual=true
+  go test $tags $timeout -run='TestKeyCount' --manual=true
+  go test $tags $timeout -run='TestIteratePrefix' --manual=true
+  go test $tags $timeout -run='TestIterateParallel' --manual=true
+  go test $tags $timeout -run='TestBigStream' --manual=true
+  go test $tags $timeout -run='TestGoroutineLeak' --manual=true
+  go test $tags $timeout -run='TestGetMore' --manual=true
 
   echo "==> DONE manual tests"
 }
@@ -89,11 +91,27 @@ root() {
 
   echo "==> Running root level tests."
   set -e
-  go test $tags -timeout=25m . -race -parallel 16
+  go test $tags -timeout=25m . -v -race -parallel 16
   echo "==> DONE root level tests"
 }
 
+stream() {
+  pushd badger
+  baseDir=$(mktemp -d -p .)
+  ./badger benchmark write -s --dir=$baseDir/test | tee $baseDir/log.txt
+  ./badger stream --dir=$baseDir/test -o "$baseDir/test2" | tee --append $baseDir/log.txt
+  count=$(cat "$baseDir/log.txt" | grep "at program end: 0 B" | wc -l)
+  rm -rf $baseDir
+  if [ $count -ne 2 ]; then
+    echo "LEAK detected in Badger stream."
+    return 1
+  fi
+  echo "==> DONE stream test"
+  return 0
+}
+
+export -f stream
 export -f manual
 export -f root
 
-parallel --halt now,fail=1 --progress --line-buffer ::: manual root
+parallel --halt now,fail=1 --progress --line-buffer ::: stream manual root


### PR DESCRIPTION
Cherry-pick of #1593 onto release/v3.2011.

We removed the global z.Allocator pool from z package. Instead, we now use a new z.AllocatorPool class in the places which need a pool. In this case, we brought it to TableBuilder and Stream.

Fix up a memory leak in Stream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1595)
<!-- Reviewable:end -->
