### PR TITLE
fix(pendingWrites): don't skip the pending entries with version=0

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -638,7 +638,7 @@ func (it *Iterator) parseItem() bool {
 	// Skip any versions which are beyond the readTs.
 	version := y.ParseTs(key)
 	// Ignore everything that is above the readTs and below or at the sinceTs.
-	if version > it.readTs || version <= it.opt.SinceTs {
+	if version > it.readTs || (it.opt.SinceTs > 0 && version <= it.opt.SinceTs) {
 		mi.Next()
 		return false
 	}


### PR DESCRIPTION
Addresses https://discuss.dgraph.io/t/bug-iterator-inside-a-transaction/14794/2

With the introduction of `SinceTs`, a bug was introduced https://github.com/dgraph-io/badger/pull/1653 that skips the pending entries.
The default value of SinceTs is zero. And for the transaction made at readTs 0, the pending entries have version set to 0. So they were also getting skipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1721)
<!-- Reviewable:end -->
