### PR TITLE
fix: avoid deadlock in publisher and subscriber

### DIFF
--- a/publisher_test.go
+++ b/publisher_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/pkg/errors"
-	"log"
 	"sync"
 	"sync/atomic"
 	"testing"

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -18,13 +18,68 @@ package badger
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/badger/v3/pb"
 )
+
+// This test will result in deadlock for commits before this.
+// Exiting this test gracefully will be the proof that the
+// publisher is no longer stuck in deadlock.
+func TestPublisherDeadlock(t *testing.T) {
+	runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+		var subWg sync.WaitGroup
+		subWg.Add(1)
+
+		var firstUpdate sync.WaitGroup
+		firstUpdate.Add(1)
+
+
+		var subDone sync.WaitGroup
+		subDone.Add(1)
+		go func() {
+			subWg.Done()
+			match := pb.Match{Prefix: []byte("ke"), IgnoreBytes: ""}
+			db.Subscribe(context.Background(), func(kvs *pb.KVList) error {
+				firstUpdate.Done()
+				time.Sleep(time.Second * 20)
+				return errors.New("error returned")
+			}, []pb.Match{match})
+			subDone.Done()
+		}()
+		subWg.Wait()
+		go db.Update(func(txn *Txn) error {
+			e := NewEntry([]byte(fmt.Sprintf("key%d", 0)), []byte(fmt.Sprintf("value%d", 0)))
+			return txn.SetEntry(e)
+		})
+
+		firstUpdate.Wait()
+		req := int64(0)
+		for i := 1; i < 1110; i++ {
+			time.Sleep(time.Millisecond * 10)
+			go func(i int) {
+				db.Update(func(txn *Txn) error {
+					e := NewEntry([]byte(fmt.Sprintf("key%d", i)), []byte(fmt.Sprintf("value%d", i)))
+					return txn.SetEntry(e)
+				})
+				atomic.AddInt64(&req, 1)
+			}(i)
+		}
+		for {
+			if atomic.LoadInt64(&req) == 1109 {
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		subDone.Wait()
+	})
+}
 
 func TestPublisherOrdering(t *testing.T) {
 	runBadgerTest(t, nil, func(t *testing.T, db *DB) {


### PR DESCRIPTION
There is one scenario where badger could end up in a deadlock state. Complete goroutine dump can be found here https://drive.google.com/file/d/1nIrYlrbwlGtvk4WGDCzM0z996eEydaNI/view?usp=sharing

The issue is publisher sends out the messages over the subscriber channel and subscriber will process those message one at a time. Now subsriber channel size is 1000, so if the channel is completely filled publisher will wait indefinitly to send the message. And this is what happened. while processing the message, subscriber receive the error after 15 min and in the meantime publisher was waiting indefinitely for the channel to clear. On receiving the error subscriber asked the publisher to delete the subscriber and this turns into a deadlock state where one lock is acquired by the publisher to send the message and message processor of subscriber is waiting on that lock to delete the subscriber.

This PR tries to solve this issue by adding a atomic variable in subscriber so that publisher can stop sending out the new updates and thus making the deadlock to be released eventually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1749)
<!-- Reviewable:end -->
