### PR TITLE
fix(iterator): fix iterator when data does not exist in read only mode #1670

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -235,6 +235,32 @@ func TestIteratePrefix(t *testing.T) {
 
 }
 
+// Sanity test to verify the iterator does not crash the db in readonly mode if data does not exist.
+func TestIteratorReadOnlyWithNoData(t *testing.T) {
+	dir, err := ioutil.TempDir(".", "badger-test")
+	y.Check(err)
+	defer removeDir(dir)
+	opts := getTestOptions(dir)
+	db, err := Open(opts)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	opts.ReadOnly = true
+	db, err = Open(opts)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	require.NoError(t, db.View(func(txn *Txn) error {
+		iopts := DefaultIteratorOptions
+		iopts.Prefix = []byte("xxx")
+		itr := txn.NewIterator(iopts)
+		defer itr.Close()
+		return nil
+	}))
+}
+
 // go test -v -run=XXX -bench=BenchmarkIterate -benchtime=3s
 // Benchmark with opt.Prefix set ===
 // goos: linux


### PR DESCRIPTION

Prevent iterator crashing the DB in case the data does not exist in read-only mode.

(cherry picked from commit 195b212b986e37d890cb459f32b409b52f5bcc23)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1671)
<!-- Reviewable:end -->
