### PR TITLE
chore(stream): log the estimated size of data to be streamed

### DIFF
--- a/db.go
+++ b/db.go
@@ -1300,6 +1300,19 @@ func (db *DB) Levels() []LevelInfo {
 	return db.lc.getLevelInfo()
 }
 
+// EstimateSize can be used to get rough estimate of data size for a given prefix.
+func (db *DB) EstimateSize(prefix []byte) (uint64, uint64) {
+	var onDiskSize, uncompressedSize uint64
+	tables := db.Tables()
+	for _, ti := range tables {
+		if bytes.HasPrefix(ti.Left, prefix) && bytes.HasPrefix(ti.Right, prefix) {
+			onDiskSize += uint64(ti.OnDiskSize)
+			uncompressedSize += uint64(ti.UncompressedSize)
+		}
+	}
+	return onDiskSize, uncompressedSize
+}
+
 // KeySplits can be used to get rough key ranges to divide up iteration over
 // the DB.
 func (db *DB) KeySplits(prefix []byte) []string {

--- a/iterator.go
+++ b/iterator.go
@@ -564,8 +564,9 @@ func (it *Iterator) Next() {
 
 	// Set next item to current
 	it.item = it.data.pop()
-	it.scanned = len(it.item.key) + len(it.item.val) + len(it.item.vptr) + 1 + 1 // meta + usermeta
-
+	if it.item != nil {
+		it.scanned += len(it.item.key) + len(it.item.val) + len(it.item.vptr) + 2 // meta + usermeta
+	}
 	for it.iitr.Valid() {
 		if it.parseItem() {
 			// parseItem calls one extra next.

--- a/iterator.go
+++ b/iterator.go
@@ -560,9 +560,9 @@ func (it *Iterator) Close() {
 func (it *Iterator) Next() {
 	// Reuse current item
 	it.item.wg.Wait() // Just cleaner to wait before pushing to avoid doing ref counting.
+	it.scanned += len(it.item.key) + len(it.item.val) + len(it.item.vptr) + 2
 	it.waste.push(it.item)
 
-	it.scanned += len(it.item.key) + len(it.item.val) + len(it.item.vptr) + 2 // meta + usermeta
 	// Set next item to current
 	it.item = it.data.pop()
 	for it.iitr.Valid() {

--- a/iterator.go
+++ b/iterator.go
@@ -429,7 +429,8 @@ type Iterator struct {
 
 	lastKey []byte // Used to skip over multiple versions of the same key.
 
-	closed bool
+	closed  bool
+	scanned int // Used to estimate the size of data scanned by iterator.
 
 	// ThreadId is an optional value that can be set to identify which goroutine created
 	// the iterator. It can be used, for example, to uniquely identify each of the
@@ -563,6 +564,7 @@ func (it *Iterator) Next() {
 
 	// Set next item to current
 	it.item = it.data.pop()
+	it.scanned = len(it.item.key) + len(it.item.val) + len(it.item.vptr) + 1 + 1 // meta + usermeta
 
 	for it.iitr.Valid() {
 		if it.parseItem() {

--- a/iterator.go
+++ b/iterator.go
@@ -562,11 +562,9 @@ func (it *Iterator) Next() {
 	it.item.wg.Wait() // Just cleaner to wait before pushing to avoid doing ref counting.
 	it.waste.push(it.item)
 
+	it.scanned += len(it.item.key) + len(it.item.val) + len(it.item.vptr) + 2 // meta + usermeta
 	// Set next item to current
 	it.item = it.data.pop()
-	if it.item != nil {
-		it.scanned += len(it.item.key) + len(it.item.val) + len(it.item.vptr) + 2 // meta + usermeta
-	}
 	for it.iitr.Valid() {
 		if it.parseItem() {
 			// parseItem calls one extra next.

--- a/stream.go
+++ b/stream.go
@@ -88,7 +88,6 @@ type Stream struct {
 	kvChan       chan *z.Buffer
 	nextStreamId uint32
 	doneMarkers  bool
-	estimatedSz  uint64
 }
 
 // SendDoneMarkers when true would send out done markers on the stream. False by default.
@@ -283,6 +282,10 @@ func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
 }
 
 func (st *Stream) streamKVs(ctx context.Context) error {
+	onDiskSize, uncompressedSize := st.db.EstimateSize(st.Prefix)
+	st.db.opt.Infof("%s Streaming about %s of uncompressed data (%s on disk)\n",
+		st.LogPrefix, humanize.Bytes(uncompressedSize), humanize.Bytes(onDiskSize))
+
 	var bytesSent uint64
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
@@ -343,14 +346,13 @@ outer:
 			}
 			speed := bytesSent / durSec
 			var timeInfo string
-			if st.estimatedSz > bytesSent {
-				eta := time.Duration((st.estimatedSz-bytesSent)/speed) * time.Second
+			if uncompressedSize > bytesSent {
+				eta := time.Duration((uncompressedSize-bytesSent)/speed) * time.Second
 				timeInfo = fmt.Sprintf("Time elapsed: %s, Time remaining: %s",
 					y.FixedDuration(dur), y.FixedDuration(eta))
 			} else {
 				timeInfo = fmt.Sprintf("Time elapsed: %s,", y.FixedDuration(dur))
 			}
-
 			st.db.opt.Infof("%s %s, bytes sent: %s, speed: %s/sec, jemalloc: %s\n",
 				st.LogPrefix, timeInfo, humanize.IBytes(bytesSent),
 				humanize.IBytes(speed), humanize.IBytes(uint64(z.NumAllocBytes())))
@@ -392,11 +394,6 @@ func (st *Stream) Orchestrate(ctx context.Context) error {
 	if st.KeyToList == nil {
 		st.KeyToList = st.ToList
 	}
-
-	onDiskSize, uncompressedSize := st.db.EstimateSize(st.Prefix)
-	st.estimatedSz = onDiskSize
-	st.db.opt.Infof("%s Streaming about %s of uncompressed data (%s on disk)\n",
-		st.LogPrefix, humanize.Bytes(uncompressedSize), humanize.Bytes(onDiskSize))
 
 	// Picks up ranges from Badger, and sends them to rangeCh.
 	go st.produceRanges(ctx)

--- a/stream.go
+++ b/stream.go
@@ -228,13 +228,14 @@ func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
 			if len(kr.right) > 0 && bytes.Compare(item.Key(), kr.right) >= 0 {
 				break
 			}
+
+			sz := uint64(len(item.key)+len(item.vptr)+len(item.val)) + 1 + 1 // meta + usermeta
+			atomic.AddUint64(&st.scanned, sz)
+
 			// Check if we should pick this key.
 			if st.ChooseKey != nil && !st.ChooseKey(item) {
 				continue
 			}
-
-			sz := uint64(len(item.key)+len(item.vptr)+len(item.val)) + 1 + 1 // meta + usermeta
-			atomic.AddUint64(&st.scanned, sz)
 
 			// Now convert to key value.
 			itr.Alloc.Reset()


### PR DESCRIPTION
Fixes DGRAPH-2833
When you're scanning a lot, but sending little data, the stream framework seems to work really slowly. But, that's deceiving, because it is scanning really fast.
We calculate the rough uncompressed size of the data the stream framework will send. We also periodically log the amount of data scanned by produceKVs.

If I stream the predicate with badger stream, then I get following logs:
```
badger 2021/01/05 12:52:13 INFO: Streaming DB to new DB at ./dir Time elapsed: 01s, scanned: ~823 MiB/17 GiB, bytes sent: 240 MiB, speed: 240 MiB/sec,jemalloc: 2.5 GiB
badger 2021/01/05 12:52:15 INFO: Streaming DB to new DB at ./dir Time elapsed: 02s, scanned: ~1.1 GiB/17 GiB, bytes sent: 576 MiB, speed: 288 MiB/sec,jemalloc: 3.6 GiB
badger 2021/01/05 12:52:15 INFO: Streaming DB to new DB at ./dir Time elapsed: 03s, scanned: ~1.3 GiB/17 GiB, bytes sent: 800 MiB, speed: 267 MiB/sec,jemalloc: 4.4 GiB
badger 2021/01/05 12:52:18 INFO: Streaming DB to new DB at ./dir Time elapsed: 06s, scanned: ~2.1 GiB/17 GiB, bytes sent: 1.7 GiB, speed: 283 MiB/sec,jemalloc: 7.4 GiB
badger 2021/01/05 12:52:20 INFO: Streaming DB to new DB at ./dir Time elapsed: 08s, scanned: ~2.6 GiB/17 GiB, bytes sent: 2.2 GiB, speed: 282 MiB/sec,jemalloc: 7.4 GiB
...
badger 2021/01/05 12:53:12 INFO: Streaming DB to new DB at ./dir Time elapsed: 01m00s, scanned: ~16 GiB/17 GiB, bytes sent: 16 GiB, speed: 278 MiB/sec,jemalloc: 7.4 GiB
badger 2021/01/05 12:53:14 INFO: Streaming DB to new DB at ./dir Time elapsed: 01m01s, scanned: ~16 GiB/17 GiB, bytes sent: 17 GiB, speed: 281 MiB/sec,jemalloc: 7.4 GiB
badger 2021/01/05 12:53:17 INFO: Streaming DB to new DB at ./dir Time elapsed: 01m04s, scanned: ~17 GiB/17 GiB, bytes sent: 17 GiB, speed: 278 MiB/sec,jemalloc: 7.3 GiB
badger 2021/01/05 12:53:18 INFO: Streaming DB to new DB at ./dir Time elapsed: 01m05s, scanned: ~17 GiB/17 GiB, bytes sent: 18 GiB, speed: 278 MiB/sec,jemalloc: 7.2 GiB
badger 2021/01/05 12:53:20 INFO: Streaming DB to new DB at ./dir Time elapsed: 01m07s, scanned: ~17 GiB/17 GiB, bytes sent: 18 GiB, speed: 278 MiB/sec,jemalloc: 6.9 GiB
badger 2021/01/05 12:53:21 INFO: Streaming DB to new DB at ./dir Time elapsed: 01m08s, scanned: ~17 GiB/17 GiB, bytes sent: 18 GiB, speed: 277 MiB/sec,jemalloc: 6.7 GiB
badger 2021/01/05 12:53:22 INFO: Streaming DB to new DB at ./dir Time elapsed: 01m09s, scanned: ~17 GiB/17 GiB, bytes sent: 19 GiB, speed: 276 MiB/sec,jemalloc: 6.3 GiB
```

Predicate movement which uses stream framework spits the following logs:
```
I0104 17:57:43.321575 3794523 log.go:34] Sending predicate: [comment.text] Streaming about 18 GB of uncompressed data (12 GB on disk)
...
I0106 12:22:02.074005  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 01s, scanned: ~86 MB/18 GB, bytes sent: 0 B, speed: 0 B/sec,jemalloc: 930 MiB
I0106 12:22:04.195811  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 03s, scanned: ~182 MB/18 GB, bytes sent: 128 MiB, speed: 43 MiB/sec,jemalloc: 930 MiB
I0106 12:22:15.538932  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 14s, scanned: ~981 MB/18 GB, bytes sent: 368 MiB, speed: 26 MiB/sec,jemalloc: 1.9 GiB
I0106 12:22:31.611034  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 30s, scanned: ~1.3 GB/18 GB, bytes sent: 704 MiB, speed: 24 MiB/sec,jemalloc: 1.9 GiB
I0106 12:22:42.071525  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 40s, scanned: ~1.5 GB/18 GB, bytes sent: 928 MiB, speed: 23 MiB/sec,jemalloc: 1.9 GiB
I0106 12:23:18.647787  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 01m17s, scanned: ~2.3 GB/18 GB, bytes sent: 1.7 GiB, speed: 22 MiB/sec,jemalloc: 1.9 GiB
...
I0106 12:35:21.111361  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 13m20s, scanned: ~17 GB/18 GB, bytes sent: 16 GiB, speed: 21 MiB/sec,jemalloc: 1.9 GiB
I0106 12:35:32.212137  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 13m31s, scanned: ~17 GB/18 GB, ...
I0106 12:37:18.934390  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 15m17s, scanned: ~18 GB/18 GB, bytes sent: 19 GiB, speed: 21 MiB/sec,jemalloc: 1.7 GiB
I0106 12:37:25.456424  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 15m24s, scanned: ~19 GB/18 GB, bytes sent: 19 GiB, speed: 21 MiB/sec,jemalloc: 1.7 GiB
...
I0106 12:38:43.878926  261336 log.go:34] Sending predicate: [comment.text] Time elapsed: 16m42s, scanned: ~19 GB/18 GB, bytes sent: 20 GiB, speed: 20 MiB/sec,jemalloc: 639 MiB
I0106 12:38:43.878950  261336 log.go:34] Sending predicate: [comment.text] Sent data of size 20 GiB
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1632)
<!-- Reviewable:end -->
