### PR TITLE
[Do Not Merge] fix(compaction): Don't drop keys if there is an overlap

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -660,7 +660,12 @@ func (s *levelsController) subcompact(it y.Iterator, kr keyRange, cd compactDef,
 
 			// See if we need to skip this key.
 			if len(skipKey) > 0 {
-				if y.SameKey(it.Key(), skipKey) {
+				// Do not drop this key if there is an overlap with the lower
+				// levels. Keys are reinserted because of the value log GC and
+				// if we drop the keys here, we might drop valid version (which
+				// are moved) and the older keys would show up. The keys would
+				// be dropped with they all are at the same level.
+				if !hasOverlap && y.SameKey(it.Key(), skipKey) {
 					numSkips++
 					updateStats(it.Value())
 					continue


### PR DESCRIPTION
This commit fixes the `Unable to read Key: xxx error: file with ID yyy not
found` issue.

The issue occurs because we drop intermediate keys (the moved ones)
during compaction. If key X is moved because of GC and there is a
version X' with a higher version and bitDiscardEarlierVersions set, we
might end up dropping the moved key X and the original key X (which
points to an invalid file) will show up again.

This change also has a side effect. The LSM Tree would be cleaned up
only when all the compaction doesn't have any overlap with the lower
levels. This could also mean that keys are dropped from the LSM tree
only when they reach the bottommost level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1618)
<!-- Reviewable:end -->
