### PR TITLE
fix(vlog): Log error on missing vlog

### DIFF
--- a/value.go
+++ b/value.go
@@ -1440,7 +1440,14 @@ func (vlog *valueLog) write(reqs []*request) error {
 
 	vlog.filesLock.RLock()
 	maxFid := vlog.maxFid
-	curlf := vlog.filesMap[maxFid]
+	curlf, ok := vlog.filesMap[maxFid]
+	if !ok {
+		var fids []uint32
+		for fid := range vlog.filesMap {
+			fids = append(fids, fid)
+		}
+		return errors.Errorf("Cannot find MaxFid: %d in filesMap: %+v", maxFid, fids)
+	}
 	vlog.filesLock.RUnlock()
 
 	var buf bytes.Buffer


### PR DESCRIPTION
We recently saw a crash on `vlog.write` function that could only happen if the vlog file with `maxFid` doesn't exist in the filesMap (which is highly unlikely). This PR adds appropriate errors so that we can debug this issue futher.
```
I1224 06:04:48.314143 3930260 backup_processor.go:236] Backup completed OK.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x123e26c]

goroutine 21121096 [running]:
github.com/dgraph-io/badger/v2.(*valueLog).write(0xc0000815d0, 0xc049c46410, 0x1, 0xa, 0x0, 0x0)
        /home/dg/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.2007.3-0.20200927102853-5e3d4b9926a7/value.go:1497 +0x2cc
github.com/dgraph-io/badger/v2.(*DB).writeRequests(0xc000081400, 0xc049c46410, 0x1, 0xa, 0x0, 0x10000c00865dc20)
        /home/dg/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.2007.3-0.20200927102853-5e3d4b9926a7/db.go:776 +0xd1
github.com/dgraph-io/badger/v2.(*DB).doWrites.func1(0xc049c46410, 0x1, 0xa)
        /home/dg/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.2007.3-0.20200927102853-5e3d4b9926a7/db.go:850 +0x5a
created by github.com/dgraph-io/badger/v2.(*DB).doWrites
        /home/dg/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.2007.3-0.20200927102853-5e3d4b9926a7/db.go:903 +0x32b
```
Fixes DGRAPH-2884
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1628)
<!-- Reviewable:end -->
