### PR TITLE
fix(skiplist-handler): Iterate over skiplist and send updates to publisher

### DIFF
--- a/db.go
+++ b/db.go
@@ -1045,9 +1045,7 @@ func (db *DB) HandoverSkiplist(skl *skl.Skiplist, callback func()) error {
 			Key:       it.Key(),
 			Value:     v.Value,
 			ExpiresAt: v.ExpiresAt,
-			version:   v.Version,
 			UserMeta:  v.UserMeta,
-			meta:      v.Meta,
 		}
 		entries = append(entries, e)
 		it.Next()

--- a/db.go
+++ b/db.go
@@ -1050,13 +1050,13 @@ func (db *DB) HandoverSkiplist(skl *skl.Skiplist, callback func()) error {
 			meta:      v.Meta,
 		}
 		entries = append(entries, e)
-		req := &request{
-			Entries: entries,
-		}
-		reqs := []*request{req}
-		db.pub.sendUpdates(reqs)
 		it.Next()
 	}
+	req := &request{
+		Entries: entries,
+	}
+	reqs := []*request{req}
+	db.pub.sendUpdates(reqs)
 
 	select {
 	case db.flushChan <- flushTask{mt: mt, cb: callback}:

--- a/db2_test.go
+++ b/db2_test.go
@@ -995,7 +995,7 @@ func TestKeyCount(t *testing.T) {
 		}()
 
 		write := func(kvs *pb.KVList) error {
-			buf := z.NewBuffer(1 << 20, "test")
+			buf := z.NewBuffer(1<<20, "test")
 			defer buf.Release()
 
 			for _, kv := range kvs.Kv {

--- a/db_test.go
+++ b/db_test.go
@@ -2134,7 +2134,7 @@ func TestMain(m *testing.M) {
 
 func removeDir(dir string) {
 	if err := os.RemoveAll(dir); err != nil {
-		panic(err)
+		fmt.Printf("Error while removing dir: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
When skiplist is handled to badger, it is directly sent for writing to the LSM tree, and
the published doesn't send updates for the entries received in the skiplist. This PR
fixes it. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1697)
<!-- Reviewable:end -->
