### PR TITLE
fix(table): sync SST to disk after creation

### DIFF
--- a/options.go
+++ b/options.go
@@ -167,7 +167,6 @@ func buildTableOptions(db *DB) table.Options {
 	dk, err := db.registry.LatestDataKey()
 	y.Check(err)
 	return table.Options{
-		SyncWrites:           opt.SyncWrites,
 		ReadOnly:             opt.ReadOnly,
 		TableSize:            uint64(opt.BaseTableSize),
 		BlockSize:            opt.BlockSize,

--- a/table/table.go
+++ b/table/table.go
@@ -51,7 +51,6 @@ const intSize = int(unsafe.Sizeof(int(0)))
 type Options struct {
 	// Options for Opening/Building Table.
 
-	SyncWrites bool
 	// Open tables in read only mode.
 	ReadOnly bool
 
@@ -269,10 +268,8 @@ func CreateTable(fname string, builder *Builder) (*Table, error) {
 
 	written := bd.Copy(mf.Data)
 	y.AssertTrue(written == len(mf.Data))
-	if builder.opts.SyncWrites {
-		if err := z.Msync(mf.Data); err != nil {
-			return nil, y.Wrapf(err, "while calling msync on %s", fname)
-		}
+	if err := z.Msync(mf.Data); err != nil {
+		return nil, y.Wrapf(err, "while calling msync on %s", fname)
 	}
 	return OpenTable(mf, *builder.opts)
 }


### PR DESCRIPTION
SST files were not `sync`'ed to disk by default. Machine crash may happen before the explicit sync (which happens at DB close), leading to an inconsistent state and badger not able to open. 
It is better to explicitly do a sync. This PR explicitly `Msync` the SST and removes the table options `SyncWrites`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1625)
<!-- Reviewable:end -->
