### PR TITLE
[BREAKING] fix(Subscribe): Add option to subscribe with holes in prefixes.

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -559,9 +559,9 @@ func runTest(cmd *cobra.Command, args []string) error {
 		subWg.Add(1)
 		go func() {
 			defer subWg.Done()
-			accountIDS := [][]byte{}
+			accountIDS := []pb.Match{}
 			for i := 0; i < numAccounts; i++ {
-				accountIDS = append(accountIDS, key(i))
+				accountIDS = append(accountIDS, pb.Match{Prefix: key(i), IgnoreBytes: ""})
 			}
 			updater := func(kvs *pb.KVList) error {
 				batch := subscribeDB.NewWriteBatch()
@@ -571,7 +571,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 
 				return batch.Flush()
 			}
-			_ = db.Subscribe(ctx, updater, "", accountIDS...)
+			_ = db.Subscribe(ctx, updater, accountIDS)
 		}()
 	}
 

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -571,7 +571,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 
 				return batch.Flush()
 			}
-			_ = db.Subscribe(ctx, updater, accountIDS...)
+			_ = db.Subscribe(ctx, updater, "", accountIDS...)
 		}()
 	}
 

--- a/db.go
+++ b/db.go
@@ -1826,18 +1826,17 @@ type KVList = pb.KVList
 // At least one prefix should be passed, or an error will be returned.
 // You can use an empty prefix to monitor all changes to the DB.
 // Ignore string is the byte ranges for which prefix matching will be ignored.
-// For example: ignore = "2-3", and prefix = "abcde" will match for keys "abxxe", "abdfe" etc.
+// For example: ignore = "2-3", and prefix = "abc" will match for keys "abxxc", "abdfc" etc.
 // This function blocks until the given context is done or an error occurs.
 // The given function will be called with a new KVList containing the modified keys and the
 // corresponding values.
-func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, ignore string,
-	prefixes ...[]byte) error {
+func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, matches []pb.Match) error {
 	if cb == nil {
 		return ErrNilCallback
 	}
 
 	c := z.NewCloser(1)
-	recvCh, id := db.pub.newSubscriber(c, ignore, prefixes...)
+	recvCh, id := db.pub.newSubscriber(c, matches)
 	slurp := func(batch *pb.KVList) error {
 		for {
 			select {

--- a/db.go
+++ b/db.go
@@ -1822,9 +1822,11 @@ func (db *DB) BannedNamespaces() []uint64 {
 // KVList contains a list of key-value pairs.
 type KVList = pb.KVList
 
-// Subscribe can be used to watch key changes for the given key prefixes.
+// Subscribe can be used to watch key changes for the given key prefixes and the ignore string.
 // At least one prefix should be passed, or an error will be returned.
 // You can use an empty prefix to monitor all changes to the DB.
+// Ignore string is the byte ranges for which prefix matching will be ignored.
+// For example: ignore = "2-3", and prefix = "abcde" will match for keys "abxxe", "abdfe" etc.
 // This function blocks until the given context is done or an error occurs.
 // The given function will be called with a new KVList containing the modified keys and the
 // corresponding values.

--- a/db.go
+++ b/db.go
@@ -1828,7 +1828,8 @@ type KVList = pb.KVList
 // This function blocks until the given context is done or an error occurs.
 // The given function will be called with a new KVList containing the modified keys and the
 // corresponding values.
-func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, ignore string, prefixes ...[]byte) error {
+func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, ignore string,
+	prefixes ...[]byte) error {
 	if cb == nil {
 		return ErrNilCallback
 	}

--- a/db.go
+++ b/db.go
@@ -1828,13 +1828,13 @@ type KVList = pb.KVList
 // This function blocks until the given context is done or an error occurs.
 // The given function will be called with a new KVList containing the modified keys and the
 // corresponding values.
-func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, prefixes ...[]byte) error {
+func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, ignore string, prefixes ...[]byte) error {
 	if cb == nil {
 		return ErrNilCallback
 	}
 
 	c := z.NewCloser(1)
-	recvCh, id := db.pub.newSubscriber(c, prefixes...)
+	recvCh, id := db.pub.newSubscriber(c, ignore, prefixes...)
 	slurp := func(batch *pb.KVList) error {
 		for {
 			select {

--- a/db_test.go
+++ b/db_test.go
@@ -1852,7 +1852,7 @@ func TestGoroutineLeak(t *testing.T) {
 						updated = true
 						wg.Done()
 						return nil
-					}, []byte("key"))
+					}, "", []byte("key"))
 					if err != nil {
 						require.Equal(t, err.Error(), context.Canceled.Error())
 					}

--- a/db_test.go
+++ b/db_test.go
@@ -1847,12 +1847,13 @@ func TestGoroutineLeak(t *testing.T) {
 				var wg sync.WaitGroup
 				wg.Add(1)
 				go func() {
+					match := pb.Match{Prefix: []byte("key"), IgnoreBytes: ""}
 					err := db.Subscribe(ctx, func(kvs *pb.KVList) error {
 						require.Equal(t, []byte("value"), kvs.Kv[0].GetValue())
 						updated = true
 						wg.Done()
 						return nil
-					}, "", []byte("key"))
+					}, []pb.Match{match})
 					if err != nil {
 						require.Equal(t, err.Error(), context.Canceled.Error())
 					}

--- a/publisher.go
+++ b/publisher.go
@@ -110,7 +110,7 @@ func (p *publisher) publishUpdates(reqs requests) {
 	}
 }
 
-func (p *publisher) newSubscriber(c *z.Closer, prefixes ...[]byte) (<-chan *pb.KVList, uint64) {
+func (p *publisher) newSubscriber(c *z.Closer, ignore string, prefixes ...[]byte) (<-chan *pb.KVList, uint64) {
 	p.Lock()
 	defer p.Unlock()
 	ch := make(chan *pb.KVList, 1000)
@@ -123,7 +123,11 @@ func (p *publisher) newSubscriber(c *z.Closer, prefixes ...[]byte) (<-chan *pb.K
 		subCloser: c,
 	}
 	for _, prefix := range prefixes {
-		p.indexer.Add(prefix, id)
+		m := pb.Match{
+			Prefix:      prefix,
+			IgnoreBytes: ignore,
+		}
+		p.indexer.AddMatch(m, id)
 	}
 	return ch, id
 }

--- a/publisher.go
+++ b/publisher.go
@@ -110,7 +110,8 @@ func (p *publisher) publishUpdates(reqs requests) {
 	}
 }
 
-func (p *publisher) newSubscriber(c *z.Closer, ignore string, prefixes ...[]byte) (<-chan *pb.KVList, uint64) {
+func (p *publisher) newSubscriber(c *z.Closer, ignore string,
+	prefixes ...[]byte) (<-chan *pb.KVList, uint64) {
 	p.Lock()
 	defer p.Unlock()
 	ch := make(chan *pb.KVList, 1000)

--- a/publisher.go
+++ b/publisher.go
@@ -26,7 +26,7 @@ import (
 )
 
 type subscriber struct {
-	prefixes  [][]byte
+	matches   []pb.Match
 	sendCh    chan<- *pb.KVList
 	subCloser *z.Closer
 }
@@ -110,8 +110,7 @@ func (p *publisher) publishUpdates(reqs requests) {
 	}
 }
 
-func (p *publisher) newSubscriber(c *z.Closer, ignore string,
-	prefixes ...[]byte) (<-chan *pb.KVList, uint64) {
+func (p *publisher) newSubscriber(c *z.Closer, matches []pb.Match) (<-chan *pb.KVList, uint64) {
 	p.Lock()
 	defer p.Unlock()
 	ch := make(chan *pb.KVList, 1000)
@@ -119,15 +118,11 @@ func (p *publisher) newSubscriber(c *z.Closer, ignore string,
 	// Increment next ID.
 	p.nextID++
 	p.subscribers[id] = subscriber{
-		prefixes:  prefixes,
+		matches:   matches,
 		sendCh:    ch,
 		subCloser: c,
 	}
-	for _, prefix := range prefixes {
-		m := pb.Match{
-			Prefix:      prefix,
-			IgnoreBytes: ignore,
-		}
+	for _, m := range matches {
 		p.indexer.AddMatch(m, id)
 	}
 	return ch, id
@@ -138,8 +133,8 @@ func (p *publisher) cleanSubscribers() {
 	p.Lock()
 	defer p.Unlock()
 	for id, s := range p.subscribers {
-		for _, prefix := range s.prefixes {
-			p.indexer.Delete(prefix, id)
+		for _, m := range s.matches {
+			p.indexer.DeleteMatch(m, id)
 		}
 		delete(p.subscribers, id)
 		s.subCloser.SignalAndWait()
@@ -150,8 +145,8 @@ func (p *publisher) deleteSubscriber(id uint64) {
 	p.Lock()
 	defer p.Unlock()
 	if s, ok := p.subscribers[id]; ok {
-		for _, prefix := range s.prefixes {
-			p.indexer.Delete(prefix, id)
+		for _, m := range s.matches {
+			p.indexer.DeleteMatch(m, id)
 		}
 	}
 	delete(p.subscribers, id)

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -45,7 +45,7 @@ func TestPublisherOrdering(t *testing.T) {
 					wg.Done()
 				}
 				return nil
-			}, []byte("ke"))
+			}, "", []byte("ke"))
 			if err != nil {
 				require.Equal(t, err.Error(), context.Canceled.Error())
 			}
@@ -86,7 +86,7 @@ func TestMultiplePrefix(t *testing.T) {
 					wg.Done()
 				}
 				return nil
-			}, []byte("ke"), []byte("hel"))
+			}, "", []byte("ke"), []byte("hel"))
 			if err != nil {
 				require.Equal(t, err.Error(), context.Canceled.Error())
 			}

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -36,6 +36,7 @@ func TestPublisherOrdering(t *testing.T) {
 		go func() {
 			subWg.Done()
 			updates := 0
+			match := pb.Match{Prefix: []byte("ke"), IgnoreBytes: ""}
 			err := db.Subscribe(context.Background(), func(kvs *pb.KVList) error {
 				updates += len(kvs.GetKv())
 				for _, kv := range kvs.GetKv() {
@@ -45,7 +46,7 @@ func TestPublisherOrdering(t *testing.T) {
 					wg.Done()
 				}
 				return nil
-			}, "", []byte("ke"))
+			}, []pb.Match{match})
 			if err != nil {
 				require.Equal(t, err.Error(), context.Canceled.Error())
 			}
@@ -73,6 +74,8 @@ func TestMultiplePrefix(t *testing.T) {
 		go func() {
 			subWg.Done()
 			updates := 0
+			match1 := pb.Match{Prefix: []byte("ke"), IgnoreBytes: ""}
+			match2 := pb.Match{Prefix: []byte("hel"), IgnoreBytes: ""}
 			err := db.Subscribe(context.Background(), func(kvs *pb.KVList) error {
 				updates += len(kvs.GetKv())
 				for _, kv := range kvs.GetKv() {
@@ -86,7 +89,7 @@ func TestMultiplePrefix(t *testing.T) {
 					wg.Done()
 				}
 				return nil
-			}, "", []byte("ke"), []byte("hel"))
+			}, []pb.Match{match1, match2})
 			if err != nil {
 				require.Equal(t, err.Error(), context.Canceled.Error())
 			}


### PR DESCRIPTION
Add an argument in `(*DB) Subscribe()` for the ignore string so that the subscriber can subscribe to a prefix with holes (or ignore bytes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1658)
<!-- Reviewable:end -->
