### PR TITLE
debug(iterator): Add debug logs for iterator crash

### DIFF
--- a/table/iterator.go
+++ b/table/iterator.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
-	"runtime/debug"
 	"sort"
 
 	"github.com/dgraph-io/badger/v2/fb"
@@ -90,12 +88,13 @@ func (itr *blockIterator) setIdx(i int) {
 	}
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Printf("==== Recovered====\n%s", string(debug.Stack()))
-			fmt.Printf("Table ID: %d\nBlock ID: %d\nEntry Idx: %d\nData len: %d\n"+
+			var debugBuf bytes.Buffer
+			fmt.Fprintf(&debugBuf, "==== Recovered====\n")
+			fmt.Fprintf(&debugBuf, "Table ID: %d\nBlock ID: %d\nEntry Idx: %d\nData len: %d\n"+
 				"StartOffset: %d\nEndOffset: %d\nEntryOffsets len: %d\nEntryOffsets: %v\n",
 				itr.tableID, itr.blockID, itr.idx, len(itr.data), startOffset, endOffset,
 				len(itr.entryOffsets), itr.entryOffsets)
-			os.Exit(1)
+			panic(debugBuf.String())
 		}
 	}()
 


### PR DESCRIPTION
This PR adds debug logs for the following crash:

```
panic: runtime error: slice bounds out of range [:527064] with capacity 4028

goroutine 3198697 [running]:
github.com/dgraph-io/badger/v2/table.(*blockIterator).setIdx(0xc1066a8010, 0x3b)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/table/iterator.go:87 +0x52c
github.com/dgraph-io/badger/v2/table.(*blockIterator).next(...)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/table/iterator.go:154
github.com/dgraph-io/badger/v2/table.(*Iterator).next(0xc1066a8000)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/table/iterator.go:322 +0x1b5
github.com/dgraph-io/badger/v2/table.(*Iterator).Next(0xc1066a8000)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/table/iterator.go:382 +0x3e
github.com/dgraph-io/badger/v2/table.(*ConcatIterator).Next(0xc1c2a40910)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/table/iterator.go:505 +0x33
github.com/dgraph-io/badger/v2/table.(*node).next(0xc18ff847d0)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/table/merge_iterator.go:81 +0x3d
github.com/dgraph-io/badger/v2/table.(*MergeIterator).Next(0xc18ff84790)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/table/merge_iterator.go:157 +0x38
github.com/dgraph-io/badger/v2.(*levelsController).subcompact.func3(0xc166c6f480)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/levels.go:646 +0x164
github.com/dgraph-io/badger/v2.(*levelsController).subcompact(0xc00011a0e0, 0x20719a0, 0xc18ff84790, 0xc1c26904c0, 0x1e, 0x1e, 0xc1c2690500, 0x1e, 0x1e, 0x0, ...)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/levels.go:765 +0x547
github.com/dgraph-io/badger/v2.(*levelsController).compactBuildTables.func3(0xc154706100, 0xc1547060c0, 0xc00011a0e0, 0xc2e581ab60, 0xc1c266e060, 0xc1c26904c0, 0x1e, 0x1e, 0xc1c2690500, 0x1e, ...)
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/levels.go:868 +0x1c9
created by github.com/dgraph-io/badger/v2.(*levelsController).compactBuildTables
        /usr/local/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20201112000450-e002a9d4a500/levels.go:864 +0x620
```

I had to add two new fields (blockID and tableID) in `blockIterator` for the debug logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1629)
<!-- Reviewable:end -->
