### PR TITLE
fix(discard): close the discard stats file on db close

### DIFF
--- a/value.go
+++ b/value.go
@@ -640,6 +640,11 @@ func (vlog *valueLog) Close() error {
 			err = terr
 		}
 	}
+	if vlog.discardStats != nil {
+		if terr := vlog.discardStats.Close(-1); terr != nil && err == nil {
+			err = terr
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
In windows, an unclosed file cannot be removed. Which causes the failure of `os.RemoveAll()`.
See https://discuss.dgraph.io/t/dgraph-takes-all-disk-space-in-windows/12494
Fixes DGRAPH-3002

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1672)
<!-- Reviewable:end -->
