### PR TITLE
fix: avoid deadlock by separating subscribers and publisher

### DIFF
--- a/db.go
+++ b/db.go
@@ -2131,7 +2131,8 @@ func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, matches 
 				db.pub.inactivateSubscription(id)
 				// drain the whole channel so that if there is any blocked
 				// go routine to send message on this channel it will be cleared
-				for range recvCh {
+				for len(recvCh) > 0 {
+					<-recvCh
 				}
 				// Delete the subscriber if there is an error by the callback.
 				db.pub.deleteSubscriber(id)

--- a/db.go
+++ b/db.go
@@ -2127,10 +2127,10 @@ func (db *DB) Subscribe(ctx context.Context, cb func(kv *KVList) error, matches 
 			err := slurp(batch)
 			if err != nil {
 				c.Done()
-				// we ran into the deadlock state with subscription with following
-				// inactivate the subscription so we dont have any more updates on this channel
+				// inactivate the subscription so we don't have any more updates on this channel
 				db.pub.inactivateSubscription(id)
-				// drain the whole channel so that if there is any locked go routine it will be cleared
+				// drain the whole channel so that if there is any blocked
+				// go routine to send message on this channel it will be cleared
 				for range recvCh {
 				}
 				// Delete the subscriber if there is an error by the callback.

--- a/publisher.go
+++ b/publisher.go
@@ -17,6 +17,7 @@
 package badger
 
 import (
+	"log"
 	"sync"
 
 	"github.com/dgraph-io/badger/v3/pb"
@@ -49,6 +50,7 @@ func (s *subscriber) sendMessages(id uint64, kvs *pb.KVList) {
 	defer s.Unlock()
 
 	if sub, ok := s.subs[id]; ok {
+		log.Println("subscription channel size is ", len(sub.sendCh))
 		sub.sendCh <- kvs
 	}
 }

--- a/publisher.go
+++ b/publisher.go
@@ -114,6 +114,7 @@ func newPublisher() *publisher {
 		},
 		indexer:       trie.NewTrie(),
 		subMatcherMap: make(map[uint64][]pb.Match),
+		inactiveSubs: make(map[uint64]struct{}),
 	}
 }
 


### PR DESCRIPTION
There is one scenario where badger could end up in a deadlock state. Complete goroutine dump can be found here https://drive.google.com/file/d/1nIrYlrbwlGtvk4WGDCzM0z996eEydaNI/view?usp=sharing

The issue is publisher sends out the messages over the subscriber channel and subscriber will process those message one at a time. Now subsriber channel size is 1000, so if the channel is completely filled publisher will wait indefinitly to send the message. And this is what happened. while processing the message, subscriber receive the error after 15 min and in the meantime publisher was waiting indefinitely for the channel to clear. On receiving the error subscriber asked the publisher to delete the subscriber and this turns into a deadlock state where one lock is acquired by the publisher to send the message and message processor of subscriber is waiting on that lock to delete the subscriber.

This PR tries to solve this issue by separating out the publisher and subscriber from each other and thus making them to work independently of each other. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1747)
<!-- Reviewable:end -->
