### PR TITLE
opt(DropPrefix): check if there exist some data to drop before dropping prefixes

### DIFF
--- a/db.go
+++ b/db.go
@@ -1638,6 +1638,16 @@ func (db *DB) DropPrefix(prefixes ...[]byte) error {
 		return err
 	}
 	defer f()
+
+	var filtered [][]byte
+	if filtered, err = db.filterPrefixesToDrop(prefixes); err != nil {
+		return err
+	}
+	// If there is no prefix for which the data already exist, do not do anything.
+	if len(filtered) == 0 {
+		db.opt.Infof("No prefixes to drop")
+		return nil
+	}
 	// Block all foreign interactions with memory tables.
 	db.Lock()
 	defer db.Unlock()
@@ -1651,7 +1661,7 @@ func (db *DB) DropPrefix(prefixes ...[]byte) error {
 		task := flushTask{
 			mt: memtable,
 			// Ensure that the head of value log gets persisted to disk.
-			dropPrefixes: prefixes,
+			dropPrefixes: filtered,
 		}
 		db.opt.Debugf("Flushing memtable")
 		if err := db.handleFlushTask(task); err != nil {
@@ -1669,11 +1679,34 @@ func (db *DB) DropPrefix(prefixes ...[]byte) error {
 	}
 
 	// Drop prefixes from the levels.
-	if err := db.lc.dropPrefixes(prefixes); err != nil {
+	if err := db.lc.dropPrefixes(filtered); err != nil {
 		return err
 	}
 	db.opt.Infof("DropPrefix done")
 	return nil
+}
+
+func (db *DB) filterPrefixesToDrop(prefixes [][]byte) ([][]byte, error) {
+	var filtered [][]byte
+	for _, prefix := range prefixes {
+		err := db.View(func(txn *Txn) error {
+			iopts := DefaultIteratorOptions
+			iopts.Prefix = prefix
+			iopts.PrefetchValues = false
+			iopts.AllVersions = true
+			itr := txn.NewIterator(iopts)
+			defer itr.Close()
+			itr.Rewind()
+			if itr.ValidForPrefix(prefix) {
+				filtered = append(filtered, prefix)
+			}
+			return nil
+		})
+		if err != nil {
+			return filtered, err
+		}
+	}
+	return filtered, nil
 }
 
 // KVList contains a list of key-value pairs.

--- a/db.go
+++ b/db.go
@@ -1693,7 +1693,6 @@ func (db *DB) filterPrefixesToDrop(prefixes [][]byte) ([][]byte, error) {
 			iopts := DefaultIteratorOptions
 			iopts.Prefix = prefix
 			iopts.PrefetchValues = false
-			iopts.AllVersions = true
 			itr := txn.NewIterator(iopts)
 			defer itr.Close()
 			itr.Rewind()


### PR DESCRIPTION
Fixes DGRAPH-2853

We currently do not check if there exist some data to drop for prefixes in [`DropPrefix()`](https://github.com/dgraph-io/badger/blob/bcfae6104545e824b40814e4bc3bc4b1430c3367/db.go#L1631-L1677). This can make drop prefix to be expensive because it has to do a bunch of compactions, etc.

This PR optimizes that behavior by not doing any of that in case no data exist for prefixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1621)
<!-- Reviewable:end -->
