### PR TITLE
Fix race condition in L0StallMs variable

### DIFF
--- a/db.go
+++ b/db.go
@@ -477,7 +477,7 @@ func (db *DB) IsClosed() bool {
 
 func (db *DB) close() (err error) {
 	db.opt.Debugf("Closing database")
-	db.opt.Infof("Lifetime L0 stalled for: %s\n", time.Duration(db.lc.l0stallsMs))
+	db.opt.Infof("Lifetime L0 stalled for: %s\n", time.Duration(atomic.LoadInt64(&db.lc.l0stallsMs)))
 
 	atomic.StoreInt32(&db.blockWrites, 1)
 

--- a/levels.go
+++ b/levels.go
@@ -41,13 +41,13 @@ import (
 
 type levelsController struct {
 	nextFileID uint64 // Atomic
+	l0stallsMs int64  // Atomic
 
 	// The following are initialized once and const.
 	levels []*levelHandler
 	kv     *DB
 
-	cstatus    compactStatus
-	l0stallsMs int64
+	cstatus compactStatus
 }
 
 // revertToManifest checks that all necessary table files exist and removes all table files not


### PR DESCRIPTION
This fixes two issues
- Atomic variable was not being accessed correctly
- Atomic variable should be first member of the struct to ensure proper alignment. Failure to do so will cause a segmentation fault.

Fixes DGRAPH-2773
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1605)
<!-- Reviewable:end -->
