### PR TITLE
feat(externalMagic): Introduce external magic number

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -51,6 +51,7 @@ type flagOptions struct {
 	encryptionKey            string
 	checksumVerificationMode string
 	discard                  bool
+	externalMagicVersion     uint16
 }
 
 var (
@@ -82,6 +83,8 @@ func init() {
 		"[none, table, block, tableAndBlock] Specifies when the db should verify checksum for SST.")
 	infoCmd.Flags().BoolVar(&opt.discard, "discard", false,
 		"Parse and print DISCARD file from value logs.")
+	infoCmd.Flags().Uint16Var(&opt.externalMagicVersion, "external-magic", 0,
+		"External magic number")
 }
 
 var infoCmd = &cobra.Command{
@@ -104,7 +107,8 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 		WithBlockCacheSize(100 << 20).
 		WithIndexCacheSize(200 << 20).
 		WithEncryptionKey([]byte(opt.encryptionKey)).
-		WithChecksumVerificationMode(cvMode)
+		WithChecksumVerificationMode(cvMode).
+		WithExternalMagic(opt.externalMagicVersion)
 
 	if opt.discard {
 		ds, err := badger.InitDiscardStats(bopt)
@@ -322,7 +326,7 @@ func printInfo(dir, valueDir string) error {
 			fp.Close()
 		}
 	}()
-	manifest, truncOffset, err := badger.ReplayManifestFile(fp, 0)
+	manifest, truncOffset, err := badger.ReplayManifestFile(fp, opt.externalMagicVersion)
 	if err != nil {
 		return err
 	}

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -322,7 +322,7 @@ func printInfo(dir, valueDir string) error {
 			fp.Close()
 		}
 	}()
-	manifest, truncOffset, err := badger.ReplayManifestFile(fp)
+	manifest, truncOffset, err := badger.ReplayManifestFile(fp, 0)
 	if err != nil {
 		return err
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -371,6 +371,7 @@ func ReplayManifestFile(fp *os.File, extMagic uint16) (Manifest, int64, error) {
 
 	extVersion := y.BytesToU16(magicBuf[4:6])
 	version := y.BytesToU16(magicBuf[6:8])
+
 	if version != badgerMagicVersion {
 		return Manifest{}, 0,
 			//nolint:lll
@@ -379,9 +380,9 @@ func ReplayManifestFile(fp *os.File, extMagic uint16) (Manifest, int64, error) {
 				" on how to fix this.",
 				version, badgerMagicVersion)
 	}
-	if extMagic != extVersion {
+	if extVersion != extMagic {
 		return Manifest{}, 0,
-			fmt.Errorf("Cannot open DB because the external magic number doesn't match."+
+			fmt.Errorf("Cannot open DB because the external magic number doesn't match. "+
 				"Expected: %d, version present in manifest: %d\n", extMagic, extVersion)
 	}
 

--- a/manifest.go
+++ b/manifest.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -260,6 +261,7 @@ func helpRewrite(dir string, m *Manifest, extMagic uint16) (*os.File, int, error
 	// | magicText (4 bytes) | externalMagic (2 bytes) | badgerMagic (2 bytes) |
 	// +---------------------+-------------------------+-----------------------+
 
+	y.AssertTrue(badgerMagicVersion <= math.MaxUint16)
 	buf := make([]byte, 8)
 	copy(buf[0:4], magicText[:])
 	binary.BigEndian.PutUint16(buf[4:6], extMagic)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -213,7 +213,7 @@ func TestManifestRewrite(t *testing.T) {
 	require.NoError(t, err)
 	defer removeDir(dir)
 	deletionsThreshold := 10
-	mf, m, err := helpOpenOrCreateManifestFile(dir, false, deletionsThreshold)
+	mf, m, err := helpOpenOrCreateManifestFile(dir, false, 0, deletionsThreshold)
 	defer func() {
 		if mf != nil {
 			mf.close()
@@ -239,7 +239,7 @@ func TestManifestRewrite(t *testing.T) {
 	err = mf.close()
 	require.NoError(t, err)
 	mf = nil
-	mf, m, err = helpOpenOrCreateManifestFile(dir, false, deletionsThreshold)
+	mf, m, err = helpOpenOrCreateManifestFile(dir, false, 0, deletionsThreshold)
 	require.NoError(t, err)
 	require.Equal(t, map[uint64]TableManifest{
 		uint64(deletionsThreshold * 3): {Level: 0},

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -102,7 +102,7 @@ func TestManifestMagic(t *testing.T) {
 }
 
 func TestManifestVersion(t *testing.T) {
-	helpTestManifestFileCorruption(t, 4, "unsupported version")
+	helpTestManifestFileCorruption(t, 6, "unsupported version")
 }
 
 func TestManifestChecksum(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -115,6 +115,10 @@ type Options struct {
 	// NamespaceOffset specifies the offset from where the next 8 bytes contains the namespace.
 	NamespaceOffset int
 
+	// Magic version used by the application using badger to ensure that it doesn't open the DB
+	// with incompatible data format.
+	ExternalMagicVersion uint16
+
 	// Transaction start and commit timestamps are managed by end-user.
 	// This is only useful for databases built on top of Badger (like Dgraph).
 	// Not recommended for most users.
@@ -793,6 +797,13 @@ func (opt Options) WithDetectConflicts(b bool) Options {
 // The default value for NamespaceOffset is -1.
 func (opt Options) WithNamespaceOffset(offset int) Options {
 	opt.NamespaceOffset = offset
+	return opt
+}
+
+// WithExternalMagic returns a new Options value with WithExternalMagic set to the given value.
+// The DB would fail to start if both the internal and the external magic number are not validated.
+func (opt Options) WithExternalMagic(magic uint16) Options {
+	opt.ExternalMagicVersion = magic
 	return opt
 }
 

--- a/options.go
+++ b/options.go
@@ -800,8 +800,8 @@ func (opt Options) WithNamespaceOffset(offset int) Options {
 	return opt
 }
 
-// WithExternalMagic returns a new Options value with WithExternalMagic set to the given value.
-// The DB would fail to start if both the internal and the external magic number are not validated.
+// WithExternalMagic returns a new Options value with ExternalMagicVersion set to the given value.
+// The DB would fail to start if either the internal or the external magic number fails validated.
 func (opt Options) WithExternalMagic(magic uint16) Options {
 	opt.ExternalMagicVersion = magic
 	return opt

--- a/y/y.go
+++ b/y/y.go
@@ -274,6 +274,18 @@ func BytesToU32(b []byte) uint32 {
 	return binary.BigEndian.Uint32(b)
 }
 
+// U16ToBytes converts the given Uint16 to bytes
+func U16ToBytes(v uint16) []byte {
+	var uBuf [2]byte
+	binary.BigEndian.PutUint16(uBuf[:], v)
+	return uBuf[:]
+}
+
+// BytesToU16 converts the given byte slice to uint16
+func BytesToU16(b []byte) uint16 {
+	return binary.BigEndian.Uint16(b)
+}
+
 // U32SliceToBytes converts the given Uint32 slice to byte slice
 func U32SliceToBytes(u32s []uint32) []byte {
 	if len(u32s) == 0 {

--- a/y/y.go
+++ b/y/y.go
@@ -262,18 +262,6 @@ func (t *Throttle) Finish() error {
 	return t.finishErr
 }
 
-// U32ToBytes converts the given Uint32 to bytes
-func U32ToBytes(v uint32) []byte {
-	var uBuf [4]byte
-	binary.BigEndian.PutUint32(uBuf[:], v)
-	return uBuf[:]
-}
-
-// BytesToU32 converts the given byte slice to uint32
-func BytesToU32(b []byte) uint32 {
-	return binary.BigEndian.Uint32(b)
-}
-
 // U16ToBytes converts the given Uint16 to bytes
 func U16ToBytes(v uint16) []byte {
 	var uBuf [2]byte
@@ -284,6 +272,18 @@ func U16ToBytes(v uint16) []byte {
 // BytesToU16 converts the given byte slice to uint16
 func BytesToU16(b []byte) uint16 {
 	return binary.BigEndian.Uint16(b)
+}
+
+// U32ToBytes converts the given Uint32 to bytes
+func U32ToBytes(v uint32) []byte {
+	var uBuf [4]byte
+	binary.BigEndian.PutUint32(uBuf[:], v)
+	return uBuf[:]
+}
+
+// BytesToU32 converts the given byte slice to uint32
+func BytesToU32(b []byte) uint32 {
+	return binary.BigEndian.Uint32(b)
 }
 
 // U32SliceToBytes converts the given Uint32 slice to byte slice


### PR DESCRIPTION
Currently, badger writes a magic number in the manifest. It helps badger to decide if its current version is compatible with the data on the disk or not. But now the internal data storage of badger is not changed but the data format for dgraph has changed. This causes a problem if someone starts dgraph-2109 on an older dgraph directory. This change adds an external magic number to badger which will help avoid data corruption by causing panic if opening Dgraph on the wrong directory.

There are 8 magic bytes in the manifest.
Prior to this change:
```
0-4: magic text
4-8: badgerMagicNumber
```

After this change:
```
0-4: magic text
4-6: externalMagicNumber
6-8: badgerMagicNumber
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1745)
<!-- Reviewable:end -->
