### PR TITLE
remove a space for better rendering on godoc

### DIFF
--- a/options.go
+++ b/options.go
@@ -475,7 +475,7 @@ func (opt Options) WithBaseTableSize(val int64) Options {
 //
 // LevelSizeMultiplier sets the ratio between the maximum sizes of contiguous levels in the LSM.
 // Once a level grows to be larger than this ratio allowed, the compaction process will be
-//  triggered.
+// triggered.
 //
 // The default value of LevelSizeMultiplier is 10.
 func (opt Options) WithLevelSizeMultiplier(val int) Options {


### PR DESCRIPTION
This is fix for https://pkg.go.dev/github.com/dgraph-io/badger/v3#Options.WithLevelSizeMultiplier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1701)
<!-- Reviewable:end -->
