### PR TITLE
feat(dropPrefix): add DropPrefixNonBlocking API

### DIFF
--- a/db2_test.go
+++ b/db2_test.go
@@ -1062,7 +1062,7 @@ func TestDropPrefixNonBlocking(t *testing.T) {
 	require.NoError(t, err)
 	defer removeDir(dir)
 
-	db, err := OpenManaged(DefaultOptions(dir).WithBlockWritesOnDrop(false))
+	db, err := OpenManaged(DefaultOptions(dir).WithAllowStopTheWorld(false))
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -1099,11 +1099,6 @@ func TestDropPrefixNonBlocking(t *testing.T) {
 	write()
 	prefixes := [][]byte{[]byte("aa")}
 	require.NoError(t, db.DropPrefix(prefixes...))
-	read()
-
-	// Writing again at same timestamp and verifying that vlog rewrites don't allow us to read
-	// these entries anyway.
-	write()
 	read()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.6-0.20210216161059-8cb8bacba7ba
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a
+	github.com/dgraph-io/ristretto v0.0.4-0.20210504175135-20a958a7e034
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 require (
 	github.com/DataDog/zstd v1.4.6-0.20210216161059-8cb8bacba7ba
 	github.com/cespare/xxhash v1.1.0
-	github.com/dgraph-io/ristretto v0.0.4-0.20210504175135-20a958a7e034
+	github.com/dgraph-io/ristretto v0.0.4-0.20210504190834-0bf2acd73aa3
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20210504175135-20a958a7e034 h1:WPhpbABd68W7GVsDEH2TlQOfd/2PQs9pczxp12oUiIw=
-github.com/dgraph-io/ristretto v0.0.4-0.20210504175135-20a958a7e034/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
+github.com/dgraph-io/ristretto v0.0.4-0.20210504190834-0bf2acd73aa3 h1:jU/wpYsEL+8JPLf/QcjkQKI5g0dOjSuwcMjkThxt5x0=
+github.com/dgraph-io/ristretto v0.0.4-0.20210504190834-0bf2acd73aa3/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
@@ -15,8 +17,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a h1:1cMMkx3iegOzbAxVl1ZZQRHk+gaCf33Y5/4I3l0NNSg=
-github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=
+github.com/dgraph-io/ristretto v0.0.4-0.20210504175135-20a958a7e034 h1:WPhpbABd68W7GVsDEH2TlQOfd/2PQs9pczxp12oUiIw=
+github.com/dgraph-io/ristretto v0.0.4-0.20210504175135-20a958a7e034/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/options.go
+++ b/options.go
@@ -104,8 +104,8 @@ type Options struct {
 	// ChecksumVerificationMode decides when db should verify checksums for SSTable blocks.
 	ChecksumVerificationMode options.ChecksumVerificationMode
 
-	// BlockWritesOnDrop determines whether the DropPrefix will be blocking/non-blocking.
-	BlockWritesOnDrop bool
+	// AllowStopTheWorld determines whether the DropPrefix will be blocking/non-blocking.
+	AllowStopTheWorld bool
 
 	// DetectConflicts determines whether the transactions would be checked for
 	// conflicts. The transactions can be processed at a higher rate when
@@ -143,7 +143,7 @@ func DefaultOptions(path string) Options {
 		MaxLevels:           7,
 		NumGoroutines:       8,
 		MetricsEnabled:      true,
-		BlockWritesOnDrop:   true,
+		AllowStopTheWorld:   true,
 
 		NumCompactors:           4, // Run at least 2 compactors. Zero-th compactor prioritizes L0.
 		NumLevelZeroTables:      5,
@@ -678,17 +678,17 @@ func (opt Options) WithChecksumVerificationMode(cvMode options.ChecksumVerificat
 	return opt
 }
 
-// WithDropMode returns a new Options value with DropMode set to the given value.
+// WithAllowStopTheWorld returns a new Options value with AllowStopTheWorld set to the given value.
 //
-// BlockWritesOnDrop indicates whether the call to DropPrefix should block the writes or not.
+// AllowStopTheWorld indicates whether the call to DropPrefix should block the writes or not.
 // When set to false, the DropPrefix will do a logical delete and will not block
 // the writes. Although, this will not immediately clear up the LSM tree.
 // When set to false, the DropPrefix will block the writes and will clear up the LSM
 // tree.
 //
-// The default value of BlockWritesOnDrop is true.
-func (opt Options) WithBlockWritesOnDrop(b bool) Options {
-	opt.BlockWritesOnDrop = b
+// The default value of AllowStopTheWorld is true.
+func (opt Options) WithAllowStopTheWorld(b bool) Options {
+	opt.AllowStopTheWorld = b
 	return opt
 }
 

--- a/options.go
+++ b/options.go
@@ -104,6 +104,9 @@ type Options struct {
 	// ChecksumVerificationMode decides when db should verify checksums for SSTable blocks.
 	ChecksumVerificationMode options.ChecksumVerificationMode
 
+	// BlockWritesOnDrop determines whether the DropPrefix will be blocking/non-blocking.
+	BlockWritesOnDrop bool
+
 	// DetectConflicts determines whether the transactions would be checked for
 	// conflicts. The transactions can be processed at a higher rate when
 	// conflict detection is disabled.
@@ -140,6 +143,7 @@ func DefaultOptions(path string) Options {
 		MaxLevels:           7,
 		NumGoroutines:       8,
 		MetricsEnabled:      true,
+		BlockWritesOnDrop:   true,
 
 		NumCompactors:           4, // Run at least 2 compactors. Zero-th compactor prioritizes L0.
 		NumLevelZeroTables:      5,
@@ -671,6 +675,20 @@ func (opt Options) WithVerifyValueChecksum(val bool) Options {
 // The default value of VerifyValueChecksum is options.NoVerification.
 func (opt Options) WithChecksumVerificationMode(cvMode options.ChecksumVerificationMode) Options {
 	opt.ChecksumVerificationMode = cvMode
+	return opt
+}
+
+// WithDropMode returns a new Options value with DropMode set to the given value.
+//
+// BlockWritesOnDrop indicates whether the call to DropPrefix should block the writes or not.
+// When set to false, the DropPrefix will do a logical delete and will not block
+// the writes. Although, this will not immediately clear up the LSM tree.
+// When set to false, the DropPrefix will block the writes and will clear up the LSM
+// tree.
+//
+// The default value of BlockWritesOnDrop is true.
+func (opt Options) WithBlockWritesOnDrop(b bool) Options {
+	opt.BlockWritesOnDrop = b
 	return opt
 }
 


### PR DESCRIPTION
Related to DGRAPH-3319

This PR adds `DropPrefixNonBlocking`  API that can be used to logically delete the data for specified prefixes at a given timestamp. This also adds an equivalent API of older `DropPrefix` == `DropPrefixBlocking`. 
`DropPrefix` now makes decision based on badger option `AllowStopTheWorld` whose default is to use `DropPrefixBlocking`.
The data would not be cleared from the LSM tree immediately. It would be deleted eventually through compactions.
This operation is useful when we don't want to block writes while we delete the prefixes (`DropPrefix` blocks writes).
It does this in the following way:
- Stream the given prefixes.
- Write them to skiplist and handover that skiplist to DB.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1698)
<!-- Reviewable:end -->
