### PR TITLE
release/v3.2011: fix(compaction): Set base level correctly after stream (#1631)

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -412,6 +412,22 @@ func (s *levelsController) levelTargets() targets {
 			t.fileSz[i] = tsz
 		}
 	}
+
+	// Bring the base level down to the last empty level.
+	for i := t.baseLevel + 1; i < len(s.levels)-1; i++ {
+		if s.levels[i].getTotalSize() > 0 {
+			break
+		}
+		t.baseLevel = i
+	}
+
+	// If the base level is empty and the next level size is less than the
+	// target size, pick the next level as the base level.
+	b := t.baseLevel
+	lvl := s.levels
+	if b < len(lvl)-1 && lvl[b].getTotalSize() == 0 && lvl[b+1].getTotalSize() < t.targetSz[b+1] {
+		t.baseLevel++
+	}
 	return t
 }
 


### PR DESCRIPTION
When we use stream writer, all the data is written to the last level. On the restart,
badger will try to figure out the correct base level. This computation of base level
is incorrect right now because of which we pick the baseLevel which has levels
below it that are empty.

(cherry picked from commit d1125c41994c50b8d75fab2ceaf59f1acc3014f2)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1651)
<!-- Reviewable:end -->
