### PR TITLE
Fix manifest corruption

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -239,8 +239,11 @@ func (mf *manifestFile) addChanges(changesParam []*pb.ManifestChange) error {
 	}
 
 	mf.appendLock.Unlock()
-	return mf.fp.Sync()
+	return syncFunc(mf.fp)
 }
+
+// this function is saved here to allow injection of fake filesystem latency at test time.
+var syncFunc = func(f *os.File) error { return f.Sync() }
 
 // Has to be 4 bytes.  The value can never change, ever, anyway.
 var magicText = [4]byte{'B', 'd', 'g', 'r'}


### PR DESCRIPTION
This fixes the manifest corruption posted about [here](https://discuss.dgraph.io/t/badgerdb-manifest-corruption-issue-solution/15915)

I was able to reproduce the race condition every time by injecting a sleep into the sync call during tests only. I am not sure if you guys would rather have this or a test that is much longer and may or may not reproduce based on high concurrency (but does not inject the sleep) or no test at all.

Let me know - I made it so we can just revert the test commit and it should be good to go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1756)
<!-- Reviewable:end -->
