### PR TITLE
Make skiplist grow

### DIFF
--- a/skl/arena.go
+++ b/skl/arena.go
@@ -63,8 +63,6 @@ func (s *Arena) allocate(sz uint32) uint32 {
 		newBuf := make([]byte, len(s.buf)+int(growBy))
 		y.AssertTrue(len(s.buf) == copy(newBuf, s.buf))
 		s.buf = newBuf
-		// log.Fatalf("Arena too small, toWrite:%d newTotal:%d limit:%d",
-		// 	sz, offset+sz, len(s.buf))
 	}
 	return offset - sz
 }
@@ -96,8 +94,7 @@ func (s *Arena) putNode(height int) uint32 {
 func (s *Arena) putVal(v y.ValueStruct) uint32 {
 	l := uint32(v.EncodedSize())
 	offset := s.allocate(l)
-	buf := s.buf[offset : offset+l]
-	v.Encode(buf)
+	v.Encode(s.buf[offset:])
 	return offset
 }
 
@@ -115,7 +112,6 @@ func (s *Arena) getNode(offset uint32) *node {
 	if offset == 0 {
 		return nil
 	}
-
 	return (*node)(unsafe.Pointer(&s.buf[offset]))
 }
 

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -35,8 +35,9 @@ const (
 
 // Arena should be lock-free.
 type Arena struct {
-	n   uint32
-	buf []byte
+	n          uint32
+	shouldGrow bool
+	buf        []byte
 }
 
 // newArena returns a new arena.
@@ -58,7 +59,7 @@ func (s *Arena) allocate(sz uint32) uint32 {
 	// maxHeight. This reduces the node's size, but checkptr doesn't know about its size and it
 	// tries to check based on MaxNodeSize causing this error checkptr: converted pointer straddles
 	// multiple allocations
-	if offset > uint32(len(s.buf))-uint32(MaxNodeSize) {
+	if s.shouldGrow && int(offset) > len(s.buf)-MaxNodeSize {
 		growBy := uint32(len(s.buf))
 		if growBy > 1<<30 {
 			growBy = 1 << 30

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -77,7 +77,6 @@ type node struct {
 
 type Skiplist struct {
 	height     int32 // Current height. 1 <= height <= kMaxHeight. CAS.
-	head       *node
 	headOffset uint32
 	ref        int32
 	arena      *Arena
@@ -135,7 +134,6 @@ func NewSkiplist(arenaSize int64) *Skiplist {
 	ho := arena.getNodeOffset(head)
 	return &Skiplist{
 		height:     1,
-		head:       head,
 		headOffset: ho,
 		arena:      arena,
 		ref:        1,

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -33,6 +33,7 @@ Key differences:
 package skl
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"sync/atomic"
@@ -75,11 +76,12 @@ type node struct {
 }
 
 type Skiplist struct {
-	height  int32 // Current height. 1 <= height <= kMaxHeight. CAS.
-	head    *node
-	ref     int32
-	arena   *Arena
-	OnClose func()
+	height     int32 // Current height. 1 <= height <= kMaxHeight. CAS.
+	head       *node
+	headOffset uint32
+	ref        int32
+	arena      *Arena
+	OnClose    func()
 }
 
 // IncrRef increases the refcount
@@ -100,19 +102,19 @@ func (s *Skiplist) DecrRef() {
 	// Indicate we are closed. Good for testing.  Also, lets GC reclaim memory. Race condition
 	// here would suggest we are accessing skiplist when we are supposed to have no reference!
 	s.arena = nil
-	// Since the head references the arena's buf, as long as the head is kept around
-	// GC can't release the buf.
-	s.head = nil
 }
 
 func newNode(arena *Arena, key []byte, v y.ValueStruct, height int) *node {
 	// The base level is already allocated in the node struct.
-	offset := arena.putNode(height)
-	node := arena.getNode(offset)
-	node.keyOffset = arena.putKey(key)
+	nodeOffset := arena.putNode(height)
+	keyOffset := arena.putKey(key)
+	val := encodeValue(arena.putVal(v), v.EncodedSize())
+
+	node := arena.getNode(nodeOffset)
+	node.keyOffset = keyOffset
 	node.keySize = uint16(len(key))
 	node.height = uint16(height)
-	node.value = encodeValue(arena.putVal(v), v.EncodedSize())
+	node.value = val
 	return node
 }
 
@@ -130,11 +132,13 @@ func decodeValue(value uint64) (valOffset uint32, valSize uint32) {
 func NewSkiplist(arenaSize int64) *Skiplist {
 	arena := newArena(arenaSize)
 	head := newNode(arena, nil, y.ValueStruct{}, maxHeight)
+	ho := arena.getNodeOffset(head)
 	return &Skiplist{
-		height: 1,
-		head:   head,
-		arena:  arena,
-		ref:    1,
+		height:     1,
+		head:       head,
+		headOffset: ho,
+		arena:      arena,
+		ref:        1,
 	}
 }
 
@@ -147,10 +151,8 @@ func (s *node) key(arena *Arena) []byte {
 	return arena.getKey(s.keyOffset, s.keySize)
 }
 
-func (s *node) setValue(arena *Arena, v y.ValueStruct) {
-	valOffset := arena.putVal(v)
-	value := encodeValue(valOffset, v.EncodedSize())
-	atomic.StoreUint64(&s.value, value)
+func (s *node) setValue(arena *Arena, vo uint64) {
+	atomic.StoreUint64(&s.value, vo)
 }
 
 func (s *node) getNextOffset(h int) uint32 {
@@ -180,6 +182,10 @@ func (s *Skiplist) getNext(nd *node, height int) *node {
 	return s.arena.getNode(nd.getNextOffset(height))
 }
 
+func (s *Skiplist) getHead() *node {
+	return s.arena.getNode(s.headOffset)
+}
+
 // findNear finds the node near to key.
 // If less=true, it finds rightmost node such that node.key < key (if allowEqual=false) or
 // node.key <= key (if allowEqual=true).
@@ -187,7 +193,7 @@ func (s *Skiplist) getNext(nd *node, height int) *node {
 // node.key >= key (if allowEqual=true).
 // Returns the node found. The bool returned is true if the node has key equal to given key.
 func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool) {
-	x := s.head
+	x := s.getHead()
 	level := int(s.getHeight() - 1)
 	for {
 		// Assume x.key < key.
@@ -204,7 +210,7 @@ func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool
 				return nil, false
 			}
 			// Try to return x. Make sure it is not a head node.
-			if x == s.head {
+			if x == s.getHead() {
 				return nil, false
 			}
 			return x, false
@@ -232,7 +238,7 @@ func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool
 				continue
 			}
 			// On base level. Return x.
-			if x == s.head {
+			if x == s.getHead() {
 				return nil, false
 			}
 			return x, false
@@ -247,7 +253,7 @@ func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool
 			return next, false
 		}
 		// Try to return x. Make sure it is not a head node.
-		if x == s.head {
+		if x == s.getHead() {
 			return nil, false
 		}
 		return x, false
@@ -258,14 +264,16 @@ func (s *Skiplist) findNear(key []byte, less bool, allowEqual bool) (*node, bool
 // The input "before" tells us where to start looking.
 // If we found a node with the same key, then we return outBefore = outAfter.
 // Otherwise, outBefore.key < key < outAfter.key.
-func (s *Skiplist) findSpliceForLevel(key []byte, before *node, level int) (*node, *node) {
+func (s *Skiplist) findSpliceForLevel(key []byte, before uint32, level int) (uint32, uint32) {
 	for {
 		// Assume before.key < key.
-		next := s.getNext(before, level)
-		if next == nil {
+		bn := s.arena.getNode(before)
+		next := bn.getNextOffset(level)
+		nextNode := s.arena.getNode(next)
+		if nextNode == nil {
 			return before, next
 		}
-		nextKey := next.key(s.arena)
+		nextKey := nextNode.key(s.arena)
 		cmp := y.CompareKeys(key, nextKey)
 		if cmp == 0 {
 			// Equality case.
@@ -289,15 +297,17 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 	// increase the height. Let's defer these actions.
 
 	listHeight := s.getHeight()
-	var prev [maxHeight + 1]*node
-	var next [maxHeight + 1]*node
-	prev[listHeight] = s.head
-	next[listHeight] = nil
+	var prev [maxHeight + 1]uint32
+	var next [maxHeight + 1]uint32
+	prev[listHeight] = s.headOffset
 	for i := int(listHeight) - 1; i >= 0; i-- {
 		// Use higher level to speed up for current level.
 		prev[i], next[i] = s.findSpliceForLevel(key, prev[i+1], i)
 		if prev[i] == next[i] {
-			prev[i].setValue(s.arena, v)
+			valOffset := s.arena.putVal(v)
+			value := encodeValue(valOffset, v.EncodedSize())
+			prevNode := s.arena.getNode(prev[i])
+			prevNode.setValue(s.arena, value)
 			return
 		}
 	}
@@ -305,7 +315,7 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 	// We do need to create a new node.
 	height := s.randomHeight()
 	x := newNode(s.arena, key, v, height)
-
+	xo := s.arena.getNodeOffset(x)
 	// Try to increase s.height via CAS.
 	listHeight = s.getHeight()
 	for height > int(listHeight) {
@@ -320,18 +330,19 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 	// create a node in the level above because it would have discovered the node in the base level.
 	for i := 0; i < height; i++ {
 		for {
-			if prev[i] == nil {
+			if s.arena.getNode(prev[i]) == nil {
 				y.AssertTrue(i > 1) // This cannot happen in base level.
 				// We haven't computed prev, next for this level because height exceeds old listHeight.
 				// For these levels, we expect the lists to be sparse, so we can just search from head.
-				prev[i], next[i] = s.findSpliceForLevel(key, s.head, i)
+				prev[i], next[i] = s.findSpliceForLevel(key, s.headOffset, i)
 				// Someone adds the exact same key before we are able to do so. This can only happen on
 				// the base level. But we know we are not on the base level.
 				y.AssertTrue(prev[i] != next[i])
 			}
-			nextOffset := s.arena.getNodeOffset(next[i])
-			x.tower[i] = nextOffset
-			if prev[i].casNextOffset(i, nextOffset, s.arena.getNodeOffset(x)) {
+			x = s.arena.getNode(xo)
+			x.tower[i] = next[i]
+			pnode := s.arena.getNode(prev[i])
+			if pnode.casNextOffset(i, next[i], s.arena.getNodeOffset(x)) {
 				// Managed to insert x between prev[i] and next[i]. Go to the next level.
 				break
 			}
@@ -341,11 +352,16 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 			prev[i], next[i] = s.findSpliceForLevel(key, prev[i], i)
 			if prev[i] == next[i] {
 				y.AssertTruef(i == 0, "Equality can happen only on base level: %d", i)
-				prev[i].setValue(s.arena, v)
+				valOffset := s.arena.putVal(v)
+				value := encodeValue(valOffset, v.EncodedSize())
+				prevNode := s.arena.getNode(prev[i])
+				prevNode.setValue(s.arena, value)
 				return
 			}
 		}
 	}
+
+	y.AssertTrue(bytes.Equal(s.Get(key).Value, v.Value))
 }
 
 // Empty returns if the Skiplist is empty.
@@ -356,7 +372,7 @@ func (s *Skiplist) Empty() bool {
 // findLast returns the last element. If head (empty list), we return nil. All the find functions
 // will NEVER return the head nodes.
 func (s *Skiplist) findLast() *node {
-	n := s.head
+	n := s.getHead()
 	level := int(s.getHeight()) - 1
 	for {
 		next := s.getNext(n, level)
@@ -365,7 +381,7 @@ func (s *Skiplist) findLast() *node {
 			continue
 		}
 		if level == 0 {
-			if n == s.head {
+			if n == s.getHead() {
 				return nil
 			}
 			return n
@@ -460,7 +476,7 @@ func (s *Iterator) SeekForPrev(target []byte) {
 // SeekToFirst seeks position at the first entry in list.
 // Final state of iterator is Valid() iff list is not empty.
 func (s *Iterator) SeekToFirst() {
-	s.n = s.list.getNext(s.list.head, 0)
+	s.n = s.list.getNext(s.list.getHead(), 0)
 }
 
 // SeekToLast seeks position at the last entry in list.
@@ -528,7 +544,7 @@ func (s *UniIterator) Close() error { return s.iter.Close() }
 // sorted order.
 type Builder struct {
 	s       *Skiplist
-	prev    [maxHeight + 1]*node
+	prev    [maxHeight + 1]uint32
 	prevKey []byte
 }
 
@@ -536,7 +552,7 @@ func NewBuilder(arenaSize int64) *Builder {
 	s := NewSkiplist(arenaSize)
 	b := &Builder{s: s}
 	for i := 0; i < maxHeight+1; i++ {
-		b.prev[i] = s.head
+		b.prev[i] = s.headOffset
 	}
 	return b
 }
@@ -561,8 +577,8 @@ func (b *Builder) Add(k []byte, v y.ValueStruct) {
 	x := newNode(s.arena, k, v, height)
 	nodeOffset := s.arena.getNodeOffset(x)
 	for i := 0; i < height; i++ {
-		node := b.prev[i]
+		node := s.arena.getNode(b.prev[i])
 		node.tower[i] = nodeOffset
-		b.prev[i] = x
+		b.prev[i] = nodeOffset
 	}
 }

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -139,6 +139,14 @@ func NewSkiplist(arenaSize int64) *Skiplist {
 	}
 }
 
+// NewGrowingSkiplist returns a new skiplist which can grow. Note that this skiplist is not thread
+// safe and must be used for serial operations only.
+func NewGrowingSkiplist(arenaSize int64) *Skiplist {
+	s := NewSkiplist(arenaSize)
+	s.arena.shouldGrow = true
+	return s
+}
+
 func (s *node) getValueOffset() (uint32, uint32) {
 	value := atomic.LoadUint64(&s.value)
 	return decodeValue(value)
@@ -542,7 +550,7 @@ type Builder struct {
 }
 
 func NewBuilder(arenaSize int64) *Builder {
-	s := NewSkiplist(arenaSize)
+	s := NewGrowingSkiplist(arenaSize)
 	b := &Builder{s: s}
 	for i := 0; i < maxHeight+1; i++ {
 		b.prev[i] = s.headOffset

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -460,7 +460,7 @@ func randomKey(rng *rand.Rand) []byte {
 
 func TestBuilder(t *testing.T) {
 	N := 1 << 16
-	b := NewBuilder(32 << 20)
+	b := NewBuilder(32 << 10)
 	buf := make([]byte, 8)
 	for i := 0; i < N; i++ {
 		binary.BigEndian.PutUint64(buf, uint64(i))

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -42,7 +42,7 @@ func newValue(v int) []byte {
 
 // length iterates over skiplist to give exact size.
 func length(s *Skiplist) int {
-	x := s.getNext(s.head, 0)
+	x := s.getNext(s.getHead(), 0)
 	count := 0
 	for x != nil {
 		count++

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -493,7 +493,7 @@ func TestBuilder(t *testing.T) {
 
 // Standard test. Some fraction is read. Some fraction is write. Writes have
 // to go through mutex lock.
-func BenchmarkReadWrite(b *testing.B) {
+func BenchmarkReadWriteSkiplist(b *testing.B) {
 	value := newValue(123)
 	for i := 0; i <= 10; i++ {
 		readFrac := float32(i) / 10.0

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -493,7 +493,7 @@ func TestBuilder(t *testing.T) {
 
 // Standard test. Some fraction is read. Some fraction is write. Writes have
 // to go through mutex lock.
-func BenchmarkReadWriteSkiplist(b *testing.B) {
+func BenchmarkReadWrite(b *testing.B) {
 	value := newValue(123)
 	for i := 0; i <= 10; i++ {
 		readFrac := float32(i) / 10.0


### PR DESCRIPTION
Sorted write benchmark:
```
pkg: github.com/dgraph-io/badger/v3/skl
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkSortedWrites
BenchmarkSortedWrites/builder
BenchmarkSortedWrites/builder-8         	11266122	       107.3 ns/op
BenchmarkSortedWrites/skiplist
BenchmarkSortedWrites/skiplist-8        	 2378619	       548.1 ns/op
BenchmarkSortedWrites/buffer
BenchmarkSortedWrites/buffer-8          	11134172	       107.0 ns/op
```


Benchmarks on this branch:
```
pkg: github.com/dgraph-io/badger/v3/skl
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkReadWrite
BenchmarkReadWrite/frac_0
BenchmarkReadWrite/frac_0-8         	 3270193	       497.5 ns/op
BenchmarkReadWrite/frac_1
BenchmarkReadWrite/frac_1-8         	 3122666	       474.7 ns/op
BenchmarkReadWrite/frac_2
BenchmarkReadWrite/frac_2-8         	 3215018	       454.6 ns/op
BenchmarkReadWrite/frac_3
BenchmarkReadWrite/frac_3-8         	 3497979	       431.5 ns/op
BenchmarkReadWrite/frac_4
BenchmarkReadWrite/frac_4-8         	 3960559	       427.1 ns/op
BenchmarkReadWrite/frac_5
BenchmarkReadWrite/frac_5-8         	 4304965	       396.9 ns/op
BenchmarkReadWrite/frac_6
BenchmarkReadWrite/frac_6-8         	 4831591	       377.2 ns/op
BenchmarkReadWrite/frac_7
BenchmarkReadWrite/frac_7-8         	 5106373	       342.2 ns/op
BenchmarkReadWrite/frac_8
BenchmarkReadWrite/frac_8-8         	 6648694	       375.4 ns/op
BenchmarkReadWrite/frac_9
BenchmarkReadWrite/frac_9-8         	 5147310	       344.5 ns/op
BenchmarkReadWrite/frac_10
BenchmarkReadWrite/frac_10-8        	46336015	        23.38 ns/op

```

Benchmarks on master
```
pkg: github.com/dgraph-io/badger/v3/skl
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkReadWrite
BenchmarkReadWrite/frac_0
BenchmarkReadWrite/frac_0-8         	 3398978	       490.5 ns/op
BenchmarkReadWrite/frac_1
BenchmarkReadWrite/frac_1-8         	 3551136	       463.2 ns/op
BenchmarkReadWrite/frac_2
BenchmarkReadWrite/frac_2-8         	 3783042	       453.8 ns/op
BenchmarkReadWrite/frac_3
BenchmarkReadWrite/frac_3-8         	 4080016	       402.6 ns/op
BenchmarkReadWrite/frac_4
BenchmarkReadWrite/frac_4-8         	 4378216	       407.5 ns/op
BenchmarkReadWrite/frac_5
BenchmarkReadWrite/frac_5-8         	 4904280	       364.6 ns/op
BenchmarkReadWrite/frac_6
BenchmarkReadWrite/frac_6-8         	 5326681	       362.7 ns/op
BenchmarkReadWrite/frac_7
BenchmarkReadWrite/frac_7-8         	 6351204	       327.8 ns/op
BenchmarkReadWrite/frac_8
BenchmarkReadWrite/frac_8-8         	 7129779	       338.8 ns/op
BenchmarkReadWrite/frac_9
BenchmarkReadWrite/frac_9-8         	 5378049	       326.9 ns/op
BenchmarkReadWrite/frac_10
BenchmarkReadWrite/frac_10-8        	47002140	        23.72 ns/op
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1695)
<!-- Reviewable:end -->
