### PR TITLE
compaction: reset value pointer

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -741,6 +741,7 @@ func (s *levelsController) subcompact(it y.Iterator, kr keyRange, cd compactDef,
 				vp.Decode(vs.Value)
 			}
 			builder.Add(it.Key(), vs, vp.Len)
+			vp.Fid, vp.Len, vp.Offset = 0, 0, 0
 		}
 		s.kv.opt.Debugf("LOG Compact. Added %d keys. Skipped %d keys. Iteration took: %v",
 			numKeys, numSkips, time.Since(timeStart).Round(time.Millisecond))


### PR DESCRIPTION
If a table has a mixture of value log pointers and embedded values, badger will carry over the last length from a value log entry into the subsequent embedded entries. I think this misestimates table size on compaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1601)
<!-- Reviewable:end -->
