### PR TITLE
fix: change default checksum verification mode to OnTableRead

### DIFF
--- a/options.go
+++ b/options.go
@@ -122,19 +122,20 @@ func DefaultOptions(path string) Options {
 		LevelSizeMultiplier: 10,
 		MaxLevels:           7,
 
-		NumCompactors:           4, // Run at least 2 compactors. Zero-th compactor prioritizes L0.
-		NumLevelZeroTables:      5,
-		NumLevelZeroTablesStall: 15,
-		NumMemtables:            5,
-		BloomFalsePositive:      0.01,
-		BlockSize:               4 * 1024,
-		SyncWrites:              false,
-		NumVersionsToKeep:       1,
-		CompactL0OnClose:        false,
-		VerifyValueChecksum:     false,
-		Compression:             options.Snappy,
-		BlockCacheSize:          256 << 20,
-		IndexCacheSize:          0,
+		NumCompactors:            4, // Run at least 2 compactors. Zero-th compactor prioritizes L0.
+		NumLevelZeroTables:       5,
+		NumLevelZeroTablesStall:  15,
+		NumMemtables:             5,
+		BloomFalsePositive:       0.01,
+		BlockSize:                4 * 1024,
+		SyncWrites:               false,
+		NumVersionsToKeep:        1,
+		CompactL0OnClose:         false,
+		VerifyValueChecksum:      false,
+		ChecksumVerificationMode: options.OnTableRead,
+		Compression:              options.Snappy,
+		BlockCacheSize:           256 << 20,
+		IndexCacheSize:           0,
 
 		// The following benchmarks were done on a 4 KB block size (default block size). The
 		// compression is ratio supposed to increase with increasing compression level but since the


### PR DESCRIPTION
Currently, the `ChecksumVerificationMode` = `NoVerification` by default, this may cause panic in a running badger instance.
Sample panic (from DGRAPH-2694)
```
panic: runtime error: slice bounds out of range [:134219923] with capacity 4066

goroutine 254 [running]:
github.com/dgraph-io/badger/v2/table.(*blockIterator).setIdx(0xc000506350, 0x33)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/table/iterator.go:87 +0x535
github.com/dgraph-io/badger/v2/table.(*blockIterator).next(...)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/table/iterator.go:154
github.com/dgraph-io/badger/v2/table.(*Iterator).next(0xc000506340)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/table/iterator.go:322 +0x1b3
github.com/dgraph-io/badger/v2/table.(*Iterator).Next(0xc000506340)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/table/iterator.go:382 +0x3e
github.com/dgraph-io/badger/v2/table.(*ConcatIterator).Next(0xc00063a000)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/table/iterator.go:505 +0x33
github.com/dgraph-io/badger/v2/table.(*node).next(0xc0003f40f0)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/table/merge_iterator.go:81 +0x3d
github.com/dgraph-io/badger/v2/table.(*MergeIterator).Next(0xc0003f40b0)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/table/merge_iterator.go:157 +0x38
github.com/dgraph-io/badger/v2.(*levelsController).subcompact.func3(0xc00118a080)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/levels.go:646 +0x163
github.com/dgraph-io/badger/v2.(*levelsController).subcompact(0xc000194000, 0x1f1d140, 0xc0003f40b0, 0xc000632060, 0x18, 0x18, 0x2d6d0b8, 0x0, 0x0, 0x0, ...)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/levels.go:765 +0x548
github.com/dgraph-io/badger/v2.(*levelsController).compactBuildTables.func3(0xc0008161c0, 0xc000816180, 0xc000194000, 0xc000818ea0, 0xc0004f5080, 0xc000632060, 0x18, 0x18, 0x2d6d0b8, 0x0, ...)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/levels.go:868 +0x198
created by github.com/dgraph-io/badger/v2.(*levelsController).compactBuildTables
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201106140743-6c074551f8f5/levels.go:864 +0x628
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1599)
<!-- Reviewable:end -->
