### PR TITLE
Fix the memory usage part of doc

### DIFF
--- a/docs/content/get-started/index.md
+++ b/docs/content/get-started/index.md
@@ -626,9 +626,6 @@ Badger's memory usage can be managed by tweaking several options available in
 the `Options` struct that is passed in when opening the database using
 `DB.Open`.
 
-- `Options.ValueLogLoadingMode` can be set to `options.FileIO` (instead of the
-  default `options.MemoryMap`) to avoid memory-mapping log files. This can be
-  useful in environments with low RAM.
 - Number of memtables (`Options.NumMemtables`)
   - If you modify `Options.NumMemtables`, also adjust `Options.NumLevelZeroTables` and
    `Options.NumLevelZeroTablesStall` accordingly.

--- a/docs/content/get-started/index.md
+++ b/docs/content/get-started/index.md
@@ -633,7 +633,6 @@ the `Options` struct that is passed in when opening the database using
   - If you modify `Options.NumMemtables`, also adjust `Options.NumLevelZeroTables` and
    `Options.NumLevelZeroTablesStall` accordingly.
 - Number of concurrent compactions (`Options.NumCompactors`)
-- Mode in which LSM tree is loaded (`Options.TableLoadingMode`)
 - Size of table (`Options.MaxTableSize`)
 - Size of value log file (`Options.ValueLogFileSize`)
 


### PR DESCRIPTION
According to CHANGELOG.md#removed-apis. `TableLoadingMode` option is removed.
fixup the memory usage part of doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1724)
<!-- Reviewable:end -->
