### PR TITLE
Fix(OOM): Reuse pb.KVs in Stream

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -87,7 +87,8 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 
 			// clear txn bits
 			meta := item.meta &^ (bitTxn | bitFinTxn)
-			kv := &pb.KV{
+			kv := itr.NewKV()
+			*kv = pb.KV{
 				Key:       item.KeyCopy(nil),
 				Value:     valCopy,
 				UserMeta:  []byte{item.UserMeta()},

--- a/iterator.go
+++ b/iterator.go
@@ -483,7 +483,7 @@ func (txn *Txn) NewKeyIterator(key []byte, opt IteratorOptions) *Iterator {
 	return txn.NewIterator(opt)
 }
 
-// newKV must be called serially. It is NOT thread-safe.
+// NewKV must be called serially. It is NOT thread-safe.
 func (it *Iterator) NewKV() *pb.KV {
 	if len(it.reuse) == 0 {
 		return &pb.KV{}

--- a/iterator.go
+++ b/iterator.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/badger/v2/table"
 
 	"github.com/dgraph-io/badger/v2/y"
@@ -421,6 +422,8 @@ type Iterator struct {
 	// the iterator. It can be used, for example, to uniquely identify each of the
 	// iterators created by the stream interface
 	ThreadId int
+
+	reuse []*pb.KV
 }
 
 // NewIterator returns a new iterator. Depending upon the options, either only keys, or both
@@ -478,6 +481,20 @@ func (txn *Txn) NewKeyIterator(key []byte, opt IteratorOptions) *Iterator {
 	opt.prefixIsKey = true
 	opt.AllVersions = true
 	return txn.NewIterator(opt)
+}
+
+// newKV must be called serially. It is NOT thread-safe.
+func (it *Iterator) NewKV() *pb.KV {
+	if len(it.reuse) == 0 {
+		return &pb.KV{}
+	}
+	kv := it.reuse[len(it.reuse)-1]
+	it.reuse = it.reuse[:len(it.reuse)-1]
+	if kv == nil {
+		kv = &pb.KV{}
+	}
+	kv.Reset()
+	return kv
 }
 
 func (it *Iterator) newItem() *Item {

--- a/stream.go
+++ b/stream.go
@@ -110,7 +110,7 @@ func (st *Stream) ToList(key []byte, itr *Iterator) (*pb.KVList, error) {
 			break
 		}
 
-		kv := &pb.KV{}
+		kv := itr.NewKV()
 		kv.Key = ka
 
 		if err := item.Value(func(val []byte) error {
@@ -244,6 +244,9 @@ func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
 				if err := sendIt(); err != nil {
 					return err
 				}
+			}
+			if len(itr.reuse) < 100 {
+				itr.reuse = append(itr.reuse, list.Kv...)
 			}
 		}
 		// Mark the stream as done.

--- a/stream_test.go
+++ b/stream_test.go
@@ -300,7 +300,8 @@ func TestStreamCustomKeyToList(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		kv := &pb.KV{
+		kv := itr.NewKV()
+		*kv = pb.KV{
 			Key:   y.Copy(item.Key()),
 			Value: val,
 		}


### PR DESCRIPTION
We store a slice of pb.KVs in Iterator, so it can be used by Stream users.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1609)
<!-- Reviewable:end -->
