### PR TITLE
docs(README): Add Opacity storage-node to the projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Below is a list of known projects that use Badger:
 * [Xuperchain](https://github.com/xuperchain/xupercore) - A highly flexible blockchain architecture with great transaction performance.
 * [m2](https://github.com/qichengzx/m2) - A simple http key/value store based on raft protocal.
 * [chaindb](https://github.com/ChainSafe/chaindb) - A blockchain storage layer used by [Gossamer](https://chainsafe.github.io/gossamer/), a Go client for the [Polkadot Network](https://polkadot.network/).
+* [Opacity](https://github.com/opacity/storage-node) - Backend implementation for the Opacity storage project
 
 If you are using Badger in a project please send a pull request to add it to the list.
 


### PR DESCRIPTION
This PR adds the Opacity storage-node backend implementation GitHub repository to the project list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1760)
<!-- Reviewable:end -->
