### PR TITLE
chore(info): add checksum verification mode flag to badger info

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -39,18 +39,18 @@ import (
 )
 
 type flagOptions struct {
-	showTables       bool
-	showHistogram    bool
-	showKeys         bool
-	withPrefix       string
-	keyLookup        string
-	itemMeta         bool
-	keyHistory       bool
-	showInternal     bool
-	readOnly         bool
-	truncate         bool
-	encryptionKey    string
-	verificationMode string
+	showTables               bool
+	showHistogram            bool
+	showKeys                 bool
+	withPrefix               string
+	keyLookup                string
+	itemMeta                 bool
+	keyHistory               bool
+	showInternal             bool
+	readOnly                 bool
+	truncate                 bool
+	encryptionKey            string
+	checksumVerificationMode string
 }
 
 var (
@@ -78,7 +78,7 @@ func init() {
 	infoCmd.Flags().BoolVar(&opt.truncate, "truncate", false, "If set to true, it allows "+
 		"truncation of value log files if they have corrupt data.")
 	infoCmd.Flags().StringVar(&opt.encryptionKey, "enc-key", "", "Use the provided encryption key")
-	infoCmd.Flags().StringVar(&opt.verificationMode, "verification-mode", "none",
+	infoCmd.Flags().StringVar(&opt.checksumVerificationMode, "cv-mode", "none",
 		"[none, table, block, tableAndBlock] Specifies when the db should verify checksum for SST.")
 }
 
@@ -99,7 +99,7 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 		return y.Wrap(err, "failed to print information in MANIFEST file")
 	}
 
-	cvMode, err := checksumVerificationMode(opt.verificationMode)
+	cvMode, err := checksumVerificationMode(opt.checksumVerificationMode)
 	if err != nil {
 		return err
 	}

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -99,10 +99,7 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 		return y.Wrap(err, "failed to print information in MANIFEST file")
 	}
 
-	cvMode, err := checksumVerificationMode(opt.checksumVerificationMode)
-	if err != nil {
-		return err
-	}
+	cvMode := checksumVerificationMode(opt.checksumVerificationMode)
 	// Open DB
 	db, err := badger.Open(badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
@@ -487,16 +484,19 @@ func pluralFiles(count int) string {
 	return "files"
 }
 
-func checksumVerificationMode(cvMode string) (options.ChecksumVerificationMode, error) {
+func checksumVerificationMode(cvMode string) options.ChecksumVerificationMode {
 	switch cvMode {
 	case "none":
-		return options.NoVerification, nil
+		return options.NoVerification
 	case "table":
-		return options.OnTableRead, nil
+		return options.OnTableRead
 	case "block":
-		return options.OnBlockRead, nil
+		return options.OnBlockRead
 	case "tableAndblock":
-		return options.OnTableAndBlockRead, nil
+		return options.OnTableAndBlockRead
+	default:
+		fmt.Printf("Invalid checksum verification mode: %s\n", cvMode)
+		os.Exit(1)
 	}
-	return options.NoVerification, errors.Errorf("Invalid checksum verification mode %s", cvMode)
+	return options.NoVerification
 }

--- a/errors.go
+++ b/errors.go
@@ -82,10 +82,6 @@ var (
 	// ErrZeroBandwidth is returned if the user passes in zero bandwidth for sequence.
 	ErrZeroBandwidth = errors.New("Bandwidth must be greater than zero")
 
-	// ErrInvalidLoadingMode is returned when opt.ValueLogLoadingMode option is not
-	// within the valid range
-	ErrInvalidLoadingMode = errors.New("Invalid ValueLogLoadingMode, must be FileIO or MemoryMap")
-
 	// ErrWindowsNotSupported is returned when opt.ReadOnly is used on Windows
 	ErrWindowsNotSupported = errors.New("Read-only mode is not supported on Windows")
 


### PR DESCRIPTION
This PR adds a checksum verification mode (`--cv-mode`)  flag to `badger info` tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1644)
<!-- Reviewable:end -->
