### PR TITLE
fix(builder): put the upper limit on reallocation

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -100,8 +100,12 @@ type Builder struct {
 func (b *Builder) allocate(need int) []byte {
 	bb := b.curBlock
 	if len(bb.data[bb.end:]) < need {
-		// We need to reallocate.
+		// We need to reallocate. 1GB is the max size that the allocator can allocate.
+		// While reallocating, if doubling exceeds that limit, then put the upper bound on it.
 		sz := 2 * len(bb.data)
+		if sz > (1 << 30) {
+			sz = 1 << 30
+		}
 		if bb.end+need > sz {
 			sz = bb.end + need
 		}


### PR DESCRIPTION
z.Allocator imposes an upper bound of `1GB` on the size of the allocator. In builder, we double the allocation while reallocating to amortize the cost over the future allocations.

Consider a scenario where the size of KV is 700MB. The size of the allocator would be 700MB. Now we want to finish the block, so we will need some bytes for the metadata. That can easily fit into the remaining 324MB. But we were earlier doing over-allocation that causes panic.

```
panic: Unable to allocate more than 1073741824


goroutine 306 [running]:
github.com/dgraph-io/ristretto/z.(*Allocator).Allocate(0xc002898800, 0x5780034a, 0x6, 0x0, 0xa1)
	/home/algod/go/pkg/mod/github.com/dgraph-io/ristretto@v0.1.1-0.20210824115121-89e99415887a/z/allocator.go:285 +0x2ec
github.com/dgraph-io/badger/v3/table.(*Builder).allocate(0xc00015c360, 0x4, 0x7f0a01dc8768, 0xc002658bb8, 0x0)
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/table/builder.go:108 +0xc5
github.com/dgraph-io/badger/v3/table.(*Builder).append(0xc00015c360, 0xc002578008, 0x4, 0x4)
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/table/builder.go:118 +0x39
github.com/dgraph-io/badger/v3/table.(*Builder).finishBlock(0xc00015c360)
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/table/builder.go:275 +0x57
github.com/dgraph-io/badger/v3/table.(*Builder).Done(0xc00015c360, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/table/builder.go:428 +0x6e
github.com/dgraph-io/badger/v3/table.CreateTable(0xc000042288, 0x12, 0xc00015c360, 0xc000042288, 0x12, 0x6565656565656565)
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/table/table.go:259 +0x45
github.com/dgraph-io/badger/v3.(*sortedWriter).createTable(0xc002832e70, 0xc00015c360, 0x0, 0x0)
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/stream_writer.go:545 +0x690
github.com/dgraph-io/badger/v3.(*sortedWriter).send.func1(0xc002832e70, 0xc00015c360)
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/stream_writer.go:500 +0x35
created by github.com/dgraph-io/badger/v3.(*sortedWriter).send
	/home/algod/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210916095630-2a9a524b649b/stream_writer.go:499 +0x89

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1748)
<!-- Reviewable:end -->
