### PR TITLE
chore(badger): making metrics configuration with options

### DIFF
--- a/db.go
+++ b/db.go
@@ -738,10 +738,10 @@ func (db *DB) get(key []byte) (y.ValueStruct, error) {
 	var maxVs y.ValueStruct
 	version := y.ParseTs(key)
 
-	y.NumGets.Add(1)
+	y.AddIntMetric(db.opt.MetricsEnabled, y.NumGets, 1)
 	for i := 0; i < len(tables); i++ {
 		vs := tables[i].sl.Get(key)
-		y.NumMemtableGets.Add(1)
+		y.AddIntMetric(db.opt.MetricsEnabled, y.NumMemtableGets,1)
 		if vs.Meta == 0 && vs.Value == nil {
 			continue
 		}
@@ -879,7 +879,7 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 	req.Wg.Add(1)
 	req.IncrRef()     // for db write
 	db.writeCh <- req // Handled in doWrites.
-	y.NumPuts.Add(int64(len(entries)))
+	y.AddIntMetric(db.opt.MetricsEnabled, y.NumPuts, int64(len(entries)))
 
 	return req, nil
 }
@@ -897,7 +897,7 @@ func (db *DB) doWrites(lc *z.Closer) {
 
 	// This variable tracks the number of pending writes.
 	reqLen := new(expvar.Int)
-	y.PendingWrites.Set(db.opt.Dir, reqLen)
+	y.StoreMapMetric(db.opt.MetricsEnabled, y.PendingWrites, db.opt.Dir, reqLen)
 
 	reqs := make([]*request, 0, 10)
 	for {
@@ -1155,12 +1155,12 @@ func (db *DB) calculateSize() {
 	}
 
 	lsmSize, vlogSize := totalSize(db.opt.Dir)
-	y.LSMSize.Set(db.opt.Dir, newInt(lsmSize))
+	y.StoreMapMetric(db.opt.MetricsEnabled, y.LSMSize, db.opt.Dir, newInt(lsmSize))
 	// If valueDir is different from dir, we'd have to do another walk.
 	if db.opt.ValueDir != db.opt.Dir {
 		_, vlogSize = totalSize(db.opt.ValueDir)
 	}
-	y.VlogSize.Set(db.opt.ValueDir, newInt(vlogSize))
+	y.StoreMapMetric(db.opt.MetricsEnabled, y.VlogSize, db.opt.ValueDir, newInt(vlogSize))
 }
 
 func (db *DB) updateSize(lc *z.Closer) {
@@ -1224,12 +1224,12 @@ func (db *DB) RunValueLogGC(discardRatio float64) error {
 // Size returns the size of lsm and value log files in bytes. It can be used to decide how often to
 // call RunValueLogGC.
 func (db *DB) Size() (lsm, vlog int64) {
-	if y.LSMSize.Get(db.opt.Dir) == nil {
+	if y.GetMapMetric(db.opt.MetricsEnabled, y.LSMSize, db.opt.Dir) == nil {
 		lsm, vlog = 0, 0
 		return
 	}
-	lsm = y.LSMSize.Get(db.opt.Dir).(*expvar.Int).Value()
-	vlog = y.VlogSize.Get(db.opt.ValueDir).(*expvar.Int).Value()
+	lsm = y.GetMapMetric(db.opt.MetricsEnabled, y.LSMSize, db.opt.Dir).(*expvar.Int).Value()
+	vlog = y.GetMapMetric(db.opt.MetricsEnabled, y.VlogSize, db.opt.ValueDir).(*expvar.Int).Value()
 	return
 }
 

--- a/db.go
+++ b/db.go
@@ -738,10 +738,10 @@ func (db *DB) get(key []byte) (y.ValueStruct, error) {
 	var maxVs y.ValueStruct
 	version := y.ParseTs(key)
 
-	y.AddIntMetric(db.opt.MetricsEnabled, y.NumGets, 1)
+	y.NumGetsAdd(db.opt.MetricsEnabled, 1)
 	for i := 0; i < len(tables); i++ {
 		vs := tables[i].sl.Get(key)
-		y.AddIntMetric(db.opt.MetricsEnabled, y.NumMemtableGets,1)
+		y.NumMemtableGetsAdd(db.opt.MetricsEnabled, 1)
 		if vs.Meta == 0 && vs.Value == nil {
 			continue
 		}
@@ -879,7 +879,7 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 	req.Wg.Add(1)
 	req.IncrRef()     // for db write
 	db.writeCh <- req // Handled in doWrites.
-	y.AddIntMetric(db.opt.MetricsEnabled, y.NumPuts, int64(len(entries)))
+	y.NumPutsAdd(db.opt.MetricsEnabled, int64(len(entries)))
 
 	return req, nil
 }
@@ -897,7 +897,7 @@ func (db *DB) doWrites(lc *z.Closer) {
 
 	// This variable tracks the number of pending writes.
 	reqLen := new(expvar.Int)
-	y.StoreMapMetric(db.opt.MetricsEnabled, y.PendingWrites, db.opt.Dir, reqLen)
+	y.PendingWritesSet(db.opt.MetricsEnabled, db.opt.Dir, reqLen)
 
 	reqs := make([]*request, 0, 10)
 	for {
@@ -1155,12 +1155,12 @@ func (db *DB) calculateSize() {
 	}
 
 	lsmSize, vlogSize := totalSize(db.opt.Dir)
-	y.StoreMapMetric(db.opt.MetricsEnabled, y.LSMSize, db.opt.Dir, newInt(lsmSize))
+	y.LSMSizeSet(db.opt.MetricsEnabled, db.opt.Dir, newInt(lsmSize))
 	// If valueDir is different from dir, we'd have to do another walk.
 	if db.opt.ValueDir != db.opt.Dir {
 		_, vlogSize = totalSize(db.opt.ValueDir)
 	}
-	y.StoreMapMetric(db.opt.MetricsEnabled, y.VlogSize, db.opt.ValueDir, newInt(vlogSize))
+	y.VlogSizeSet(db.opt.MetricsEnabled, db.opt.ValueDir, newInt(vlogSize))
 }
 
 func (db *DB) updateSize(lc *z.Closer) {
@@ -1224,12 +1224,12 @@ func (db *DB) RunValueLogGC(discardRatio float64) error {
 // Size returns the size of lsm and value log files in bytes. It can be used to decide how often to
 // call RunValueLogGC.
 func (db *DB) Size() (lsm, vlog int64) {
-	if y.GetMapMetric(db.opt.MetricsEnabled, y.LSMSize, db.opt.Dir) == nil {
+	if y.LSMSizeGet(db.opt.MetricsEnabled, db.opt.Dir) == nil {
 		lsm, vlog = 0, 0
 		return
 	}
-	lsm = y.GetMapMetric(db.opt.MetricsEnabled, y.LSMSize, db.opt.Dir).(*expvar.Int).Value()
-	vlog = y.GetMapMetric(db.opt.MetricsEnabled, y.VlogSize, db.opt.ValueDir).(*expvar.Int).Value()
+	lsm = y.LSMSizeGet(db.opt.MetricsEnabled, db.opt.Dir).(*expvar.Int).Value()
+	vlog = y.VlogSizeGet(db.opt.MetricsEnabled, db.opt.ValueDir).(*expvar.Int).Value()
 	return
 }
 

--- a/level_handler.go
+++ b/level_handler.go
@@ -282,14 +282,14 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 	var maxVs y.ValueStruct
 	for _, th := range tables {
 		if th.DoesNotHave(hash) {
-			y.AddMapMetric(s.db.opt.MetricsEnabled, y.NumLSMBloomHits, s.strLevel, 1)
+			y.NumLSMBloomHitsAdd(s.db.opt.MetricsEnabled, s.strLevel, 1)
 			continue
 		}
 
 		it := th.NewIterator(0)
 		defer it.Close()
 
-		y.AddMapMetric(s.db.opt.MetricsEnabled, y.NumLSMGets, s.strLevel, 1)
+		y.NumLSMGetsAdd(s.db.opt.MetricsEnabled, s.strLevel, 1)
 		it.Seek(key)
 		if !it.Valid() {
 			continue

--- a/level_handler.go
+++ b/level_handler.go
@@ -282,14 +282,14 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 	var maxVs y.ValueStruct
 	for _, th := range tables {
 		if th.DoesNotHave(hash) {
-			y.NumLSMBloomHits.Add(s.strLevel, 1)
+			y.AddMapMetric(s.db.opt.MetricsEnabled, y.NumLSMBloomHits, s.strLevel, 1)
 			continue
 		}
 
 		it := th.NewIterator(0)
 		defer it.Close()
 
-		y.NumLSMGets.Add(s.strLevel, 1)
+		y.AddMapMetric(s.db.opt.MetricsEnabled, y.NumLSMGets, s.strLevel, 1)
 		it.Seek(key)
 		if !it.Valid() {
 			continue

--- a/levels.go
+++ b/levels.go
@@ -879,8 +879,8 @@ func (s *levelsController) compactBuildTables(
 	botTables := cd.bot
 
 	numTables := int64(len(topTables) + len(botTables))
-	y.AddIntMetric(s.kv.opt.MetricsEnabled, y.NumCompactionTables, numTables)
-	defer y.AddIntMetric(s.kv.opt.MetricsEnabled, y.NumCompactionTables, -numTables)
+	y.NumCompactionTablesAdd(s.kv.opt.MetricsEnabled, numTables)
+	defer y.NumCompactionTablesAdd(s.kv.opt.MetricsEnabled, -numTables)
 
 	cd.span.Annotatef(nil, "Top tables count: %v Bottom tables count: %v",
 		len(topTables), len(botTables))

--- a/levels.go
+++ b/levels.go
@@ -879,8 +879,8 @@ func (s *levelsController) compactBuildTables(
 	botTables := cd.bot
 
 	numTables := int64(len(topTables) + len(botTables))
-	y.NumCompactionTables.Add(numTables)
-	defer y.NumCompactionTables.Add(-numTables)
+	y.AddIntMetric(s.kv.opt.MetricsEnabled, y.NumCompactionTables, numTables)
+	defer y.AddIntMetric(s.kv.opt.MetricsEnabled, y.NumCompactionTables, -numTables)
 
 	cd.span.Annotatef(nil, "Top tables count: %v Bottom tables count: %v",
 		len(topTables), len(botTables))

--- a/memtable.go
+++ b/memtable.go
@@ -408,8 +408,8 @@ func (lf *logFile) read(p valuePointer) (buf []byte, err error) {
 		buf = lf.Data[offset : offset+valsz]
 		nbr = int64(valsz)
 	}
-	y.NumReads.Add(1)
-	y.NumBytesRead.Add(nbr)
+	y.AddIntMetric(lf.opt.MetricsEnabled, y.NumReads, 1)
+	y.AddIntMetric(lf.opt.MetricsEnabled, y.NumBytesRead, nbr)
 	return buf, err
 }
 

--- a/memtable.go
+++ b/memtable.go
@@ -408,8 +408,8 @@ func (lf *logFile) read(p valuePointer) (buf []byte, err error) {
 		buf = lf.Data[offset : offset+valsz]
 		nbr = int64(valsz)
 	}
-	y.AddIntMetric(lf.opt.MetricsEnabled, y.NumReads, 1)
-	y.AddIntMetric(lf.opt.MetricsEnabled, y.NumBytesRead, nbr)
+	y.NumReadsAdd(lf.opt.MetricsEnabled, 1)
+	y.NumBytesReadAdd(lf.opt.MetricsEnabled, nbr)
 	return buf, err
 }
 

--- a/options.go
+++ b/options.go
@@ -136,6 +136,7 @@ func DefaultOptions(path string) Options {
 		LevelSizeMultiplier: 10,
 		MaxLevels:           7,
 		NumGoroutines:       8,
+		MetricsEnabled:      true,
 
 		NumCompactors:           4, // Run at least 2 compactors. Zero-th compactor prioritizes L0.
 		NumLevelZeroTables:      5,

--- a/options.go
+++ b/options.go
@@ -339,6 +339,8 @@ func (opt Options) WithReadOnly(val bool) Options {
 // This flag is useful for use cases like in Dgraph where we open temporary badger instances to
 // index data. In those cases we don't want badger metrics to be polluted with the noise from
 // those temporary instances.
+//
+// Default value is set to true
 func (opt Options) WithMetricsEnabled(val bool) Options {
 	opt.MetricsEnabled = val
 	return opt

--- a/options.go
+++ b/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	Logger            Logger
 	Compression       options.CompressionType
 	InMemory          bool
+	MetricsEnabled    bool
 	// Sets the Stream.numGo field
 	NumGoroutines int
 
@@ -186,6 +187,7 @@ func buildTableOptions(db *DB) table.Options {
 	y.Check(err)
 	return table.Options{
 		ReadOnly:             opt.ReadOnly,
+		MetricsEnabled:       db.opt.MetricsEnabled,
 		TableSize:            uint64(opt.BaseTableSize),
 		BlockSize:            opt.BlockSize,
 		BloomFalsePositive:   opt.BloomFalsePositive,
@@ -325,6 +327,19 @@ func (opt Options) WithNumGoroutines(val int) Options {
 // The default value of ReadOnly is false.
 func (opt Options) WithReadOnly(val bool) Options {
 	opt.ReadOnly = val
+	return opt
+}
+
+// WithMetricsEnabled returns a new Options value with MetricsEnabled set to the given value.
+//
+// When MetricsEnabled is set to false, then the DB will be opened and no badger metrics
+// will be logged. Metrics are defined in metric.go file.
+//
+// This flag is useful for use cases like in Dgraph where we open temporary badger instances to
+// index data. In those cases we don't want badger metrics to be polluted with the noise from
+// those temporary instances.
+func (opt Options) WithMetricsEnabled(val bool) Options {
+	opt.MetricsEnabled = val
 	return opt
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -683,12 +683,12 @@ func (t *Table) DoesNotHave(hash uint32) bool {
 		return false
 	}
 
-	y.AddMapMetric(t.opt.MetricsEnabled, y.NumLSMBloomHits, "DoesNotHave_ALL", 1)
+	y.NumLSMBloomHitsAdd(t.opt.MetricsEnabled, "DoesNotHave_ALL", 1)
 	index := t.fetchIndex()
 	bf := index.BloomFilterBytes()
 	mayContain := y.Filter(bf).MayContain(hash)
 	if !mayContain {
-		y.AddMapMetric(t.opt.MetricsEnabled, y.NumLSMBloomHits, "DoesNotHave_HIT", 1)
+		y.NumLSMBloomHitsAdd(t.opt.MetricsEnabled, "DoesNotHave_HIT", 1)
 	}
 	return !mayContain
 }

--- a/table/table.go
+++ b/table/table.go
@@ -51,7 +51,8 @@ type Options struct {
 	// Options for Opening/Building Table.
 
 	// Open tables in read only mode.
-	ReadOnly bool
+	ReadOnly       bool
+	MetricsEnabled bool
 
 	// Maximum size of the table.
 	TableSize     uint64
@@ -682,12 +683,12 @@ func (t *Table) DoesNotHave(hash uint32) bool {
 		return false
 	}
 
-	y.NumLSMBloomHits.Add("DoesNotHave_ALL", 1)
+	y.AddMapMetric(t.opt.MetricsEnabled, y.NumLSMBloomHits, "DoesNotHave_ALL", 1)
 	index := t.fetchIndex()
 	bf := index.BloomFilterBytes()
 	mayContain := y.Filter(bf).MayContain(hash)
 	if !mayContain {
-		y.NumLSMBloomHits.Add("DoesNotHave_HIT", 1)
+		y.AddMapMetric(t.opt.MetricsEnabled, y.NumLSMBloomHits, "DoesNotHave_HIT", 1)
 	}
 	return !mayContain
 }

--- a/value.go
+++ b/value.go
@@ -888,8 +888,8 @@ func (vlog *valueLog) write(reqs []*request) error {
 			bytesWritten += buf.Len()
 			// No need to flush anything, we write to file directly via mmap.
 		}
-		y.AddIntMetric(vlog.opt.MetricsEnabled, y.NumWrites, int64(written))
-		y.AddIntMetric(vlog.opt.MetricsEnabled, y.NumBytesWritten, int64(bytesWritten))
+		y.NumWritesAdd(vlog.opt.MetricsEnabled, int64(written))
+		y.NumBytesWrittenAdd(vlog.opt.MetricsEnabled, int64(bytesWritten))
 
 		vlog.numEntriesWritten += uint32(written)
 		vlog.db.threshold.update(valueSizes)

--- a/value.go
+++ b/value.go
@@ -888,8 +888,8 @@ func (vlog *valueLog) write(reqs []*request) error {
 			bytesWritten += buf.Len()
 			// No need to flush anything, we write to file directly via mmap.
 		}
-		y.NumWrites.Add(int64(written))
-		y.NumBytesWritten.Add(int64(bytesWritten))
+		y.AddIntMetric(vlog.opt.MetricsEnabled, y.NumWrites, int64(written))
+		y.AddIntMetric(vlog.opt.MetricsEnabled, y.NumBytesWritten, int64(bytesWritten))
 
 		vlog.numEntriesWritten += uint32(written)
 		vlog.db.threshold.update(valueSizes)

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -16,94 +16,186 @@
 
 package y
 
-import "expvar"
+import (
+	"expvar"
+)
 
-// DO NOT USE these variables directly to update metrics. Badger has the option Metrics Enabled
-// to enable/disable these metrics. Always use function AddIntMetric, AddMapMetric, StoreMapMetric
-// and GetMapMetric to access these variables. They handle those configuration well.
-//
-// We cannot use an atomic variable here to manage the state of metrics because that will be global
-// and can be messed up with multiple initialization of badger instances.
 var (
-	// LSMSize has size of the LSM in bytes
-	LSMSize *expvar.Map
-	// VlogSize has size of the value log in bytes
-	VlogSize *expvar.Map
-	// PendingWrites tracks the number of pending writes.
-	PendingWrites *expvar.Map
+	// lsmSize has size of the LSM in bytes
+	lsmSize *expvar.Map
+	// vlogSize has size of the value log in bytes
+	vlogSize *expvar.Map
+	// pendingWrites tracks the number of pending writes.
+	pendingWrites *expvar.Map
 
 	// These are cumulative
 
-	// NumReads has cumulative number of reads
-	NumReads *expvar.Int
-	// NumWrites has cumulative number of writes
-	NumWrites *expvar.Int
-	// NumBytesRead has cumulative number of bytes read
-	NumBytesRead *expvar.Int
-	// NumBytesWritten has cumulative number of bytes written
-	NumBytesWritten *expvar.Int
-	// NumLSMGets is number of LMS gets
-	NumLSMGets *expvar.Map
-	// NumLSMBloomHits is number of LMS bloom hits
-	NumLSMBloomHits *expvar.Map
-	// NumGets is number of gets
-	NumGets *expvar.Int
-	// NumPuts is number of puts
-	NumPuts *expvar.Int
-	// NumBlockedPuts is number of blocked puts
-	NumBlockedPuts *expvar.Int
-	// NumMemtableGets is number of memtable gets
-	NumMemtableGets *expvar.Int
-	// NumCompactionTables is the number of tables being compacted
-	NumCompactionTables *expvar.Int
+	// numReads has cumulative number of reads
+	numReads *expvar.Int
+	// numWrites has cumulative number of writes
+	numWrites *expvar.Int
+	// numBytesRead has cumulative number of bytes read
+	numBytesRead *expvar.Int
+	// numBytesWritten has cumulative number of bytes written
+	numBytesWritten *expvar.Int
+	// numLSMGets is number of LMS gets
+	numLSMGets *expvar.Map
+	// numLSMBloomHits is number of LMS bloom hits
+	numLSMBloomHits *expvar.Map
+	// numGets is number of gets
+	numGets *expvar.Int
+	// numPuts is number of puts
+	numPuts *expvar.Int
+	// numBlockedPuts is number of blocked puts
+	numBlockedPuts *expvar.Int
+	// numMemtableGets is number of memtable gets
+	numMemtableGets *expvar.Int
+	// numCompactionTables is the number of tables being compacted
+	numCompactionTables *expvar.Int
 )
 
 // These variables are global and have cumulative values for all kv stores.
 func init() {
-	NumReads = expvar.NewInt("badger_v3_disk_reads_total")
-	NumWrites = expvar.NewInt("badger_v3_disk_writes_total")
-	NumBytesRead = expvar.NewInt("badger_v3_read_bytes")
-	NumBytesWritten = expvar.NewInt("badger_v3_written_bytes")
-	NumLSMGets = expvar.NewMap("badger_v3_lsm_level_gets_total")
-	NumLSMBloomHits = expvar.NewMap("badger_v3_lsm_bloom_hits_total")
-	NumGets = expvar.NewInt("badger_v3_gets_total")
-	NumPuts = expvar.NewInt("badger_v3_puts_total")
-	NumBlockedPuts = expvar.NewInt("badger_v3_blocked_puts_total")
-	NumMemtableGets = expvar.NewInt("badger_v3_memtable_gets_total")
-	LSMSize = expvar.NewMap("badger_v3_lsm_size_bytes")
-	VlogSize = expvar.NewMap("badger_v3_vlog_size_bytes")
-	PendingWrites = expvar.NewMap("badger_v3_pending_writes_total")
-	NumCompactionTables = expvar.NewInt("badger_v3_compactions_current")
+	numReads = expvar.NewInt("badger_v3_disk_reads_total")
+	numWrites = expvar.NewInt("badger_v3_disk_writes_total")
+	numBytesRead = expvar.NewInt("badger_v3_read_bytes")
+	numBytesWritten = expvar.NewInt("badger_v3_written_bytes")
+	numLSMGets = expvar.NewMap("badger_v3_lsm_level_gets_total")
+	numLSMBloomHits = expvar.NewMap("badger_v3_lsm_bloom_hits_total")
+	numGets = expvar.NewInt("badger_v3_gets_total")
+	numPuts = expvar.NewInt("badger_v3_puts_total")
+	numBlockedPuts = expvar.NewInt("badger_v3_blocked_puts_total")
+	numMemtableGets = expvar.NewInt("badger_v3_memtable_gets_total")
+	lsmSize = expvar.NewMap("badger_v3_lsm_size_bytes")
+	vlogSize = expvar.NewMap("badger_v3_vlog_size_bytes")
+	pendingWrites = expvar.NewMap("badger_v3_pending_writes_total")
+	numCompactionTables = expvar.NewInt("badger_v3_compactions_current")
 }
 
-func AddIntMetric(enabled bool, metric *expvar.Int, val int64) {
+func NumReadsAdd(enabled bool, val int64) {
 	if !enabled {
 		return
 	}
 
-	metric.Add(val)
+	numReads.Add(val)
 }
 
-func AddMapMetric(enabled bool, metric *expvar.Map, key string, val int64) {
+func NumWritesAdd(enabled bool, val int64) {
 	if !enabled {
 		return
 	}
 
-	metric.Add(key, val)
+	numWrites.Add(val)
 }
 
-func StoreMapMetric(enabled bool, metric *expvar.Map, key string, val expvar.Var) {
+func NumBytesReadAdd(enabled bool, val int64) {
 	if !enabled {
 		return
 	}
 
-	metric.Set(key, val)
+	numBytesRead.Add(val)
 }
 
-func GetMapMetric(enabled bool, metric *expvar.Map, key string) expvar.Var {
+func NumBytesWrittenAdd(enabled bool, val int64) {
+	if !enabled {
+		return
+	}
+
+	numBytesWritten.Add(val)
+}
+
+func NumGetsAdd(enabled bool, val int64) {
+	if !enabled {
+		return
+	}
+
+	numGets.Add(val)
+}
+
+func NumPutsAdd(enabled bool, val int64) {
+	if !enabled {
+		return
+	}
+
+	numPuts.Add(val)
+}
+
+func NumBlockedPutsAdd(enabled bool, val int64) {
+	if !enabled {
+		return
+	}
+
+	numBlockedPuts.Add(val)
+}
+
+func NumMemtableGetsAdd(enabled bool, val int64) {
+	if !enabled {
+		return
+	}
+
+	numMemtableGets.Add(val)
+}
+
+func NumCompactionTablesAdd(enabled bool, val int64) {
+	if !enabled {
+		return
+	}
+
+	numCompactionTables.Add(val)
+}
+
+func LSMSizeSet(enabled bool, key string, val expvar.Var) {
+	if !enabled {
+		return
+	}
+
+	lsmSize.Set(key, val)
+}
+
+func VlogSizeSet(enabled bool, key string, val expvar.Var) {
+	if !enabled {
+		return
+	}
+
+	vlogSize.Set(key, val)
+}
+
+func PendingWritesSet(enabled bool, key string, val expvar.Var) {
+	if !enabled {
+		return
+	}
+
+	pendingWrites.Set(key, val)
+}
+
+func NumLSMBloomHitsAdd(enabled bool, key string, val int64) {
+	if !enabled {
+		return
+	}
+
+	numLSMBloomHits.Add(key, val)
+}
+
+func NumLSMGetsAdd(enabled bool, key string, val int64) {
+	if !enabled {
+		return
+	}
+
+	numLSMGets.Add(key, val)
+}
+
+func LSMSizeGet(enabled bool, key string) expvar.Var {
 	if !enabled {
 		return nil
 	}
 
-	return metric.Get(key)
+	return lsmSize.Get(key)
+}
+
+func VlogSizeGet(enabled bool, key string) expvar.Var {
+	if !enabled {
+		return nil
+	}
+
+	return vlogSize.Get(key)
 }

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -18,6 +18,12 @@ package y
 
 import "expvar"
 
+// DO NOT USE these variables directly to update metrics. Badger has the option Metrics Enabled
+// to enable/disable these metrics. Always use function AddIntMetric, AddMapMetric, StoreMapMetric
+// and GetMapMetric to access these variables. They handle those configuration well.
+//
+// We cannot use an atomic variable here to manage the state of metrics because that will be global
+// and can be messed up with multiple initialization of badger instances.
 var (
 	// LSMSize has size of the LSM in bytes
 	LSMSize *expvar.Map
@@ -68,4 +74,36 @@ func init() {
 	VlogSize = expvar.NewMap("badger_v3_vlog_size_bytes")
 	PendingWrites = expvar.NewMap("badger_v3_pending_writes_total")
 	NumCompactionTables = expvar.NewInt("badger_v3_compactions_current")
+}
+
+func AddIntMetric(enabled bool, metric *expvar.Int, val int64) {
+	if !enabled {
+		return
+	}
+
+	metric.Add(val)
+}
+
+func AddMapMetric(enabled bool, metric *expvar.Map, key string, val int64) {
+	if !enabled {
+		return
+	}
+
+	metric.Add(key, val)
+}
+
+func StoreMapMetric(enabled bool, metric *expvar.Map, key string, val expvar.Var) {
+	if !enabled {
+		return
+	}
+
+	metric.Set(key, val)
+}
+
+func GetMapMetric(enabled bool, metric *expvar.Map, key string) expvar.Var {
+	if !enabled {
+		return nil
+	}
+
+	return metric.Get(key)
 }

--- a/y/metrics.go
+++ b/y/metrics.go
@@ -73,129 +73,97 @@ func init() {
 }
 
 func NumReadsAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numReads.Add(val)
+	addInt(enabled, numReads, val)
 }
 
 func NumWritesAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numWrites.Add(val)
+	addInt(enabled, numWrites, val)
 }
 
 func NumBytesReadAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numBytesRead.Add(val)
+	addInt(enabled, numBytesRead, val)
 }
 
 func NumBytesWrittenAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numBytesWritten.Add(val)
+	addInt(enabled, numBytesWritten, val)
 }
 
 func NumGetsAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numGets.Add(val)
+	addInt(enabled, numGets, val)
 }
 
 func NumPutsAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numPuts.Add(val)
+	addInt(enabled, numPuts, val)
 }
 
 func NumBlockedPutsAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numBlockedPuts.Add(val)
+	addInt(enabled, numBlockedPuts, val)
 }
 
 func NumMemtableGetsAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numMemtableGets.Add(val)
+	addInt(enabled, numMemtableGets, val)
 }
 
 func NumCompactionTablesAdd(enabled bool, val int64) {
-	if !enabled {
-		return
-	}
-
-	numCompactionTables.Add(val)
+	addInt(enabled, numCompactionTables, val)
 }
 
 func LSMSizeSet(enabled bool, key string, val expvar.Var) {
-	if !enabled {
-		return
-	}
-
-	lsmSize.Set(key, val)
+	storeToMap(enabled, lsmSize, key, val)
 }
 
 func VlogSizeSet(enabled bool, key string, val expvar.Var) {
-	if !enabled {
-		return
-	}
-
-	vlogSize.Set(key, val)
+	storeToMap(enabled, vlogSize, key, val)
 }
 
 func PendingWritesSet(enabled bool, key string, val expvar.Var) {
-	if !enabled {
-		return
-	}
-
-	pendingWrites.Set(key, val)
+	storeToMap(enabled, pendingWrites, key, val)
 }
 
 func NumLSMBloomHitsAdd(enabled bool, key string, val int64) {
-	if !enabled {
-		return
-	}
-
-	numLSMBloomHits.Add(key, val)
+	addToMap(enabled, numLSMBloomHits, key, val)
 }
 
 func NumLSMGetsAdd(enabled bool, key string, val int64) {
+	addToMap(enabled, numLSMGets, key, val)
+}
+
+func LSMSizeGet(enabled bool, key string) expvar.Var {
+	return getFromMap(enabled, lsmSize, key)
+}
+
+func VlogSizeGet(enabled bool, key string) expvar.Var {
+	return getFromMap(enabled, vlogSize, key)
+}
+
+func addInt(enabled bool, metric *expvar.Int, val int64) {
 	if !enabled {
 		return
 	}
 
-	numLSMGets.Add(key, val)
+	metric.Add(val)
 }
 
-func LSMSizeGet(enabled bool, key string) expvar.Var {
+func addToMap(enabled bool, metric *expvar.Map, key string, val int64) {
+	if !enabled {
+		return
+	}
+
+	metric.Add(key, val)
+}
+
+func storeToMap(enabled bool, metric *expvar.Map, key string, val expvar.Var) {
+	if !enabled {
+		return
+	}
+
+	metric.Set(key, val)
+}
+
+func getFromMap(enabled bool, metric *expvar.Map, key string) expvar.Var {
 	if !enabled {
 		return nil
 	}
 
-	return lsmSize.Get(key)
-}
-
-func VlogSizeGet(enabled bool, key string) expvar.Var {
-	if !enabled {
-		return nil
-	}
-
-	return vlogSize.Get(key)
+	return metric.Get(key)
 }


### PR DESCRIPTION
this PR makes badger metrics to be enabled/disabled. This flag is useful for use cases like in Dgraph where we open temporary badger instances to index data. In those cases we don't want badger metrics to be polluted with the noise from those temporary instances.

Added new options: MetricsEnabled
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1674)
<!-- Reviewable:end -->
