### PR TITLE
overwrite default Options from SuperFlag string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.12
 
 // replace github.com/dgraph-io/ristretto => /home/amanbansal/go/src/github.com/dgraph-io/ristretto
 
+replace github.com/dgraph-io/ristretto => /home/karl/go/src/github.com/dgraph-io/ristretto
+
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ replace github.com/dgraph-io/ristretto => /home/karl/go/src/github.com/dgraph-io
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/davecgh/go-spew v1.1.1
-	github.com/dgraph-io/ristretto v0.0.4-0.20210205131921-1fb8d282aa8b
+	github.com/dgraph-io/ristretto v0.0.4-0.20210205182321-f8e4908e34d1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1
 	github.com/google/flatbuffers v1.12.0
+	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20210204105926-13024c7bdb7e
+	github.com/dgraph-io/ristretto v0.0.4-0.20210205131921-1fb8d282aa8b
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/ristretto v0.0.4-0.20210205131921-1fb8d282aa8b
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.12
 
 // replace github.com/dgraph-io/ristretto => /home/amanbansal/go/src/github.com/dgraph-io/ristretto
 
-replace github.com/dgraph-io/ristretto => /home/karl/go/src/github.com/dgraph-io/ristretto
-
 require (
 	github.com/DataDog/zstd v1.4.1
 	github.com/cespare/xxhash v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20210127133938-1b848e7192b2 h1:XGWcXLd8WhjNcbdf/9xLkem6sB0WvbCn+s49B6q/E9I=
-github.com/dgraph-io/ristretto v0.0.4-0.20210127133938-1b848e7192b2/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
-github.com/dgraph-io/ristretto v0.0.4-0.20210204105926-13024c7bdb7e h1:GOe4M9eSEqKobxuydk/elptr/b11H9BJ152TYvsufi8=
-github.com/dgraph-io/ristretto v0.0.4-0.20210204105926-13024c7bdb7e/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
+github.com/dgraph-io/ristretto v0.0.4-0.20210205131921-1fb8d282aa8b h1:ivk3pt+NpQ1Pp9gZKX3WKJxRr0I0TC5t/io6jEZC1Mg=
+github.com/dgraph-io/ristretto v0.0.4-0.20210205131921-1fb8d282aa8b/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20210205131921-1fb8d282aa8b h1:ivk3pt+NpQ1Pp9gZKX3WKJxRr0I0TC5t/io6jEZC1Mg=
-github.com/dgraph-io/ristretto v0.0.4-0.20210205131921-1fb8d282aa8b/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -41,6 +39,8 @@ github.com/google/flatbuffers v1.12.0 h1:/PtAHvnBY4Kqnx/xCQ3OIV9uYcSFGScBsWI3Oog
 github.com/google/flatbuffers v1.12.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-dap v0.2.0/go.mod h1:5q8aYQFnHOAZEMP+6vmq25HKYAEwE+LF5yh7JKrrhSQ=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -147,6 +147,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto v0.0.4-0.20210205182321-f8e4908e34d1 h1:E+NH1+aTO3vgP/t01DvYbX8qnwBC0bPgPwK7y+y0vaE=
+github.com/dgraph-io/ristretto v0.0.4-0.20210205182321-f8e4908e34d1/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/options.go
+++ b/options.go
@@ -17,13 +17,14 @@
 package badger
 
 import (
+	"fmt"
 	"os"
+	"reflect"
 	"time"
 
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/badger/v3/table"
 	"github.com/dgraph-io/badger/v3/y"
-	"github.com/dgraph-io/ristretto/z"
 )
 
 // Note: If you add a new option X make sure you also add a WithX method on Options.
@@ -124,12 +125,10 @@ const DefaultFlags = ""
 
 // DefaultOptions sets a list of recommended options for good performance.
 // Feel free to modify these to suit your needs with the WithX methods.
-func DefaultOptions(superflag string) Options {
-	flags := z.NewSuperFlag(superflag).MergeAndCheckDefault(DefaultFlags)
-
-	return Options{
-		Dir:      flags.GetString("path"),
-		ValueDir: flags.GetString("path"),
+func DefaultOptions(path string) Options {
+	options := Options{
+		Dir:      path,
+		ValueDir: path,
 
 		MemTableSize:        64 << 20,
 		BaseTableSize:       2 << 20,
@@ -181,6 +180,26 @@ func DefaultOptions(superflag string) Options {
 		DetectConflicts:               true,
 		NamespaceOffset:               -1,
 	}
+
+	v := reflect.ValueOf(options)
+	typeFields := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		// only iterate over exported fields
+		if v.Field(i).CanInterface() {
+			name := typeFields.Field(i).Name
+			kind := v.Field(i).Kind()
+
+			fmt.Println(name, kind)
+		}
+	}
+
+	return options
+}
+
+// TODO
+func compareOptionFlags() Options {
+	return Options{}
 }
 
 func buildTableOptions(db *DB) table.Options {

--- a/options.go
+++ b/options.go
@@ -120,10 +120,6 @@ type Options struct {
 	maxValueThreshold float64
 }
 
-// TODO: move everything from DefaultOptions to here? then MergeAndCheckDefault
-//       will handle overwriting default options with the set flags
-const DefaultFlags = ""
-
 // DefaultOptions sets a list of recommended options for good performance.
 // Feel free to modify these to suit your needs with the WithX methods.
 func DefaultOptions(superflag string) Options {
@@ -183,12 +179,11 @@ func DefaultOptions(superflag string) Options {
 	})
 }
 
+// overwriteOptions replaces Option values if found in superflag
 func overwriteOptions(superflag string, options Options) Options {
 	flags := z.NewSuperFlag(superflag)
-
 	v := reflect.ValueOf(&options).Elem()
 	optionsStruct := v.Type()
-
 	for i := 0; i < v.NumField(); i++ {
 		// only iterate over exported fields
 		if field := v.Field(i); field.CanInterface() {
@@ -196,7 +191,6 @@ func overwriteOptions(superflag string, options Options) Options {
 			// insensitive
 			name := strings.ToLower(optionsStruct.Field(i).Name)
 			kind := v.Field(i).Kind()
-
 			// make sure the option exists in the SuperFlag first, otherwise
 			// we'd overwrite the defaults with 0 values
 			if flags.Has(name) {
@@ -220,7 +214,6 @@ func overwriteOptions(superflag string, options Options) Options {
 			}
 		}
 	}
-
 	return options
 }
 

--- a/options.go
+++ b/options.go
@@ -17,11 +17,12 @@
 package badger
 
 import (
-	"github.com/dgraph-io/ristretto/z"
 	"os"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/dgraph-io/ristretto/z"
 
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/badger/v3/table"

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/badger/v3/table"
 	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 // Note: If you add a new option X make sure you also add a WithX method on Options.
@@ -117,12 +118,18 @@ type Options struct {
 	maxValueThreshold float64
 }
 
+// TODO: move everything from DefaultOptions to here? then MergeAndCheckDefault
+//       will handle overwriting default options with the set flags
+const DefaultFlags = ""
+
 // DefaultOptions sets a list of recommended options for good performance.
 // Feel free to modify these to suit your needs with the WithX methods.
-func DefaultOptions(path string) Options {
+func DefaultOptions(superflag string) Options {
+	flags := z.NewSuperFlag(superflag).MergeAndCheckDefault(DefaultFlags)
+
 	return Options{
-		Dir:      path,
-		ValueDir: path,
+		Dir:      flags.GetString("path"),
+		ValueDir: flags.GetString("path"),
 
 		MemTableSize:        64 << 20,
 		BaseTableSize:       2 << 20,

--- a/options.go
+++ b/options.go
@@ -122,10 +122,10 @@ type Options struct {
 
 // DefaultOptions sets a list of recommended options for good performance.
 // Feel free to modify these to suit your needs with the WithX methods.
-func DefaultOptions(superflag string) Options {
-	return overwriteOptions(superflag, Options{
-		Dir:      "", // TODO
-		ValueDir: "", // TODO
+func DefaultOptions(path string) Options {
+	return Options{
+		Dir:      path,
+		ValueDir: path,
 
 		MemTableSize:        64 << 20,
 		BaseTableSize:       2 << 20,
@@ -176,11 +176,20 @@ func DefaultOptions(superflag string) Options {
 		EncryptionKeyRotationDuration: 10 * 24 * time.Hour, // Default 10 days.
 		DetectConflicts:               true,
 		NamespaceOffset:               -1,
-	})
+	}
 }
 
-// overwriteOptions replaces Option values if found in superflag
-func overwriteOptions(superflag string, options Options) Options {
+// SetSuperFlag fills Options fields for each flag within the superflag. For
+// example, replacing the default Options.NumGoroutines:
+//
+//	options := SetSuperFlag("numgoroutines=4", DefaultOptions(""))
+//
+// It's important to note that if you pass an empty Options struct, SetSuperFlag
+// will not fill it with default values. SetSuperFlag only writes to the fields
+// present within the superflag string (case insensitive).
+//
+// Unsupported: Options.Logger, Options.EncryptionKey
+func SetSuperFlag(superflag string, options Options) Options {
 	flags := z.NewSuperFlag(superflag)
 	v := reflect.ValueOf(&options).Elem()
 	optionsStruct := v.Type()

--- a/options.go
+++ b/options.go
@@ -196,20 +196,15 @@ func overwriteOptions(superflag string, options Options) Options {
 			if flags.Has(name) {
 				switch kind {
 				case reflect.Bool:
-					f := flags.GetBool(name)
-					field.SetBool(f)
+					field.SetBool(flags.GetBool(name))
 				case reflect.Int, reflect.Int64:
-					f := flags.GetInt64(name)
-					field.SetInt(f)
+					field.SetInt(flags.GetInt64(name))
 				case reflect.Uint32:
-					f := flags.GetUint32(name)
-					field.SetUint(uint64(f))
+					field.SetUint(uint64(flags.GetUint32(name)))
 				case reflect.Float64:
-					f := flags.GetFloat64(name)
-					field.SetFloat(f)
+					field.SetFloat(flags.GetFloat64(name))
 				case reflect.String:
-					f := flags.GetString(name)
-					field.SetString(f)
+					field.SetString(flags.GetString(name))
 				}
 			}
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -11,10 +11,15 @@ func TestOptions(t *testing.T) {
 	// copy all the default options over to a big SuperFlag string
 	defaultSuperFlag := generateSuperFlag(DefaultOptions(""))
 	// fill an empty Options with values from the SuperFlag
-	overwritten := overwriteOptions(defaultSuperFlag, Options{})
+	generated := overwriteOptions(defaultSuperFlag, Options{})
 	// make sure they're equal
-	if !optionsEqual(DefaultOptions(""), overwritten) {
+	if !optionsEqual(DefaultOptions(""), generated) {
 		t.Fatal("generated default SuperFlag != default Options")
+	}
+	// check that values are overwritten properly
+	overwritten := DefaultOptions("numgoroutines=1234")
+	if overwritten.NumGoroutines != 1234 {
+		t.Fatal("Option value not overwritten by SuperFlag value")
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -11,13 +11,13 @@ func TestOptions(t *testing.T) {
 	// copy all the default options over to a big SuperFlag string
 	defaultSuperFlag := generateSuperFlag(DefaultOptions(""))
 	// fill an empty Options with values from the SuperFlag
-	generated := overwriteOptions(defaultSuperFlag, Options{})
+	generated := SetSuperFlag(defaultSuperFlag, Options{})
 	// make sure they're equal
 	if !optionsEqual(DefaultOptions(""), generated) {
 		t.Fatal("generated default SuperFlag != default Options")
 	}
 	// check that values are overwritten properly
-	overwritten := DefaultOptions("numgoroutines=1234")
+	overwritten := SetSuperFlag("numgoroutines=1234", DefaultOptions(""))
 	if overwritten.NumGoroutines != 1234 {
 		t.Fatal("Option value not overwritten by SuperFlag value")
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -1,13 +1,85 @@
 package badger
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestOptions(t *testing.T) {
-	options := DefaultOptions("")
+	defaultSuperFlag := generateSuperFlag(DefaultOptions(""))
+	overwritten := overwriteOptions(defaultSuperFlag, Options{})
+	if !optionsEqual(DefaultOptions(""), overwritten) {
+		t.Fatal("generated default SuperFlag != default Options")
+	}
+}
 
-	spew.Dump(options)
+// generateSuperFlag generates an identical SuperFlag string from the provided
+// Options--useful for testing.
+func generateSuperFlag(options Options) string {
+	superflag := ""
+	v := reflect.ValueOf(&options).Elem()
+	optionsStruct := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		if field := v.Field(i); field.CanInterface() {
+			name := strings.ToLower(optionsStruct.Field(i).Name)
+			kind := v.Field(i).Kind()
+			switch kind {
+			case reflect.Bool:
+				superflag += name + "="
+				superflag += fmt.Sprintf("%v; ", field.Bool())
+			case reflect.Int, reflect.Int64:
+				superflag += name + "="
+				superflag += fmt.Sprintf("%v; ", field.Int())
+			case reflect.Uint32, reflect.Uint64:
+				superflag += name + "="
+				superflag += fmt.Sprintf("%v; ", field.Uint())
+			case reflect.Float64:
+				superflag += name + "="
+				superflag += fmt.Sprintf("%v; ", field.Float())
+			case reflect.String:
+				superflag += name + "="
+				superflag += fmt.Sprintf("%v; ", field.String())
+			default:
+				continue
+			}
+		}
+	}
+	return superflag
+}
+
+// optionsEqual just compares the values of two Options structs
+func optionsEqual(o1, o2 Options) bool {
+	o1v := reflect.ValueOf(&o1).Elem()
+	o2v := reflect.ValueOf(&o2).Elem()
+	for i := 0; i < o1v.NumField(); i++ {
+		if o1v.Field(i).CanInterface() {
+			kind := o1v.Field(i).Kind()
+			// compare values
+			switch kind {
+			case reflect.Bool:
+				if o1v.Field(i).Bool() != o2v.Field(i).Bool() {
+					return false
+				}
+			case reflect.Int, reflect.Int64:
+				if o1v.Field(i).Int() != o2v.Field(i).Int() {
+					return false
+				}
+			case reflect.Uint32, reflect.Uint64:
+				if o1v.Field(i).Uint() != o2v.Field(i).Uint() {
+					return false
+				}
+			case reflect.Float64:
+				if o1v.Field(i).Float() != o2v.Field(i).Float() {
+					return false
+				}
+			case reflect.String:
+				if o1v.Field(i).String() != o2v.Field(i).String() {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package badger
 
 import (
@@ -11,13 +27,13 @@ func TestOptions(t *testing.T) {
 	// copy all the default options over to a big SuperFlag string
 	defaultSuperFlag := generateSuperFlag(DefaultOptions(""))
 	// fill an empty Options with values from the SuperFlag
-	generated := SetSuperFlag(defaultSuperFlag, Options{})
+	generated := Options{}.FromSuperFlag(defaultSuperFlag)
 	// make sure they're equal
 	if !optionsEqual(DefaultOptions(""), generated) {
 		t.Fatal("generated default SuperFlag != default Options")
 	}
 	// check that values are overwritten properly
-	overwritten := SetSuperFlag("numgoroutines=1234", DefaultOptions(""))
+	overwritten := DefaultOptions("").FromSuperFlag("numgoroutines=1234")
 	if overwritten.NumGoroutines != 1234 {
 		t.Fatal("Option value not overwritten by SuperFlag value")
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -8,8 +8,11 @@ import (
 )
 
 func TestOptions(t *testing.T) {
+	// copy all the default options over to a big SuperFlag string
 	defaultSuperFlag := generateSuperFlag(DefaultOptions(""))
+	// fill an empty Options with values from the SuperFlag
 	overwritten := overwriteOptions(defaultSuperFlag, Options{})
+	// make sure they're equal
 	if !optionsEqual(DefaultOptions(""), overwritten) {
 		t.Fatal("generated default SuperFlag != default Options")
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,13 @@
+package badger
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestOptions(t *testing.T) {
+	options := DefaultOptions("")
+
+	spew.Dump(options)
+}


### PR DESCRIPTION
(This relates to DGRAPH-3003 and is blocked by dgraph-io/ristretto#247.)

1. I don't think there's a good way to include slices in a SuperFlag, so in `overwriteOptions` I only look at scalar, non-interface fields. I figured people could just use `WithLogger` and `WithEncryptionKey` instead of trying to accommodate it in SuperFlag. 
2. How should we handle `Dir` and `ValueDir` which previously [didn't really have a default value](https://github.com/dgraph-io/badger/blob/master/options.go#L124-L125)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1663)
<!-- Reviewable:end -->
