### PR TITLE
fix(benchmarks): use uint32 in filename generation

### DIFF
--- a/manifest_test.go
+++ b/manifest_test.go
@@ -137,7 +137,7 @@ func buildTable(t *testing.T, keyValues [][]string, bopts table.Options) *table.
 	defer b.Close()
 	// TODO: Add test for file garbage collection here. No files should be left after the tests here.
 
-	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
+	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Uint32())
 
 	sort.Slice(keyValues, func(i, j int) bool {
 		return keyValues[i][0] < keyValues[j][0]

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -652,7 +652,7 @@ func TestTableBigValues(t *testing.T) {
 		builder.Add(key, vs, 0)
 	}
 
-	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
+	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Uint32())
 	tbl, err := CreateTable(filename, builder)
 	require.NoError(t, err, "unable to open table")
 	defer tbl.DecrRef()
@@ -754,7 +754,7 @@ func BenchmarkReadMerged(b *testing.B) {
 	require.NoError(b, err)
 
 	for i := 0; i < m; i++ {
-		filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
+		filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Uint32())
 		opts := Options{Compression: options.ZSTD, BlockSize: 4 * 1024, BloomFalsePositive: 0.01}
 		opts.BlockCache = cache
 		builder := NewTableBuilder(opts)
@@ -848,7 +848,7 @@ func getTableForBenchmarks(b *testing.B, count int, cache *ristretto.Cache) *Tab
 	opts.BlockCache = cache
 	builder := NewTableBuilder(opts)
 	defer builder.Close()
-	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
+	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Uint32())
 	for i := 0; i < count; i++ {
 		k := fmt.Sprintf("%016x", i)
 		v := fmt.Sprintf("%d", i)

--- a/value_test.go
+++ b/value_test.go
@@ -965,8 +965,9 @@ func BenchmarkReadWrite(b *testing.B) {
 				dir, err := ioutil.TempDir("", "vlog-benchmark")
 				y.Check(err)
 				defer removeDir(dir)
-
-				db, err := Open(getTestOptions(dir))
+				opts := getTestOptions(dir)
+				opts.ValueThreshold = 0
+				db, err := Open(opts)
 				y.Check(err)
 
 				vl := &db.vlog


### PR DESCRIPTION
The benchmarks fail at: https://github.com/dgraph-io/badger/blob/73314229872727d01f643cf42eb7c9702af59596/table/table.go#L663-L672. Note that the file ID can be 32 bit only, while the benchmarks were using 63-bit number for the same.

Addresses https://discuss.dgraph.io/t/benchmarks-fail-to-run-asserttrue-failing-and-many-files-not-found-errors/15467

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1741)
<!-- Reviewable:end -->
