### PR TITLE
fix(compaction): Set base level correctly after stream

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -424,7 +424,8 @@ func (s *levelsController) levelTargets() targets {
 	// If the base level is empty and the next level size is less than the
 	// target size, pick the next level as the base level.
 	b := t.baseLevel
-	if s.levels[b].getTotalSize() == 0 && s.levels[b+1].getTotalSize() < t.targetSz[b+1] {
+	lvl := s.levels
+	if b < len(lvl)-1 && lvl[b].getTotalSize() == 0 && lvl[b+1].getTotalSize() < t.targetSz[b+1] {
 		t.baseLevel++
 	}
 	return t

--- a/levels.go
+++ b/levels.go
@@ -412,6 +412,21 @@ func (s *levelsController) levelTargets() targets {
 			t.fileSz[i] = tsz
 		}
 	}
+
+	// Bring the base level down to the last empty level.
+	for i := t.baseLevel + 1; i < len(s.levels)-1; i++ {
+		if s.levels[i].getTotalSize() > 0 {
+			break
+		}
+		t.baseLevel = i
+	}
+
+	// If the base level is empty and the next level size is less than the
+	// target size, pick the next level as the base level.
+	b := t.baseLevel
+	if s.levels[b].getTotalSize() == 0 && s.levels[b+1].getTotalSize() < t.targetSz[b+1] {
+		t.baseLevel++
+	}
 	return t
 }
 


### PR DESCRIPTION
When we use stream writer, all the data is written to the last level. On the restart, badger will try to figure out the correct base level. This computation of base level is incorrect right now because of which we pick the baseLevel which has levels below it that are empty.

The following is the state of badger directory after a stream writer and restart.
**On master** (base level on 3 while 4 and 5 are empty)
```
Level 0 [ ]: NumTables: 01. Size: 27 MiB of 0 B. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 64 MiB
Level 1 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level 2 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level 3 [B]: NumTables: 71. Size: 136 MiB of 10 MiB. Score: 13.60->1359.74 StaleData: 0 B Target FileSize: 2.0 MiB
Level 4 [ ]: NumTables: 00. Size: 0 B of 23 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 4.0 MiB
Level 5 [ ]: NumTables: 00. Size: 0 B of 233 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 8.0 MiB
Level 6 [ ]: NumTables: 40. Size: 2.3 GiB of 2.3 GiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 16 MiB
```
**This PR** (base level at 5)
```
Level 0 [ ]: NumTables: 01. Size: 27 MiB of 0 B. Score: 0.00->0.00 Target FileSize: 64 MiB
Level 1 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 Target FileSize: 2.0 MiB
Level 2 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 Target FileSize: 2.0 MiB
Level 3 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 Target FileSize: 2.0 MiB
Level 4 [ ]: NumTables: 00. Size: 0 B of 23 MiB. Score: 0.00->0.00 Target FileSize: 4.0 MiB
Level 5 [B]: NumTables: 18. Size: 136 MiB of 233 MiB. Score: 0.00->0.00 Target FileSize: 8.0 MiB
Level 6 [ ]: NumTables: 40. Size: 2.3 GiB of 2.3 GiB. Score: 0.00->0.00 Target FileSize: 16 MiB
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1631)
<!-- Reviewable:end -->
