### PR TITLE
chore(cmd/stream): Default to snappy for compression flag.

### DIFF
--- a/badger/cmd/stream.go
+++ b/badger/cmd/stream.go
@@ -51,7 +51,7 @@ func init() {
 	streamCmd.Flags().IntVarP(&numVersions, "num_versions", "", 0,
 		"Option to configure the maximum number of versions per key. "+
 			"Values <= 0 will be considered to have the max number of versions.")
-	streamCmd.Flags().Uint32VarP(&compressionType, "compression", "", 0,
+	streamCmd.Flags().Uint32VarP(&compressionType, "compression", "", 1,
 		"Option to configure the compression type in output DB. "+
 			"0 to disable, 1 for Snappy, and 2 for ZSTD.")
 	streamCmd.Flags().StringVarP(&keyPath, "encryption-key-file", "e", "",


### PR DESCRIPTION
The DefaultOptions already has snappy set to the default, so the stream
CLI tool aligns with that now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1610)
<!-- Reviewable:end -->
