### PR TITLE
Support SinceTs in iterators

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 // flushThreshold determines when a buffer will be flushed. When performing a
@@ -68,6 +69,10 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 			item := itr.Item()
 			if !bytes.Equal(item.Key(), key) {
 				return list, nil
+			}
+			if item.Version() < since {
+				return nil, errors.Errorf("Backup: Item Version: %d less than sinceTs: %d",
+					item.Version(), since)
 			}
 
 			var valCopy []byte

--- a/backup.go
+++ b/backup.go
@@ -48,6 +48,7 @@ const flushThreshold = 100 << 20
 func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 	stream := db.NewStream()
 	stream.LogPrefix = "DB.Backup"
+	stream.SinceTs = since
 	return stream.Backup(w, since)
 }
 
@@ -66,11 +67,6 @@ func (stream *Stream) Backup(w io.Writer, since uint64) (uint64, error) {
 		for ; itr.Valid(); itr.Next() {
 			item := itr.Item()
 			if !bytes.Equal(item.Key(), key) {
-				return list, nil
-			}
-			if item.Version() < since {
-				// Ignore versions less than given timestamp, or skip older
-				// versions of the given key.
 				return list, nil
 			}
 

--- a/iterator.go
+++ b/iterator.go
@@ -368,8 +368,13 @@ func (opt *IteratorOptions) pickTable(t table.TableInterface) bool {
 // that the tables are sorted in the right order.
 func (opt *IteratorOptions) pickTables(all []*table.Table) []*table.Table {
 	if len(opt.Prefix) == 0 {
-		out := make([]*table.Table, len(all))
-		copy(out, all)
+		out := make([]*table.Table, 0, len(all))
+		for _, t := range all {
+			if t.MaxVersion() < opt.SinceTs {
+				continue
+			}
+			out = append(out, t)
+		}
 		return out
 	}
 	sIdx := sort.Search(len(all), func(i int) bool {

--- a/iterator.go
+++ b/iterator.go
@@ -368,6 +368,11 @@ func (opt *IteratorOptions) pickTable(t table.TableInterface) bool {
 // that the tables are sorted in the right order.
 func (opt *IteratorOptions) pickTables(all []*table.Table) []*table.Table {
 	if len(opt.Prefix) == 0 {
+		if opt.SinceTs == 0 {
+			out := make([]*table.Table, len(all))
+			copy(out, all)
+			return out
+		}
 		out := make([]*table.Table, 0, len(all))
 		for _, t := range all {
 			if t.MaxVersion() < opt.SinceTs {

--- a/levels_test.go
+++ b/levels_test.go
@@ -230,10 +230,10 @@ func TestCompaction(t *testing.T) {
 
 	t.Run("level 0 to level 1 with lower overlap", func(t *testing.T) {
 		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
-			l0 := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
-			l01 := []keyValVersion{{"foo", "bar", 2, 0}}
-			l1 := []keyValVersion{{"foo", "bar", 1, 0}}
-			l2 := []keyValVersion{{"foo", "bar", 0, 0}}
+			l0 := []keyValVersion{{"foo", "bar", 4, 0}, {"fooz", "baz", 1, 0}}
+			l01 := []keyValVersion{{"foo", "bar", 3, 0}}
+			l1 := []keyValVersion{{"foo", "bar", 2, 0}}
+			l2 := []keyValVersion{{"foo", "bar", 1, 0}}
 			// Level 0 has table l0 and l01.
 			createAndOpen(db, l0, 0)
 			createAndOpen(db, l01, 0)
@@ -246,8 +246,8 @@ func TestCompaction(t *testing.T) {
 			db.SetDiscardTs(10)
 
 			getAllAndCheck(t, db, []keyValVersion{
-				{"foo", "bar", 3, 0}, {"foo", "bar", 2, 0}, {"foo", "bar", 1, 0},
-				{"foo", "bar", 0, 0}, {"fooz", "baz", 1, 0},
+				{"foo", "bar", 4, 0}, {"foo", "bar", 3, 0}, {"foo", "bar", 2, 0},
+				{"foo", "bar", 1, 0}, {"fooz", "baz", 1, 0},
 			})
 			cdef := compactDef{
 				thisLevel: db.lc.levels[0],
@@ -260,7 +260,7 @@ func TestCompaction(t *testing.T) {
 			require.NoError(t, db.lc.runCompactDef(-1, 0, cdef))
 			// foo version 2 and version 1 should be dropped after compaction.
 			getAllAndCheck(t, db, []keyValVersion{
-				{"foo", "bar", 3, 0}, {"foo", "bar", 0, 0}, {"fooz", "baz", 1, 0},
+				{"foo", "bar", 4, 0}, {"foo", "bar", 1, 0}, {"fooz", "baz", 1, 0},
 			})
 		})
 	})

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -761,12 +761,12 @@ func TestWriteBatchDuplicate(t *testing.T) {
 			wb := db.NewManagedWriteBatch()
 			defer wb.Cancel()
 
-			for i := uint64(0); i < uint64(N); i++ {
+			for i := uint64(1); i <= uint64(N); i++ {
 				// Multiple versions of the same key.
 				require.NoError(t, wb.SetEntryAt(&Entry{Key: k, Value: v}, i))
 			}
 			require.NoError(t, wb.Flush())
-			readVerify(t, db, N, []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0})
+			readVerify(t, db, N, []int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1})
 		})
 	})
 }

--- a/stream.go
+++ b/stream.go
@@ -81,6 +81,8 @@ type Stream struct {
 	// single goroutine, i.e. logic within Send method can expect single threaded execution.
 	Send func(buf *z.Buffer) error
 
+	// Read data above the sinceTs. All keys with version < sinceTs will be ignored.
+	SinceTs      uint64
 	readTs       uint64
 	db           *DB
 	rangeCh      chan keyRange
@@ -193,6 +195,7 @@ func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
 		iterOpts.AllVersions = true
 		iterOpts.Prefix = st.Prefix
 		iterOpts.PrefetchValues = false
+		iterOpts.SinceTs = st.SinceTs
 		itr := txn.NewIterator(iterOpts)
 		itr.ThreadId = threadId
 		defer itr.Close()

--- a/stream.go
+++ b/stream.go
@@ -81,7 +81,7 @@ type Stream struct {
 	// single goroutine, i.e. logic within Send method can expect single threaded execution.
 	Send func(buf *z.Buffer) error
 
-	// Read data above the sinceTs. All keys with version < sinceTs will be ignored.
+	// Read data above the sinceTs. All keys with version =< sinceTs will be ignored.
 	SinceTs      uint64
 	readTs       uint64
 	db           *DB

--- a/table/table.go
+++ b/table/table.go
@@ -89,6 +89,7 @@ type TableInterface interface {
 	Smallest() []byte
 	Biggest() []byte
 	DoesNotHave(hash uint32) bool
+	MaxVersion() uint64
 }
 
 // Table represents a loaded table file with the info we have about it.


### PR DESCRIPTION
SinceTs can be used to read data above a particular timestamp. All data
less with version less than the sinceTs will be ignored.

SinceTs is always less than the readTs and when sinceTs is set, the
data between sinceTs and readTs will be read.

sinceTs < data to be read <= readTs

Fixes DGRAPH-2958
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1653)
<!-- Reviewable:end -->
