### PR TITLE
release/v3.2011: fix(badger): Do not reuse variable across badger commands (#1624)

### DIFF
--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -25,7 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var backupFile string
+var bo = struct {
+	backupFile  string
+	numVersions int
+}{}
 
 // backupCmd represents the backup command
 var backupCmd = &cobra.Command{
@@ -42,9 +45,9 @@ database.`,
 
 func init() {
 	RootCmd.AddCommand(backupCmd)
-	backupCmd.Flags().StringVarP(&backupFile, "backup-file", "f",
+	backupCmd.Flags().StringVarP(&bo.backupFile, "backup-file", "f",
 		"badger.bak", "File to backup to")
-	backupCmd.Flags().IntVarP(&numVersions, "num-versions", "n",
+	backupCmd.Flags().IntVarP(&bo.numVersions, "num-versions", "n",
 		0, "Number of versions to keep. A value <= 0 means keep all versions.")
 }
 
@@ -53,8 +56,8 @@ func doBackup(cmd *cobra.Command, args []string) error {
 		WithValueDir(vlogDir).
 		WithNumVersionsToKeep(math.MaxInt32)
 
-	if numVersions > 0 {
-		opt.NumVersionsToKeep = numVersions
+	if bo.numVersions > 0 {
+		opt.NumVersionsToKeep = bo.numVersions
 	}
 
 	// Open DB
@@ -65,7 +68,7 @@ func doBackup(cmd *cobra.Command, args []string) error {
 	defer db.Close()
 
 	// Create File
-	f, err := os.Create(backupFile)
+	f, err := os.Create(bo.backupFile)
 	if err != nil {
 		return err
 	}

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -21,6 +21,8 @@ import (
 	"math"
 
 	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v3/options"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -33,36 +35,48 @@ This command would compact all the LSM tables into one level.
 	RunE: flatten,
 }
 
-var keyPath string
-var numWorkers int
+var fo = struct {
+	keyPath         string
+	numWorkers      int
+	numVersions     int
+	compressionType uint32
+}{}
 
 func init() {
 	RootCmd.AddCommand(flattenCmd)
-	flattenCmd.Flags().IntVarP(&numWorkers, "num-workers", "w", 1,
+	flattenCmd.Flags().IntVarP(&fo.numWorkers, "num-workers", "w", 1,
 		"Number of concurrent compactors to run. More compactors would use more"+
 			" server resources to potentially achieve faster compactions.")
-	flattenCmd.Flags().IntVarP(&numVersions, "num_versions", "", 1,
+	flattenCmd.Flags().IntVarP(&fo.numVersions, "num_versions", "", 0,
 		"Option to configure the maximum number of versions per key. "+
 			"Values <= 0 will be considered to have the max number of versions.")
-	flattenCmd.Flags().StringVar(&keyPath, "encryption-key-file", "",
+	flattenCmd.Flags().StringVar(&fo.keyPath, "encryption-key-file", "",
 		"Path of the encryption key file.")
+	flattenCmd.Flags().Uint32VarP(&fo.compressionType, "compression", "", 1,
+		"Option to configure the compression type in output DB. "+
+			"0 to disable, 1 for Snappy, and 2 for ZSTD.")
 }
 
 func flatten(cmd *cobra.Command, args []string) error {
-	if numVersions <= 0 {
+	if fo.numVersions <= 0 {
 		// Keep all versions.
-		numVersions = math.MaxInt32
+		fo.numVersions = math.MaxInt32
 	}
-	encKey, err := getKey(keyPath)
+	encKey, err := getKey(fo.keyPath)
 	if err != nil {
 		return err
 	}
+	if fo.compressionType < 0 || fo.compressionType > 2 {
+		return errors.Errorf(
+			"compression value must be one of 0 (disabled), 1 (Snappy), or 2 (ZSTD)")
+	}
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithNumVersionsToKeep(numVersions).
+		WithNumVersionsToKeep(fo.numVersions).
 		WithNumCompactors(0).
 		WithBlockCacheSize(100 << 20).
 		WithIndexCacheSize(200 << 20).
+		WithCompression(options.CompressionType(fo.compressionType)).
 		WithEncryptionKey(encKey)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.Open(opt)
@@ -71,5 +85,5 @@ func flatten(cmd *cobra.Command, args []string) error {
 	}
 	defer db.Close()
 
-	return db.Flatten(numWorkers)
+	return db.Flatten(fo.numWorkers)
 }


### PR DESCRIPTION
The same variables were being across multiple badger commands. The
default value of a flag that uses the same variable across two commands
could be from one of the commands and it isn't clear which default value
would be used.

The numVersions command was being used in flatten (default value 1)
and stream (default value 0). Running badger stream --help would show
the default value to be 0 but if you print the value of the
numVersions variable, it would turn out to be 1. This is misleading.

This PR separates the variable so that they don't overlap.

This PR also adds the compression flag to the flatten tool.

(cherry picked from commit 3adc574c149019f3373fc4fbfd252c38d5598c08)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1650)
<!-- Reviewable:end -->
