### PR TITLE
fix(stream): ensure that the stream level do not have any data

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -115,6 +115,7 @@ func (sw *StreamWriter) PrepareIncremental() error {
 		if level.NumTables > 0 {
 			sw.prevLevel = level.Level
 			isEmptyDB = false
+			break
 		}
 	}
 	if isEmptyDB {


### PR DESCRIPTION
While doing an incremental stream write, we should look at the first level on which there is no data. Earlier, due to a bug we were writing to a level that already has some tables. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1723)
<!-- Reviewable:end -->
