### PR TITLE
Fix conflict detection for managed DB

### DIFF
--- a/txn_test.go
+++ b/txn_test.go
@@ -817,6 +817,15 @@ func TestManagedDB(t *testing.T) {
 			}
 		}
 		txn.Discard()
+
+		// Write data to same key, causing a conflict
+		txn = db.NewTransactionAt(10, true)
+		txnb := db.NewTransactionAt(10, true)
+		txnb.Get(key(0))
+		require.NoError(t, txn.SetEntry(NewEntry(key(0), val(0))))
+		require.NoError(t, txnb.SetEntry(NewEntry(key(0), val(1))))
+		require.NoError(t, txn.CommitAt(11, nil))
+		require.Equal(t, ErrConflict, txnb.CommitAt(11, nil))
 	}
 	t.Run("disk mode", func(t *testing.T) {
 		db, err := Open(opt)


### PR DESCRIPTION
I propose this simple fix for detecting conflicts in managed mode. Addresses https://discuss.dgraph.io/t/fatal-error-when-writing-conflicting-keys-in-managed-mode/14784.

When a write conflict exists for a managed DB, an internal assert can fail: https://github.com/dgraph-io/badger/blob/aaab25305b94b57e461b09d5dc9c399b1bd6635f/txn.go#L616

This occurs because a detected conflict is indicated with `commitTs` of 0, but handling the error is skipped for managed DB instances: https://github.com/dgraph-io/badger/blob/aaab25305b94b57e461b09d5dc9c399b1bd6635f/txn.go#L563.

Rather than conflate conflict detection with a timestamp of 0, it can be indicated with another return value from `hasConflict`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1716)
<!-- Reviewable:end -->
