### PR TITLE
fix: update ristretto and use filepath

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -248,7 +247,7 @@ func dur(src, dst time.Time) string {
 func getInfo(fileInfos []os.FileInfo, tid uint64) int64 {
 	fileName := table.IDToFilename(tid)
 	for _, fi := range fileInfos {
-		if path.Base(fi.Name()) == fileName {
+		if filepath.Base(fi.Name()) == fileName {
 			return fi.Size()
 		}
 	}

--- a/badger/cmd/restore.go
+++ b/badger/cmd/restore.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"math"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/spf13/cobra"
@@ -56,7 +56,7 @@ func init() {
 
 func doRestore(cmd *cobra.Command, args []string) error {
 	// Check if the DB already exists
-	manifestFile := path.Join(sstDir, badger.ManifestFilename)
+	manifestFile := filepath.Join(sstDir, badger.ManifestFilename)
 	if _, err := os.Stat(manifestFile); err == nil { // No error. File already exists.
 		return errors.New("Cannot restore to an already existing database")
 	} else if os.IsNotExist(err) {

--- a/db2_test.go
+++ b/db2_test.go
@@ -27,7 +27,7 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sync"
@@ -73,7 +73,7 @@ func TestTruncateVlogWithClose(t *testing.T) {
 	// Close the DB.
 	require.NoError(t, db.Close())
 	// We start value logs at 1.
-	require.NoError(t, os.Truncate(path.Join(dir, "000001.vlog"), 4090))
+	require.NoError(t, os.Truncate(filepath.Join(dir, "000001.vlog"), 4090))
 
 	// Reopen and write some new data.
 	db, err = Open(opt)

--- a/discard.go
+++ b/discard.go
@@ -19,7 +19,7 @@ package badger
 import (
 	"encoding/binary"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"sync"
 
@@ -40,7 +40,7 @@ type discardStats struct {
 const discardFname string = "DISCARD"
 
 func initDiscardStats(opt Options) (*discardStats, error) {
-	fname := path.Join(opt.ValueDir, discardFname)
+	fname := filepath.Join(opt.ValueDir, discardFname)
 
 	// 1GB file can store 67M discard entries. Each entry is 16 bytes.
 	mf, err := z.OpenMmapFile(fname, os.O_CREATE|os.O_RDWR, 1<<20)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20201224172411-e860a6c48e8a
+	github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2
+	github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20201224172411-e860a6c48e8a h1:jbJJPy2En2HoeNzt3C8Pc03O6+WRmle0O+xTNiORZW0=
-github.com/dgraph-io/ristretto v0.0.4-0.20201224172411-e860a6c48e8a/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
+github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2 h1:Ii2KMtC40rP1jJB08GVFfQh/NEca2LBjKokO45N7xes=
+github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2 h1:Ii2KMtC40rP1jJB08GVFfQh/NEca2LBjKokO45N7xes=
-github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
+github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d h1:eQYOG6A4td1tht0NdJB9Ls6DsXRGb2Ft6X9REU/MbbE=
+github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/memtable.go
+++ b/memtable.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -164,7 +164,7 @@ func (db *DB) newMemTable() (*memTable, error) {
 }
 
 func (db *DB) mtFilePath(fid int) string {
-	return path.Join(db.opt.Dir, fmt.Sprintf("%05d%s", fid, memFileExt))
+	return filepath.Join(db.opt.Dir, fmt.Sprintf("%05d%s", fid, memFileExt))
 }
 
 func (mt *memTable) SyncWAL() error {

--- a/table/table.go
+++ b/table/table.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -767,7 +766,7 @@ func (t *Table) decrypt(data []byte, viaCalloc bool) ([]byte, error) {
 
 // ParseFileID reads the file id out of a filename.
 func ParseFileID(name string) (uint64, bool) {
-	name = path.Base(name)
+	name = filepath.Base(name)
 	if !strings.HasSuffix(name, fileSuffix) {
 		return 0, false
 	}


### PR DESCRIPTION
This ristretto update brings in fixes for windows. This also updates badger not to use path as it is not safe for windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1649)
<!-- Reviewable:end -->
