### PR TITLE
Add a name to mutexes to make them unexported

### DIFF
--- a/db.go
+++ b/db.go
@@ -689,8 +689,8 @@ func (db *DB) Sync() error {
 
 // getMemtables returns the current memtables and get references.
 func (db *DB) getMemTables() ([]*memTable, func()) {
-	db.RLock()
-	defer db.RUnlock()
+	db.lock.RLock()
+	defer db.lock.RUnlock()
 
 	var tables []*memTable
 

--- a/db.go
+++ b/db.go
@@ -93,7 +93,7 @@ func (lk *lockedKeys) all() []uint64 {
 // DB provides the various functions required to interact with Badger.
 // DB is thread-safe.
 type DB struct {
-	sync.RWMutex // Guards list of inmemory tables, not individual reads and writes.
+	lock sync.RWMutex // Guards list of inmemory tables, not individual reads and writes.
 
 	dirLockGuard *directoryLockGuard
 	// nil if Dir and ValueDir are the same
@@ -432,7 +432,7 @@ func (db *DB) MaxVersion() uint64 {
 			maxVersion = a
 		}
 	}
-	db.Lock()
+	db.lock.Lock()
 	// In read only mode, we do not create new mem table.
 	if !db.opt.ReadOnly {
 		update(db.mt.maxVersion)
@@ -582,7 +582,7 @@ func (db *DB) close() (err error) {
 			db.opt.Debugf("Flushing memtable")
 			for {
 				pushedFlushTask := func() bool {
-					db.Lock()
+					db.lock.Lock()
 					defer db.Unlock()
 					y.AssertTrue(db.mt != nil)
 					select {
@@ -984,7 +984,7 @@ var errNoRoom = errors.New("No room for write")
 // ensureRoomForWrite is always called serially.
 func (db *DB) ensureRoomForWrite() error {
 	var err error
-	db.Lock()
+	db.lock.Lock()
 	defer db.Unlock()
 
 	y.AssertTrue(db.mt != nil) // A nil mt indicates that DB is being closed.
@@ -1089,7 +1089,7 @@ func (db *DB) flushMemtable(lc *z.Closer) error {
 			err := db.handleFlushTask(ft)
 			if err == nil {
 				// Update s.imm. Need a lock.
-				db.Lock()
+				db.lock.Lock()
 				// This is a single-threaded operation. ft.mt corresponds to the head of
 				// db.imm list. Once we flush it, we advance db.imm. The next ft.mt
 				// which would arrive here would match db.imm[0], because we acquire a
@@ -1235,7 +1235,7 @@ func (db *DB) Size() (lsm, vlog int64) {
 
 // Sequence represents a Badger sequence.
 type Sequence struct {
-	sync.Mutex
+	lock      sync.Mutex
 	db        *DB
 	key       []byte
 	next      uint64
@@ -1246,8 +1246,8 @@ type Sequence struct {
 // Next would return the next integer in the sequence, updating the lease by running a transaction
 // if needed.
 func (seq *Sequence) Next() (uint64, error) {
-	seq.Lock()
-	defer seq.Unlock()
+	seq.lock.Lock()
+	defer seq.lock.Unlock()
 	if seq.next >= seq.leased {
 		if err := seq.updateLease(); err != nil {
 			return 0, err
@@ -1262,8 +1262,8 @@ func (seq *Sequence) Next() (uint64, error) {
 // before closing the associated DB. However it is valid to use the sequence after
 // it was released, causing a new lease with full bandwidth.
 func (seq *Sequence) Release() error {
-	seq.Lock()
-	defer seq.Unlock()
+	seq.lock.Lock()
+	defer seq.lock.Unlock()
 	err := seq.db.Update(func(txn *Txn) error {
 		item, err := txn.Get(seq.key)
 		if err != nil {
@@ -1425,7 +1425,7 @@ func (db *DB) KeySplits(prefix []byte) []string {
 			_ = iter.Close()
 		}
 
-		db.Lock()
+		db.lock.Lock()
 		defer db.Unlock()
 		var memTables []*memTable
 		memTables = append(memTables, db.imm...)
@@ -1660,7 +1660,7 @@ func (db *DB) dropAll() (func(), error) {
 		f()
 	}
 	// Block all foreign interactions with memory tables.
-	db.Lock()
+	db.lock.Lock()
 	defer db.Unlock()
 
 	// Remove inmemory tables. Calling DecrRef for safety. Not sure if they're absolutely needed.
@@ -1724,7 +1724,7 @@ func (db *DB) DropPrefix(prefixes ...[]byte) error {
 		return nil
 	}
 	// Block all foreign interactions with memory tables.
-	db.Lock()
+	db.lock.Lock()
 	defer db.Unlock()
 
 	db.imm = append(db.imm, db.mt)

--- a/db_test.go
+++ b/db_test.go
@@ -2068,7 +2068,7 @@ func TestForceFlushMemtable(t *testing.T) {
 	db.imm = db.imm[:0]
 	db.mt, err = db.newMemTable()
 	require.NoError(t, err)
-	db.Unlock()
+	db.lock.Unlock()
 
 	// Since we are inserting 3 entries and ValueLogMaxEntries is 1, there will be 3 rotation.
 	require.True(t, db.nextMemFid == 3,

--- a/db_test.go
+++ b/db_test.go
@@ -2060,7 +2060,7 @@ func TestForceFlushMemtable(t *testing.T) {
 	// We want to make sure that memtable is flushed on disk. While flushing memtable to disk,
 	// latest head is also stored in it. Hence we will try to read head from disk. To make sure
 	// this. we will truncate all memtables.
-	db.Lock()
+	db.lock.Lock()
 	db.mt.DecrRef()
 	for _, mt := range db.imm {
 		mt.DecrRef()


### PR DESCRIPTION
By embedding `sync.Mutex` into an exported struct, it also exports the `Lock()` and `Unlock()` functions. This can cause trouble/confusion for users of Badger because `Lock()` is used internally and calling it can have unintended consequences. 

By naming the mutex, and not embedding it, the internally-used Lock and Unlock are not exposed to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1678)
<!-- Reviewable:end -->
