### PR TITLE
feat(options): add NumGoroutines option for default Stream.numGo

### DIFF
--- a/options.go
+++ b/options.go
@@ -48,6 +48,8 @@ type Options struct {
 	Logger            Logger
 	Compression       options.CompressionType
 	InMemory          bool
+	// Sets the default Stream.numGo
+	NumGoroutines int
 
 	// Fine tuning options.
 
@@ -125,6 +127,7 @@ func DefaultOptions(path string) Options {
 		TableSizeMultiplier: 2,
 		LevelSizeMultiplier: 10,
 		MaxLevels:           7,
+		NumGoroutines:       8,
 
 		NumCompactors:           4, // Run at least 2 compactors. Zero-th compactor prioritizes L0.
 		NumLevelZeroTables:      5,
@@ -249,6 +252,12 @@ func (opt Options) WithSyncWrites(val bool) Options {
 // The default value of NumVersionsToKeep is 1.
 func (opt Options) WithNumVersionsToKeep(val int) Options {
 	opt.NumVersionsToKeep = val
+	return opt
+}
+
+// TODO: document
+func (opt Options) WithNumGoroutines(val int) Options {
+	opt.NumGoroutines = val
 	return opt
 }
 

--- a/options.go
+++ b/options.go
@@ -48,7 +48,7 @@ type Options struct {
 	Logger            Logger
 	Compression       options.CompressionType
 	InMemory          bool
-	// Sets the default Stream.numGo
+	// Sets the Stream.numGo field
 	NumGoroutines int
 
 	// Fine tuning options.
@@ -255,7 +255,9 @@ func (opt Options) WithNumVersionsToKeep(val int) Options {
 	return opt
 }
 
-// TODO: document
+// WithNumGoroutines sets the number of goroutines to be used in Stream.
+//
+// The default value of NumGoroutines is 8.
 func (opt Options) WithNumGoroutines(val int) Options {
 	opt.NumGoroutines = val
 	return opt

--- a/stream.go
+++ b/stream.go
@@ -446,7 +446,7 @@ func (st *Stream) Orchestrate(ctx context.Context) error {
 func (db *DB) newStream() *Stream {
 	return &Stream{
 		db:        db,
-		NumGo:     8,
+		NumGo:     db.opt.NumGoroutines,
 		LogPrefix: "Badger.Stream",
 	}
 }


### PR DESCRIPTION
(This relates to DGRAPH-2953 and dgraph-io/dgraph#7387 because the best way to slow down backups rather than crash, is to set these goroutine flags.)

The `WithNumGoroutines(n int)` function sets the `NumGoroutines` option which is used as the default value of `Stream.numGo`. The default value of `8` for `Stream.numGo` stays the same, except now it's hardcoded under the default `NumGoroutines` option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1656)
<!-- Reviewable:end -->
