### PR TITLE
fix(badger): Do not reuse variable across badger commands

### DIFF
--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -25,7 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var backupFile string
+var bo = struct {
+	backupFile  string
+	numVersions int
+}{}
 
 // backupCmd represents the backup command
 var backupCmd = &cobra.Command{
@@ -42,9 +45,9 @@ database.`,
 
 func init() {
 	RootCmd.AddCommand(backupCmd)
-	backupCmd.Flags().StringVarP(&backupFile, "backup-file", "f",
+	backupCmd.Flags().StringVarP(&bo.backupFile, "backup-file", "f",
 		"badger.bak", "File to backup to")
-	backupCmd.Flags().IntVarP(&numVersions, "num-versions", "n",
+	backupCmd.Flags().IntVarP(&bo.numVersions, "num-versions", "n",
 		0, "Number of versions to keep. A value <= 0 means keep all versions.")
 }
 
@@ -53,8 +56,8 @@ func doBackup(cmd *cobra.Command, args []string) error {
 		WithValueDir(vlogDir).
 		WithNumVersionsToKeep(math.MaxInt32)
 
-	if numVersions > 0 {
-		opt.NumVersionsToKeep = numVersions
+	if bo.numVersions > 0 {
+		opt.NumVersionsToKeep = bo.numVersions
 	}
 
 	// Open DB
@@ -65,7 +68,7 @@ func doBackup(cmd *cobra.Command, args []string) error {
 	defer db.Close()
 
 	// Create File
-	f, err := os.Create(backupFile)
+	f, err := os.Create(bo.backupFile)
 	if err != nil {
 		return err
 	}

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -52,7 +52,7 @@ func init() {
 			"Values <= 0 will be considered to have the max number of versions.")
 	flattenCmd.Flags().StringVar(&fo.keyPath, "encryption-key-file", "",
 		"Path of the encryption key file.")
-	streamCmd.Flags().Uint32VarP(&fo.compressionType, "compression", "", 1,
+	flattenCmd.Flags().Uint32VarP(&fo.compressionType, "compression", "", 1,
 		"Option to configure the compression type in output DB. "+
 			"0 to disable, 1 for Snappy, and 2 for ZSTD.")
 }

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -72,7 +72,7 @@ func init() {
 		&ro.readOnly, "read-only", true, "If true, DB will be opened in read only mode.")
 	readBenchCmd.Flags().BoolVar(
 		&ro.fullScan, "full-scan", false, "If true, full db will be scanned using iterators.")
-	readBenchCmd.Flags().Int64Var(&ro.blockCacheSize, "block-cache", 0, "Max size of block cache in MB")
+	readBenchCmd.Flags().Int64Var(&ro.blockCacheSize, "block-cache", 1024, "Max size of block cache in MB")
 	readBenchCmd.Flags().Int64Var(&ro.indexCacheSize, "index-cache", 0, "Max size of index cache in MB")
 }
 

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -47,14 +47,15 @@ var (
 	entriesRead uint64    // will store entries read till now
 	startTime   time.Time // start time of read benchmarking
 
-	blockCacheSize int64
-	indexCacheSize int64
+	ro = struct {
+		blockCacheSize int64
+		indexCacheSize int64
 
-	sampleSize  int
-	loadingMode string
-	keysOnly    bool
-	readOnly    bool
-	fullScan    bool
+		sampleSize int
+		keysOnly   bool
+		readOnly   bool
+		fullScan   bool
+	}{}
 )
 
 func init() {
@@ -64,18 +65,15 @@ func init() {
 	readBenchCmd.Flags().StringVarP(
 		&duration, "duration", "d", "1m", "How long to run the benchmark.")
 	readBenchCmd.Flags().IntVar(
-		&sampleSize, "sample-size", 1000000, "Keys sample size to be used for random lookup.")
+		&ro.sampleSize, "sample-size", 1000000, "Keys sample size to be used for random lookup.")
 	readBenchCmd.Flags().BoolVar(
-		&keysOnly, "keys-only", false, "If false, values will also be read.")
+		&ro.keysOnly, "keys-only", false, "If false, values will also be read.")
 	readBenchCmd.Flags().BoolVar(
-		&readOnly, "read-only", true, "If true, DB will be opened in read only mode.")
-	readBenchCmd.Flags().StringVar(
-		&loadingMode, "loading-mode", "mmap", "Mode for accessing SSTables and value log files. "+
-			"Valid loading modes are fileio and mmap.")
+		&ro.readOnly, "read-only", true, "If true, DB will be opened in read only mode.")
 	readBenchCmd.Flags().BoolVar(
-		&fullScan, "full-scan", false, "If true, full db will be scanned using iterators.")
-	readBenchCmd.Flags().Int64Var(&blockCacheSize, "block-cache", 0, "Max size of block cache in MB")
-	readBenchCmd.Flags().Int64Var(&indexCacheSize, "index-cache", 0, "Max size of index cache in MB")
+		&ro.fullScan, "full-scan", false, "If true, full db will be scanned using iterators.")
+	readBenchCmd.Flags().Int64Var(&ro.blockCacheSize, "block-cache", 0, "Max size of block cache in MB")
+	readBenchCmd.Flags().Int64Var(&ro.indexCacheSize, "index-cache", 0, "Max size of index cache in MB")
 }
 
 // Scan the whole database using the iterators
@@ -108,9 +106,9 @@ func readBench(cmd *cobra.Command, args []string) error {
 	y.AssertTrue(numGoroutines > 0)
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithReadOnly(readOnly).
-		WithBlockCacheSize(blockCacheSize << 20).
-		WithIndexCacheSize(indexCacheSize << 20)
+		WithReadOnly(ro.readOnly).
+		WithBlockCacheSize(ro.blockCacheSize << 20).
+		WithIndexCacheSize(ro.indexCacheSize << 20)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.OpenManaged(opt)
 	if err != nil {
@@ -123,7 +121,7 @@ func readBench(cmd *cobra.Command, args []string) error {
 	fmt.Println("*********************************************************")
 
 	// if fullScan is true then do a complete scan of the db and return
-	if fullScan {
+	if ro.fullScan {
 		fullScanDB(db)
 		return nil
 	}
@@ -210,7 +208,7 @@ func getSampleKeys(db *badger.DB) ([][]byte, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stream.Send = func(buf *z.Buffer) error {
-		if count >= sampleSize {
+		if count >= ro.sampleSize {
 			return nil
 		}
 		err := buf.SliceIterate(func(s []byte) error {
@@ -220,7 +218,7 @@ func getSampleKeys(db *badger.DB) ([][]byte, error) {
 			}
 			keys = append(keys, kv.Key)
 			count++
-			if count >= sampleSize {
+			if count >= ro.sampleSize {
 				cancel()
 				return errStop
 			}

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -72,7 +72,7 @@ func init() {
 		&ro.readOnly, "read-only", true, "If true, DB will be opened in read only mode.")
 	readBenchCmd.Flags().BoolVar(
 		&ro.fullScan, "full-scan", false, "If true, full db will be scanned using iterators.")
-	readBenchCmd.Flags().Int64Var(&ro.blockCacheSize, "block-cache", 1024, "Max size of block cache in MB")
+	readBenchCmd.Flags().Int64Var(&ro.blockCacheSize, "block-cache", 256, "Max size of block cache in MB")
 	readBenchCmd.Flags().Int64Var(&ro.indexCacheSize, "index-cache", 0, "Max size of index cache in MB")
 }
 

--- a/badger/cmd/stream.go
+++ b/badger/cmd/stream.go
@@ -38,48 +38,54 @@ This command streams the contents of this DB into another DB with the given opti
 	RunE: stream,
 }
 
-var outDir string
-var outFile string
-var compressionType uint32
+var so = struct {
+	outDir          string
+	outFile         string
+	compressionType uint32
+	numVersions     int
+	readOnly        bool
+	keyPath         string
+}{}
 
 func init() {
 	// TODO: Add more options.
 	RootCmd.AddCommand(streamCmd)
-	streamCmd.Flags().StringVarP(&outDir, "out", "o", "",
+	streamCmd.Flags().StringVarP(&so.outDir, "out", "o", "",
 		"Path to output DB. The directory should be empty.")
-	streamCmd.Flags().StringVarP(&outFile, "", "f", "",
+	streamCmd.Flags().StringVarP(&so.outFile, "", "f", "",
 		"Run a backup to this file.")
-	streamCmd.Flags().BoolVarP(&readOnly, "read_only", "", true,
+	streamCmd.Flags().BoolVarP(&so.readOnly, "read_only", "", true,
 		"Option to open input DB in read-only mode")
-	streamCmd.Flags().IntVarP(&numVersions, "num_versions", "", 0,
+	streamCmd.Flags().IntVarP(&so.numVersions, "num_versions", "", 0,
 		"Option to configure the maximum number of versions per key. "+
 			"Values <= 0 will be considered to have the max number of versions.")
-	streamCmd.Flags().Uint32VarP(&compressionType, "compression", "", 1,
+	streamCmd.Flags().Uint32VarP(&so.compressionType, "compression", "", 1,
 		"Option to configure the compression type in output DB. "+
 			"0 to disable, 1 for Snappy, and 2 for ZSTD.")
-	streamCmd.Flags().StringVarP(&keyPath, "encryption-key-file", "e", "",
+	streamCmd.Flags().StringVarP(&so.keyPath, "encryption-key-file", "e", "",
 		"Path of the encryption key file.")
 }
 
 func stream(cmd *cobra.Command, args []string) error {
 	// Options for input DB.
-	if numVersions <= 0 {
-		numVersions = math.MaxInt32
+	if so.numVersions <= 0 {
+		so.numVersions = math.MaxInt32
 	}
-	encKey, err := getKey(keyPath)
+	fmt.Printf("numVersions = %+v\n", so.numVersions)
+	encKey, err := getKey(so.keyPath)
 	if err != nil {
 		return err
 	}
 	inOpt := badger.DefaultOptions(sstDir).
-		WithReadOnly(readOnly).
+		WithReadOnly(so.readOnly).
 		WithValueThreshold(1 << 10 /* 1KB */).
-		WithNumVersionsToKeep(numVersions).
+		WithNumVersionsToKeep(so.numVersions).
 		WithBlockCacheSize(100 << 20).
 		WithIndexCacheSize(200 << 20).
 		WithEncryptionKey(encKey)
 
 	// Options for output DB.
-	if compressionType < 0 || compressionType > 2 {
+	if so.compressionType < 0 || so.compressionType > 2 {
 		return errors.Errorf(
 			"compression value must be one of 0 (disabled), 1 (Snappy), or 2 (ZSTD)")
 	}
@@ -91,9 +97,9 @@ func stream(cmd *cobra.Command, args []string) error {
 
 	stream := inDB.NewStreamAt(math.MaxUint64)
 
-	if len(outDir) > 0 {
-		if _, err := os.Stat(outDir); err == nil {
-			f, err := os.Open(outDir)
+	if len(so.outDir) > 0 {
+		if _, err := os.Stat(so.outDir); err == nil {
+			f, err := os.Open(so.outDir)
 			if err != nil {
 				return err
 			}
@@ -102,22 +108,22 @@ func stream(cmd *cobra.Command, args []string) error {
 			_, err = f.Readdirnames(1)
 			if err != io.EOF {
 				return errors.Errorf(
-					"cannot run stream tool on non-empty output directory %s", outDir)
+					"cannot run stream tool on non-empty output directory %s", so.outDir)
 			}
 		}
 
 		stream.LogPrefix = "DB.Stream"
 		outOpt := inOpt.
-			WithDir(outDir).
-			WithValueDir(outDir).
-			WithNumVersionsToKeep(numVersions).
-			WithCompression(options.CompressionType(compressionType)).
+			WithDir(so.outDir).
+			WithValueDir(so.outDir).
+			WithNumVersionsToKeep(so.numVersions).
+			WithCompression(options.CompressionType(so.compressionType)).
 			WithReadOnly(false)
 		err = inDB.StreamDB(outOpt)
 
-	} else if len(outFile) > 0 {
+	} else if len(so.outFile) > 0 {
 		stream.LogPrefix = "DB.Backup"
-		f, err := os.OpenFile(outFile, os.O_RDWR|os.O_CREATE, 0666)
+		f, err := os.OpenFile(so.outFile, os.O_RDWR|os.O_CREATE, 0666)
 		y.Check(err)
 		_, err = stream.Backup(f, 0)
 	}

--- a/badger/cmd/stream.go
+++ b/badger/cmd/stream.go
@@ -71,7 +71,6 @@ func stream(cmd *cobra.Command, args []string) error {
 	if so.numVersions <= 0 {
 		so.numVersions = math.MaxInt32
 	}
-	fmt.Printf("numVersions = %+v\n", so.numVersions)
 	encKey, err := getKey(so.keyPath)
 	if err != nil {
 		return err

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -104,7 +104,7 @@ func init() {
 	writeBenchCmd.Flags().BoolVarP(&wo.showLogs, "verbose", "v", false, "Show Badger logs.")
 	writeBenchCmd.Flags().IntVarP(&wo.valueThreshold, "value-th", "t", 1<<10, "Value threshold")
 	writeBenchCmd.Flags().IntVarP(&wo.numVersions, "num-version", "n", 1, "Number of versions to keep")
-	writeBenchCmd.Flags().Int64Var(&wo.blockCacheSize, "block-cache-mb", 1024,
+	writeBenchCmd.Flags().Int64Var(&wo.blockCacheSize, "block-cache-mb", 256,
 		"Size of block cache in MB")
 	writeBenchCmd.Flags().Int64Var(&wo.indexCacheSize, "index-cache-mb", 0,
 		"Size of index cache in MB.")

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -50,36 +50,40 @@ var writeBenchCmd = &cobra.Command{
 }
 
 var (
-	keySz      int
-	valSz      int
-	numKeys    float64
-	syncWrites bool
-	force      bool
-	sorted     bool
-	showLogs   bool
+	wo = struct {
+		keySz      int
+		valSz      int
+		numKeys    float64
+		syncWrites bool
+		force      bool
+		sorted     bool
+		showLogs   bool
+
+		valueThreshold   int
+		numVersions      int
+		vlogMaxEntries   uint32
+		loadBloomsOnOpen bool
+		detectConflicts  bool
+		zstdComp         bool
+		showDir          bool
+		ttlDuration      string
+		encryptionKey    string
+		showKeysCount    bool
+		blockCacheSize   int64
+		indexCacheSize   int64
+
+		dropAllPeriod    string
+		dropPrefixPeriod string
+		gcPeriod         string
+		gcDiscardRatio   float64
+	}{}
 
 	sizeWritten    uint64
+	gcSuccess      uint64
+	sstCount       uint32
+	vlogCount      uint32
+	files          []string
 	entriesWritten uint64
-
-	valueThreshold   int
-	numVersions      int
-	vlogMaxEntries   uint32
-	loadBloomsOnOpen bool
-	detectConflicts  bool
-	zstdComp         bool
-	showDir          bool
-	ttlDuration      string
-	showKeysCount    bool
-
-	sstCount  uint32
-	vlogCount uint32
-	files     []string
-
-	dropAllPeriod    string
-	dropPrefixPeriod string
-	gcPeriod         string
-	gcDiscardRatio   float64
-	gcSuccess        uint64
 )
 
 const (
@@ -88,62 +92,60 @@ const (
 
 func init() {
 	benchCmd.AddCommand(writeBenchCmd)
-	writeBenchCmd.Flags().IntVarP(&keySz, "key-size", "k", 32, "Size of key")
-	writeBenchCmd.Flags().IntVar(&valSz, "val-size", 128, "Size of value")
-	writeBenchCmd.Flags().Float64VarP(&numKeys, "keys-mil", "m", 10.0,
+	writeBenchCmd.Flags().IntVarP(&wo.keySz, "key-size", "k", 32, "Size of key")
+	writeBenchCmd.Flags().IntVar(&wo.valSz, "val-size", 128, "Size of value")
+	writeBenchCmd.Flags().Float64VarP(&wo.numKeys, "keys-mil", "m", 10.0,
 		"Number of keys to add in millions")
-	writeBenchCmd.Flags().BoolVar(&syncWrites, "sync", false,
+	writeBenchCmd.Flags().BoolVar(&wo.syncWrites, "sync", false,
 		"If true, sync writes to disk.")
-	writeBenchCmd.Flags().BoolVarP(&force, "force-compact", "f", true,
+	writeBenchCmd.Flags().BoolVarP(&wo.force, "force-compact", "f", true,
 		"Force compact level 0 on close.")
-	writeBenchCmd.Flags().BoolVarP(&sorted, "sorted", "s", false, "Write keys in sorted order.")
-	writeBenchCmd.Flags().BoolVarP(&showLogs, "verbose", "v", false, "Show Badger logs.")
-	writeBenchCmd.Flags().IntVarP(&valueThreshold, "value-th", "t", 1<<10, "Value threshold")
-	writeBenchCmd.Flags().IntVarP(&numVersions, "num-version", "n", 1, "Number of versions to keep")
-	writeBenchCmd.Flags().Int64Var(&blockCacheSize, "block-cache-mb", 1024,
+	writeBenchCmd.Flags().BoolVarP(&wo.sorted, "sorted", "s", false, "Write keys in sorted order.")
+	writeBenchCmd.Flags().BoolVarP(&wo.showLogs, "verbose", "v", false, "Show Badger logs.")
+	writeBenchCmd.Flags().IntVarP(&wo.valueThreshold, "value-th", "t", 1<<10, "Value threshold")
+	writeBenchCmd.Flags().IntVarP(&wo.numVersions, "num-version", "n", 1, "Number of versions to keep")
+	writeBenchCmd.Flags().Int64Var(&wo.blockCacheSize, "block-cache-mb", 1024,
 		"Size of block cache in MB")
-	writeBenchCmd.Flags().Int64Var(&indexCacheSize, "index-cache-mb", 0,
+	writeBenchCmd.Flags().Int64Var(&wo.indexCacheSize, "index-cache-mb", 0,
 		"Size of index cache in MB.")
-	writeBenchCmd.Flags().Uint32Var(&vlogMaxEntries, "vlog-maxe", 1000000, "Value log Max Entries")
-	writeBenchCmd.Flags().StringVarP(&encryptionKey, "encryption-key", "e", "",
+	writeBenchCmd.Flags().Uint32Var(&wo.vlogMaxEntries, "vlog-maxe", 1000000, "Value log Max Entries")
+	writeBenchCmd.Flags().StringVarP(&wo.encryptionKey, "encryption-key", "e", "",
 		"If it is true, badger will encrypt all the data stored on the disk.")
-	writeBenchCmd.Flags().StringVar(&loadingMode, "loading-mode", "mmap",
-		"Mode for accessing SSTables")
-	writeBenchCmd.Flags().BoolVar(&loadBloomsOnOpen, "load-blooms", true,
+	writeBenchCmd.Flags().BoolVar(&wo.loadBloomsOnOpen, "load-blooms", true,
 		"Load Bloom filter on DB open.")
-	writeBenchCmd.Flags().BoolVar(&detectConflicts, "conficts", false,
+	writeBenchCmd.Flags().BoolVar(&wo.detectConflicts, "conficts", false,
 		"If true, it badger will detect the conflicts")
-	writeBenchCmd.Flags().BoolVar(&zstdComp, "zstd", false,
+	writeBenchCmd.Flags().BoolVar(&wo.zstdComp, "zstd", false,
 		"If true, badger will use ZSTD mode. Otherwise, use default.")
-	writeBenchCmd.Flags().BoolVar(&showDir, "show-dir", false,
+	writeBenchCmd.Flags().BoolVar(&wo.showDir, "show-dir", false,
 		"If true, the report will include the directory contents")
-	writeBenchCmd.Flags().StringVar(&dropAllPeriod, "dropall", "0s",
+	writeBenchCmd.Flags().StringVar(&wo.dropAllPeriod, "dropall", "0s",
 		"If set, run dropAll periodically over given duration.")
-	writeBenchCmd.Flags().StringVar(&dropPrefixPeriod, "drop-prefix", "0s",
+	writeBenchCmd.Flags().StringVar(&wo.dropPrefixPeriod, "drop-prefix", "0s",
 		"If set, drop random prefixes periodically over given duration.")
-	writeBenchCmd.Flags().StringVar(&ttlDuration, "entry-ttl", "0s",
+	writeBenchCmd.Flags().StringVar(&wo.ttlDuration, "entry-ttl", "0s",
 		"TTL duration in seconds for the entries, 0 means without TTL")
-	writeBenchCmd.Flags().StringVarP(&gcPeriod, "gc-every", "g", "0s", "GC Period.")
-	writeBenchCmd.Flags().Float64VarP(&gcDiscardRatio, "gc-ratio", "r", 0.5, "GC discard ratio.")
-	writeBenchCmd.Flags().BoolVar(&showKeysCount, "show-keys", false,
+	writeBenchCmd.Flags().StringVarP(&wo.gcPeriod, "gc-every", "g", "0s", "GC Period.")
+	writeBenchCmd.Flags().Float64VarP(&wo.gcDiscardRatio, "gc-ratio", "r", 0.5, "GC discard ratio.")
+	writeBenchCmd.Flags().BoolVar(&wo.showKeysCount, "show-keys", false,
 		"If true, the report will include the keys statistics")
 }
 
 func writeRandom(db *badger.DB, num uint64) error {
-	value := make([]byte, valSz)
+	value := make([]byte, wo.valSz)
 	y.Check2(rand.Read(value))
 
-	es := uint64(keySz + valSz) // entry size is keySz + valSz
+	es := uint64(wo.keySz + wo.valSz) // entry size is keySz + valSz
 	batch := db.NewManagedWriteBatch()
 
-	ttlPeriod, errParse := time.ParseDuration(ttlDuration)
+	ttlPeriod, errParse := time.ParseDuration(wo.ttlDuration)
 	y.Check(errParse)
 
 	for i := uint64(1); i <= num; i++ {
-		key := make([]byte, keySz)
+		key := make([]byte, wo.keySz)
 		y.Check2(rand.Read(key))
 
-		vsz := rand.Intn(valSz) + 1
+		vsz := rand.Intn(wo.valSz) + 1
 		e := badger.NewEntry(key, value[:vsz])
 
 		if ttlPeriod != 0 {
@@ -194,9 +196,9 @@ func readTest(db *badger.DB, dur time.Duration) {
 }
 
 func writeSorted(db *badger.DB, num uint64) error {
-	value := make([]byte, valSz)
+	value := make([]byte, wo.valSz)
 	y.Check2(rand.Read(value))
-	es := 8 + valSz // key size is 8 bytes and value size is valSz
+	es := 8 + wo.valSz // key size is 8 bytes and value size is valSz
 
 	writer := db.NewStreamWriter()
 	if err := writer.Prepare(); err != nil {
@@ -264,21 +266,21 @@ func writeSorted(db *badger.DB, num uint64) error {
 func writeBench(cmd *cobra.Command, args []string) error {
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithSyncWrites(syncWrites).
-		WithCompactL0OnClose(force).
-		WithValueThreshold(valueThreshold).
-		WithNumVersionsToKeep(numVersions).
-		WithBlockCacheSize(blockCacheSize << 20).
-		WithIndexCacheSize(indexCacheSize << 20).
-		WithValueLogMaxEntries(vlogMaxEntries).
-		WithEncryptionKey([]byte(encryptionKey)).
-		WithDetectConflicts(detectConflicts).
+		WithSyncWrites(wo.syncWrites).
+		WithCompactL0OnClose(wo.force).
+		WithValueThreshold(wo.valueThreshold).
+		WithNumVersionsToKeep(wo.numVersions).
+		WithBlockCacheSize(wo.blockCacheSize << 20).
+		WithIndexCacheSize(wo.indexCacheSize << 20).
+		WithValueLogMaxEntries(wo.vlogMaxEntries).
+		WithEncryptionKey([]byte(wo.encryptionKey)).
+		WithDetectConflicts(wo.detectConflicts).
 		WithLoggingLevel(badger.INFO)
-	if zstdComp {
+	if wo.zstdComp {
 		opt = opt.WithCompression(options.ZSTD)
 	}
 
-	if !showLogs {
+	if !wo.showLogs {
 		opt = opt.WithLogger(nil)
 	}
 
@@ -298,14 +300,14 @@ func writeBench(cmd *cobra.Command, args []string) error {
 	fmt.Println("*********************************************************")
 
 	startTime = time.Now()
-	num := uint64(numKeys * mil)
+	num := uint64(wo.numKeys * mil)
 	c := z.NewCloser(4)
 	go reportStats(c, db)
 	go dropAll(c, db)
 	go dropPrefix(c, db)
 	go runGC(c, db)
 
-	if sorted {
+	if wo.sorted {
 		err = writeSorted(db, num)
 	} else {
 		err = writeRandom(db, num)
@@ -360,11 +362,11 @@ func reportStats(c *z.Closer, db *badger.DB) {
 			return
 		case <-t.C:
 			count++
-			if showKeysCount {
+			if wo.showKeysCount {
 				showKeysStats(db)
 			}
 			// fetch directory contents
-			if showDir {
+			if wo.showDir {
 				err := filepath.Walk(sstDir, func(path string, info os.FileInfo, err error) error {
 					fileSize := humanize.Bytes(uint64(info.Size()))
 					files = append(files, "[Content] "+path+" "+fileSize)
@@ -407,7 +409,7 @@ func reportStats(c *z.Closer, db *badger.DB) {
 
 func runGC(c *z.Closer, db *badger.DB) {
 	defer c.Done()
-	period, err := time.ParseDuration(gcPeriod)
+	period, err := time.ParseDuration(wo.gcPeriod)
 	y.Check(err)
 	if period == 0 {
 		return
@@ -420,7 +422,7 @@ func runGC(c *z.Closer, db *badger.DB) {
 		case <-c.HasBeenClosed():
 			return
 		case <-t.C:
-			if err := db.RunValueLogGC(gcDiscardRatio); err == nil {
+			if err := db.RunValueLogGC(wo.gcDiscardRatio); err == nil {
 				atomic.AddUint64(&gcSuccess, 1)
 			} else {
 				log.Printf("[GC] Failed due to following err %v", err)
@@ -431,7 +433,7 @@ func runGC(c *z.Closer, db *badger.DB) {
 
 func dropAll(c *z.Closer, db *badger.DB) {
 	defer c.Done()
-	dropPeriod, err := time.ParseDuration(dropAllPeriod)
+	dropPeriod, err := time.ParseDuration(wo.dropAllPeriod)
 	y.Check(err)
 	if dropPeriod == 0 {
 		return
@@ -462,7 +464,7 @@ func dropAll(c *z.Closer, db *badger.DB) {
 
 func dropPrefix(c *z.Closer, db *badger.DB) {
 	defer c.Done()
-	dropPeriod, err := time.ParseDuration(dropPrefixPeriod)
+	dropPeriod, err := time.ParseDuration(wo.dropPrefixPeriod)
 	y.Check(err)
 	if dropPeriod == 0 {
 		return
@@ -476,7 +478,7 @@ func dropPrefix(c *z.Closer, db *badger.DB) {
 			return
 		case <-t.C:
 			fmt.Println("[DropPrefix] Started")
-			prefix := make([]byte, 1+int(float64(keySz)*0.1))
+			prefix := make([]byte, 1+int(float64(wo.keySz)*0.1))
 			y.Check2(rand.Read(prefix))
 			err = db.DropPrefix(prefix)
 


### PR DESCRIPTION
The same variables were being across multiple badger commands. The
default value of a flag that uses the same variable across two commands
could be from one of the commands and it isn't clear which default value
would be used.

The `numVersions` command was being used in flatten (default value 1)
and stream (default value 0). Running `badger stream --help` would show
the default value to be `0` but if you print the value of the
`numVersions` variable, it would turn out to be `1`. This is misleading.

This PR separates the variable so that they don't overlap.

This PR also adds the `compression` flag to the flatten tool.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1624)
<!-- Reviewable:end -->
