### PR TITLE
fix(GC): Set bits correctly for moved keys

### DIFF
--- a/value.go
+++ b/value.go
@@ -226,7 +226,9 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 			moved++
 			// This new entry only contains the key, and a pointer to the value.
 			ne := new(Entry)
-			ne.meta = 0 // Remove all bits. Different keyspace doesn't need these bits.
+			// Remove only the bitValuePointer and transaction markers. We
+			// should keep the other bits.
+			ne.meta = e.meta &^ (bitValuePointer | bitTxn | bitFinTxn)
 			ne.UserMeta = e.UserMeta
 			ne.ExpiresAt = e.ExpiresAt
 			ne.Key = append([]byte{}, e.Key...)


### PR DESCRIPTION
When keys are moved because of the GC, we were removing the
bitDiscardEarlierVersions and other bits. Only the transaction markers
should be removed and all the other bits should be kept.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1619)
<!-- Reviewable:end -->
