### PR TITLE
Opt(Stream): Optimize how we deduce key ranges for iteration

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -304,11 +304,6 @@ func tableInfo(dir, valueDir string, db *badger.DB) {
 	fmt.Printf("Total BloomFilter Size: %s\n", hbytes(int64(totalIndex)))
 	fmt.Printf("Mean Compression Ratio: %.2f\n", totalCompressionRatio/float64(len(tables)))
 	fmt.Println()
-	splits := db.KeySplits(nil)
-	for i, s := range splits {
-		fmt.Printf("Split %d: %x\n", i, s)
-	}
-	fmt.Println()
 }
 
 func printInfo(dir, valueDir string) error {

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -304,6 +304,11 @@ func tableInfo(dir, valueDir string, db *badger.DB) {
 	fmt.Printf("Total BloomFilter Size: %s\n", hbytes(int64(totalIndex)))
 	fmt.Printf("Mean Compression Ratio: %.2f\n", totalCompressionRatio/float64(len(tables)))
 	fmt.Println()
+	splits := db.KeySplits(nil)
+	for i, s := range splits {
+		fmt.Printf("Split %d: %x\n", i, s)
+	}
+	fmt.Println()
 }
 
 func printInfo(dir, valueDir string) error {

--- a/compaction.go
+++ b/compaction.go
@@ -31,6 +31,7 @@ type keyRange struct {
 	left  []byte
 	right []byte
 	inf   bool
+	size  int64 // size is used for Key splits.
 }
 
 func (r keyRange) isEmpty() bool {
@@ -82,10 +83,12 @@ func (r keyRange) overlapsWith(dst keyRange) bool {
 		return true
 	}
 
+	// r is to the right of dst.
 	// If my left is greater than dst right, we have no overlap.
 	if y.CompareKeys(r.left, dst.right) > 0 {
 		return false
 	}
+	// r is to the left of dst.
 	// If my right is less than dst left, we have no overlap.
 	if y.CompareKeys(r.right, dst.left) < 0 {
 		return false

--- a/compaction.go
+++ b/compaction.go
@@ -83,12 +83,12 @@ func (r keyRange) overlapsWith(dst keyRange) bool {
 		return true
 	}
 
-	// r is to the right of dst.
+	// [dst.left, dst.right] ... [r.left, r.right]
 	// If my left is greater than dst right, we have no overlap.
 	if y.CompareKeys(r.left, dst.right) > 0 {
 		return false
 	}
-	// r is to the left of dst.
+	// [r.left, r.right] ... [dst.left, dst.right]
 	// If my right is less than dst left, we have no overlap.
 	if y.CompareKeys(r.right, dst.left) < 0 {
 		return false

--- a/db.go
+++ b/db.go
@@ -1375,9 +1375,9 @@ func (db *DB) EstimateSize(prefix []byte) (uint64, uint64) {
 	return onDiskSize, uncompressedSize
 }
 
-// KeySplits can be used to get rough key ranges to divide up iteration over
+// Ranges can be used to get rough key ranges to divide up iteration over
 // the DB.
-func (db *DB) KeySplits(prefix []byte) []string {
+func (db *DB) Ranges(prefix []byte, numRanges int) []*keyRange {
 	var splits []string
 	tables := db.Tables()
 
@@ -1438,29 +1438,56 @@ func (db *DB) KeySplits(prefix []byte) []string {
 		mtSplits(db.mt)
 	}
 
+	// We have our splits now. Let's convert them to ranges.
 	sort.Strings(splits)
+	var ranges []*keyRange
+	start := y.SafeCopy(nil, prefix)
+	for _, key := range splits {
+		ranges = append(ranges, &keyRange{left: start, right: y.SafeCopy(nil, []byte(key))})
+		start = y.SafeCopy(nil, []byte(key))
+	}
+	ranges = append(ranges, &keyRange{left: start})
 
-	// Limit the maximum number of splits returned by this function. We check against
-	// maxNumberSplits * 2 so that the jump variable has a value of at least two.
-	// Otherwise, the entire list would be returned without any reduction in size.
-	if len(splits) > maxNumSplits*2 {
-		newSplits := make([]string, 0)
-		jump := len(splits) / maxNumSplits
-		if jump < 2 {
-			jump = 2
-		}
-
-		for i := 0; i < len(splits); i += jump {
-			if i >= len(splits) {
-				i = len(splits) - 1
+	// Figure out the approximate table size this range has to deal with.
+	for _, t := range tables {
+		tr := keyRange{left: t.Left, right: t.Right}
+		for _, r := range ranges {
+			if r.left == nil || r.right == nil {
+				continue
 			}
-			newSplits = append(newSplits, splits[i])
+			if r.overlapsWith(tr) {
+				r.size += int64(t.UncompressedSize)
+			}
 		}
-
-		splits = newSplits
 	}
 
-	return splits
+	var total int64
+	for _, r := range ranges {
+		total += r.size
+	}
+	if total == 0 {
+		return ranges
+	}
+	// Figure out the average size, so we know how to bin the ranges together.
+	avg := total / int64(numRanges)
+
+	var out []*keyRange
+	var i int
+	for i < len(ranges) {
+		r := ranges[i]
+		cur := &keyRange{left: r.left, size: r.size, right: r.right}
+		i++
+		for ; i < len(ranges); i++ {
+			next := ranges[i]
+			if cur.size+next.size > avg {
+				break
+			}
+			cur.right = next.right
+			cur.size += next.size
+		}
+		out = append(out, cur)
+	}
+	return out
 }
 
 // MaxBatchCount returns max possible entries in batch

--- a/db.go
+++ b/db.go
@@ -1439,9 +1439,11 @@ func (db *DB) Ranges(prefix []byte, numRanges int) []*keyRange {
 	}
 
 	// We have our splits now. Let's convert them to ranges.
+	// TODO: These ranges are not considering the prefix. We should ensure those are considered.
 	sort.Strings(splits)
 	var ranges []*keyRange
-	start := y.SafeCopy(nil, prefix)
+	var start []byte
+	// start := y.SafeCopy(nil, prefix)
 	for _, key := range splits {
 		ranges = append(ranges, &keyRange{left: start, right: y.SafeCopy(nil, []byte(key))})
 		start = y.SafeCopy(nil, []byte(key))
@@ -1452,7 +1454,7 @@ func (db *DB) Ranges(prefix []byte, numRanges int) []*keyRange {
 	for _, t := range tables {
 		tr := keyRange{left: t.Left, right: t.Right}
 		for _, r := range ranges {
-			if r.left == nil || r.right == nil {
+			if len(r.left) == 0 || len(r.right) == 0 {
 				continue
 			}
 			if r.overlapsWith(tr) {

--- a/db.go
+++ b/db.go
@@ -1443,7 +1443,6 @@ func (db *DB) Ranges(prefix []byte, numRanges int) []*keyRange {
 	sort.Strings(splits)
 	var ranges []*keyRange
 	var start []byte
-	// start := y.SafeCopy(nil, prefix)
 	for _, key := range splits {
 		ranges = append(ranges, &keyRange{left: start, right: y.SafeCopy(nil, []byte(key))})
 		start = y.SafeCopy(nil, []byte(key))

--- a/db.go
+++ b/db.go
@@ -1375,8 +1375,9 @@ func (db *DB) EstimateSize(prefix []byte) (uint64, uint64) {
 	return onDiskSize, uncompressedSize
 }
 
-// Ranges can be used to get rough key ranges to divide up iteration over
-// the DB.
+// Ranges can be used to get rough key ranges to divide up iteration over the DB. The ranges here
+// would consider the prefix, but would not necessarily start or end with the prefix. In fact, the
+// first range would have nil as left key, and the last range would have nil as the right key.
 func (db *DB) Ranges(prefix []byte, numRanges int) []*keyRange {
 	var splits []string
 	tables := db.Tables()
@@ -1439,7 +1440,6 @@ func (db *DB) Ranges(prefix []byte, numRanges int) []*keyRange {
 	}
 
 	// We have our splits now. Let's convert them to ranges.
-	// TODO: These ranges are not considering the prefix. We should ensure those are considered.
 	sort.Strings(splits)
 	var ranges []*keyRange
 	var start []byte

--- a/db.go
+++ b/db.go
@@ -1383,8 +1383,11 @@ func (db *DB) KeySplits(prefix []byte) []string {
 
 	// We just want table ranges here and not keys count.
 	for _, ti := range tables {
-		// We don't use ti.Left, because that has a tendency to store !badger
-		// keys.
+		// We don't use ti.Left, because that has a tendency to store !badger keys. Skip over tables
+		// at upper levels. Only choose tables from the last level.
+		if ti.Level != db.opt.MaxLevels-1 {
+			continue
+		}
 		if bytes.HasPrefix(ti.Right, prefix) {
 			splits = append(splits, string(ti.Right))
 		}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -363,8 +363,8 @@ func BenchmarkIteratePrefixSingleKey(b *testing.B) {
 	})
 	y.Check(err)
 	b.Logf("LSM files: %d", lsmFiles)
-	b.Logf("Key splits: %v", db.KeySplits(nil))
-	b.Logf("Key splits with prefix: %v", db.KeySplits([]byte("09")))
+	b.Logf("Key splits: %v", db.Ranges(nil, 10000))
+	b.Logf("Key splits with prefix: %v", db.Ranges([]byte("09"), 10000))
 
 	b.Logf("Outer b.N: %d", b.N)
 	b.Run("Key lookups", func(b *testing.B) {

--- a/levels_test.go
+++ b/levels_test.go
@@ -983,7 +983,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 1, len(db.KeySplits(nil)))
+				require.Equal(t, 2, len(db.Ranges(nil, 10000)))
 			})
 		})
 		t.Run("medium table", func(t *testing.T) {
@@ -993,7 +993,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 7, len(db.KeySplits(nil)))
+				require.Equal(t, 8, len(db.Ranges(nil, 10000)))
 			})
 		})
 		t.Run("large table", func(t *testing.T) {
@@ -1003,7 +1003,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 61, len(db.KeySplits(nil)))
+				require.Equal(t, 62, len(db.Ranges(nil, 10000)))
 			})
 		})
 		t.Run("prefix", func(t *testing.T) {
@@ -1013,7 +1013,7 @@ func TestKeyVersions(t *testing.T) {
 					l0 = append(l0, keyValVersion{fmt.Sprintf("%05d", i), "foo", 1, 0})
 				}
 				createAndOpen(db, l0, 0)
-				require.Equal(t, 0, len(db.KeySplits([]byte("a"))))
+				require.Equal(t, 1, len(db.Ranges([]byte("a"), 10000)))
 			})
 		})
 	})
@@ -1026,7 +1026,7 @@ func TestKeyVersions(t *testing.T) {
 					writer.Set([]byte(fmt.Sprintf("%05d", i)), []byte("foo"))
 				}
 				require.NoError(t, writer.Flush())
-				require.Equal(t, 1, len(db.KeySplits(nil)))
+				require.Equal(t, 2, len(db.Ranges(nil, 10000)))
 			})
 		})
 		t.Run("large table", func(t *testing.T) {
@@ -1036,7 +1036,7 @@ func TestKeyVersions(t *testing.T) {
 					writer.Set([]byte(fmt.Sprintf("%05d", i)), []byte("foo"))
 				}
 				require.NoError(t, writer.Flush())
-				require.Equal(t, 10, len(db.KeySplits(nil)))
+				require.Equal(t, 11, len(db.Ranges(nil, 10000)))
 			})
 		})
 		t.Run("prefix", func(t *testing.T) {
@@ -1046,7 +1046,7 @@ func TestKeyVersions(t *testing.T) {
 					writer.Set([]byte(fmt.Sprintf("%05d", i)), []byte("foo"))
 				}
 				require.NoError(t, writer.Flush())
-				require.Equal(t, 0, len(db.KeySplits([]byte("a"))))
+				require.Equal(t, 1, len(db.Ranges([]byte("a"), 10000)))
 			})
 		})
 	})

--- a/y/y.go
+++ b/y/y.go
@@ -534,3 +534,54 @@ func IBytesToString(size uint64, precision int) string {
 
 	return fmt.Sprintf(f, val, suffix)
 }
+
+type RateMonitor struct {
+	start       time.Time
+	lastSent    uint64
+	lastCapture time.Time
+	rates       []float64
+	idx         int
+}
+
+func NewRateMonitor(numSamples int) *RateMonitor {
+	return &RateMonitor{
+		start: time.Now(),
+		rates: make([]float64, numSamples),
+	}
+}
+
+const minRate = 0.0001
+
+// Capture captures the current number of sent bytes. This number should be monotonically
+// increasing.
+func (rm *RateMonitor) Capture(sent uint64) {
+	diff := sent - rm.lastSent
+	dur := time.Since(rm.lastCapture)
+	rm.lastCapture, rm.lastSent = time.Now(), sent
+
+	rate := float64(diff) / dur.Seconds()
+	if rate < minRate {
+		rate = minRate
+	}
+	rm.rates[rm.idx] = rate
+	rm.idx = (rm.idx + 1) % len(rm.rates)
+}
+
+// Rate returns the average rate of transmission smoothed out by the number of samples.
+func (rm *RateMonitor) Rate() uint64 {
+	var total float64
+	var den float64
+	for _, r := range rm.rates {
+		if r < minRate {
+			// Ignore this. We always set minRate, so this is a zero.
+			// Typically at the start of the rate monitor, we'd have zeros.
+			continue
+		}
+		total += r
+		den += 1.0
+	}
+	if den < minRate {
+		return 0
+	}
+	return uint64(total / den)
+}


### PR DESCRIPTION
Before, we were picking up table splits and to narrow down to a few ranges, just choosing every kth split and considering it a range. Now, we convert each split into a range, consider the size of that range, and then group them together to get approximately same size ranges. This helps with iterations doing the same amount of work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1687)
<!-- Reviewable:end -->
