### PR TITLE
debug(tableIndex): add debug info for initIndex

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -347,12 +346,10 @@ func (t *Table) initBiggestAndSmallest() error {
 	// This defer will help gathering debugging info incase initIndex crashes.
 	defer func() {
 		if r := recover(); r != nil {
-			debug.PrintStack()
 			// Use defer for printing info because there may be an intermediate panic.
 			var debugBuf bytes.Buffer
 			defer func() {
-				fmt.Printf("%s\n== Recovered ==\n", debugBuf.String())
-				t.initIndex()
+				panic(fmt.Sprintf("%s\n== Recovered ==\n", debugBuf.String()))
 			}()
 
 			// Get the count of null bytes at the end of file. This is to make sure if there was an

--- a/table/table.go
+++ b/table/table.go
@@ -352,7 +352,7 @@ func (t *Table) initBiggestAndSmallest() error {
 			var debugBuf bytes.Buffer
 			defer func() {
 				fmt.Printf("%s\n== Recovered ==\n", debugBuf.String())
-				os.Exit(1)
+				t.initIndex()
 			}()
 
 			// Get the count of null bytes at the end of file. This is to make sure if there was an
@@ -369,9 +369,7 @@ func (t *Table) initBiggestAndSmallest() error {
 			fmt.Fprintf(&debugBuf, "File Info: [ID: %d, Size: %d, Zeros: %d]\n",
 				t.id, t.tableSize, count)
 
-			if t.shouldDecrypt() {
-				fmt.Fprintf(&debugBuf, "dataKey: %+v ", t.opt.DataKey)
-			}
+			fmt.Fprintf(&debugBuf, "isEnrypted: %v ", t.shouldDecrypt())
 
 			readPos := t.tableSize
 
@@ -386,7 +384,7 @@ func (t *Table) initBiggestAndSmallest() error {
 			readPos -= checksumLen
 			buf = t.readNoFail(readPos, checksumLen)
 			proto.Unmarshal(buf, checksum)
-			fmt.Fprintf(&debugBuf, "checksum: %d ", checksum)
+			fmt.Fprintf(&debugBuf, "checksum: %+v ", checksum)
 
 			// Read index size from the footer.
 			readPos -= 4

--- a/table/table.go
+++ b/table/table.go
@@ -379,8 +379,12 @@ func (t *Table) initBiggestAndSmallest() error {
 			checksumLen := int(y.BytesToU32(buf))
 			fmt.Fprintf(&debugBuf, "checksumLen: %d ", checksumLen)
 
-			// Skip reading the checksum.
+			// Read checksum.
+			checksum := &pb.Checksum{}
 			readPos -= checksumLen
+			buf = t.readNoFail(readPos, checksumLen)
+			proto.Unmarshal(buf, checksum)
+			fmt.Fprintf(&debugBuf, "checksum: %d ", checksum)
 
 			// Read index size from the footer.
 			readPos -= 4


### PR DESCRIPTION
Fixes DGRAPH-2841

This PR adds debug information for the following crash. We suspect that it may be due to unsynced mmap (#1625), or because of mishandling of sst files. 
```
panic: runtime error: index out of range [3] with length 0
panic: runtime error: index out of range [3] with length 0

goroutine 187 [running]:
github.com/google/flatbuffers/go.GetInt32(...)
	/go/pkg/mod/github.com/google/flatbuffers@v1.12.0/go/encode.go:85
github.com/google/flatbuffers/go.GetUOffsetT(...)
	/go/pkg/mod/github.com/google/flatbuffers@v1.12.0/go/encode.go:121
github.com/dgraph-io/badger/v2/fb.GetRootAsTableIndex(...)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201214114056-bcfae6104545/fb/TableIndex.go:14
github.com/dgraph-io/badger/v2/table.(*Table).readTableIndex(0xc0005dc000, 0x0, 0x8, 0xc0001fe210)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201214114056-bcfae6104545/table/table.go:654 +0x234
github.com/dgraph-io/badger/v2/table.(*Table).initIndex(0xc0005dc000, 0xc000075ac0, 0x7f8be018d4c0, 0xc00004a000)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201214114056-bcfae6104545/table/table.go:412 +0x285
github.com/dgraph-io/badger/v2/table.(*Table).initBiggestAndSmallest(0xc0005dc000, 0x0, 0x0)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201214114056-bcfae6104545/table/table.go:351 +0x5e
github.com/dgraph-io/badger/v2/table.OpenTable(0xc000182280, 0x0, 0x200000, 0x0, 0x0, 0x3f847ae147ae147b, 0x1000, 0x0, 0x1, 0xc000560080, ...)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201214114056-bcfae6104545/table/table.go:312 +0x22d
github.com/dgraph-io/badger/v2.newLevelsController.func1(0xc00048c7c0, 0xc0001f41e0, 0xc000098c00, 0xc0001f41b8, 0xc00020e2c0, 0x7, 0x7, 0xc0001f4220, 0xc, 0x1d6b606, ...)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201214114056-bcfae6104545/levels.go:150 +0x205
created by github.com/dgraph-io/badger/v2.newLevelsController
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201214114056-bcfae6104545/levels.go:129 +0x645

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1626)
<!-- Reviewable:end -->
