### PR TITLE
fix(drop): drain handed skiplists before stopping memory flush

### DIFF
--- a/db.go
+++ b/db.go
@@ -112,6 +112,7 @@ type DB struct {
 	lc        *levelsController
 	vlog      valueLog
 	writeCh   chan *request
+	sklCh     chan *handoverRequest
 	flushChan chan flushTask // For flushing memtables.
 	closeOnce sync.Once      // For closing DB only once.
 
@@ -245,6 +246,7 @@ func Open(opt Options) (*DB, error) {
 		imm:              make([]*memTable, 0, opt.NumMemtables),
 		flushChan:        make(chan flushTask, opt.NumMemtables),
 		writeCh:          make(chan *request, kvWriteChCapacity),
+		sklCh:            make(chan *handoverRequest),
 		opt:              opt,
 		manifest:         manifestFile,
 		dirLockGuard:     dirLockGuard,
@@ -383,8 +385,9 @@ func Open(opt Options) (*DB, error) {
 		return db, errors.Wrapf(err, "While setting banned keys")
 	}
 
-	db.closers.writes = z.NewCloser(1)
+	db.closers.writes = z.NewCloser(2)
 	go db.doWrites(db.closers.writes)
+	go db.handleHandovers(db.closers.writes)
 
 	if !db.opt.InMemory {
 		db.closers.valueGC = z.NewCloser(1)
@@ -555,6 +558,7 @@ func (db *DB) close() (err error) {
 
 	// Don't accept any more write.
 	close(db.writeCh)
+	close(db.sklCh)
 
 	db.closers.pub.SignalAndWait()
 	db.closers.cacheHealth.Signal()
@@ -875,6 +879,19 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 	return req, nil
 }
 
+func (db *DB) handleHandovers(lc *z.Closer) {
+	defer lc.Done()
+	for {
+		select {
+		case r := <-db.sklCh:
+			r.err = db.handoverSkiplist(r)
+			r.wg.Done()
+		case <-lc.HasBeenClosed():
+			return
+		}
+	}
+}
+
 func (db *DB) doWrites(lc *z.Closer) {
 	defer lc.Done()
 	pendingCh := make(chan struct{}, 1)
@@ -1001,13 +1018,8 @@ func (db *DB) ensureRoomForWrite() error {
 	}
 }
 
-func (db *DB) HandoverSkiplist(skl *skl.Skiplist, callback func()) error {
-	if !db.opt.managedTxns {
-		panic("Handover Skiplist is only available in managed mode.")
-	}
-	db.lock.Lock()
-	defer db.lock.Unlock()
-
+func (db *DB) handoverSkiplist(r *handoverRequest) error {
+	skl, callback := r.skl, r.callback
 	// If we have some data in db.mt, we should push that first, so the ordering of writes is
 	// maintained.
 	if !db.mt.sl.Empty() {
@@ -1055,6 +1067,25 @@ func (db *DB) HandoverSkiplist(skl *skl.Skiplist, callback func()) error {
 	default:
 		return errNoRoom
 	}
+}
+
+func (db *DB) HandoverSkiplist(skl *skl.Skiplist, callback func()) error {
+	if !db.opt.managedTxns {
+		panic("Handover Skiplist is only available in managed mode.")
+	}
+
+	if atomic.LoadInt32(&db.blockWrites) == 1 {
+		return ErrBlockedWrites
+	}
+
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	req := &handoverRequest{skl: skl, callback: callback}
+	req.wg.Add(1)
+	db.sklCh <- req
+	req.wg.Wait()
+	return req.err
 }
 
 func arenaSize(opt Options) int64 {
@@ -1726,8 +1757,9 @@ func (db *DB) blockWrite() error {
 }
 
 func (db *DB) unblockWrite() {
-	db.closers.writes = z.NewCloser(1)
+	db.closers.writes = z.NewCloser(2)
 	go db.doWrites(db.closers.writes)
+	go db.handleHandovers(db.closers.writes)
 
 	// Resume writes.
 	atomic.StoreInt32(&db.blockWrites, 0)
@@ -1744,13 +1776,23 @@ func (db *DB) prepareToDrop() (func(), error) {
 		return func() {}, err
 	}
 	reqs := make([]*request, 0, 10)
+	skls := make([]*handoverRequest, 0, 5)
 	for {
 		select {
 		case r := <-db.writeCh:
 			reqs = append(reqs, r)
+		case skl := <-db.sklCh:
+			skls = append(skls, skl)
 		default:
 			if err := db.writeRequests(reqs); err != nil {
 				db.opt.Errorf("writeRequests: %v", err)
+			}
+			for _, skl := range skls {
+				skl.err = db.handoverSkiplist(skl)
+				skl.wg.Done()
+				if skl.err != nil {
+					db.opt.Errorf("handoverSkiplists: %v", skl.err)
+				}
 			}
 			db.stopMemoryFlush()
 			return func() {

--- a/value.go
+++ b/value.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/dgraph-io/badger/v3/skl"
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/pkg/errors"
@@ -675,6 +676,13 @@ type request struct {
 	Wg   sync.WaitGroup
 	Err  error
 	ref  int32
+}
+
+type handoverRequest struct {
+	skl      *skl.Skiplist
+	callback func()
+	err      error
+	wg       sync.WaitGroup
 }
 
 func (req *request) reset() {


### PR DESCRIPTION
Fixes the following race condition:
```
DATA RACE DETECTED WARNING: DATA RACE
Read at 0x00c016f7fcf0 by goroutine 13:
  github.com/dgraph-io/badger/v3.(*DB).HandoverSkiplist()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1083 +0x1e8
  github.com/dgraph-io/dgraph/worker.(*node).commitOrAbort.func2()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:1144 +0xb4
  github.com/dgraph-io/dgraph/x.RetryUntilSuccess()
      /home/algod/go/src/github.com/dgraph-io/dgraph/x/x.go:628 +0x5e
  github.com/dgraph-io/dgraph/worker.(*node).commitOrAbort()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:1138 +0x1afd
  github.com/dgraph-io/dgraph/worker.(*node).applyCommitted()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:789 +0xf44
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh.func1()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:931 +0xacd
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:1020 +0x382

Previous write at 0x00c016f7fcf0 by goroutine 394:
  github.com/dgraph-io/badger/v3.(*DB).handleHandovers()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:887 +0x215

Goroutine 13 (running) created at:
  github.com/dgraph-io/dgraph/worker.(*node).InitAndStartNode()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:2216 +0x5a4
  github.com/dgraph-io/dgraph/worker.StartRaftNodes()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/groups.go:156 +0xc30
  github.com/dgraph-io/dgraph/dgraph/cmd/alpha.run.func4()
      /home/algod/go/src/github.com/dgraph-io/dgraph/dgraph/cmd/alpha/run.go:970 +0x73

Goroutine 394 (running) created at:
  github.com/dgraph-io/badger/v3.(*DB).unblockWrite()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1757 +0xef
  github.com/dgraph-io/badger/v3.(*DB).prepareToDrop.func2()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1795 +0x7e
  github.com/dgraph-io/badger/v3.(*DB).dropAll.func1()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1832 +0x54
  github.com/dgraph-io/badger/v3.(*DB).DropAll()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1815 +0x7e
  github.com/dgraph-io/dgraph/posting.DeleteAll()
      /home/algod/go/src/github.com/dgraph-io/dgraph/posting/index.go:1219 +0x74
  github.com/dgraph-io/dgraph/worker.(*node).applyMutations()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:579 +0x4d9
  github.com/dgraph-io/dgraph/worker.(*node).applyCommitted()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:744 +0x3bd
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh.func1()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:931 +0xacd
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:1020 +0x382
==================
WARNING: DATA RACE
Read at 0x00c0189e0af0 by goroutine 399:
  github.com/dgraph-io/badger/v3.(*DB).HandoverSkiplist()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1083 +0x1e8
  github.com/dgraph-io/dgraph/posting.(*incrRollupi).Process.func1.1()
      /home/algod/go/src/github.com/dgraph-io/dgraph/posting/mvcc.go:166 +0x8f
  github.com/dgraph-io/dgraph/x.RetryUntilSuccess()
      /home/algod/go/src/github.com/dgraph-io/dgraph/x/x.go:628 +0x5e
  github.com/dgraph-io/dgraph/posting.(*incrRollupi).Process.func1()
      /home/algod/go/src/github.com/dgraph-io/dgraph/posting/mvcc.go:165 +0xb6
  github.com/dgraph-io/dgraph/posting.(*incrRollupi).Process()
      /home/algod/go/src/github.com/dgraph-io/dgraph/posting/mvcc.go:217 +0x8f4

Previous write at 0x00c0189e0af0 by goroutine 394:
  github.com/dgraph-io/badger/v3.(*DB).handleHandovers()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:887 +0x215

Goroutine 399 (running) created at:
  github.com/dgraph-io/dgraph/worker.(*node).startTaskAtTs()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:221 +0x92a
  github.com/dgraph-io/dgraph/worker.(*node).startTask()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:187 +0x4f
  github.com/dgraph-io/dgraph/worker.(*node).applyMutations()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:604 +0x704
  github.com/dgraph-io/dgraph/worker.(*node).applyCommitted()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:744 +0x3bd
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh.func1()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:931 +0xacd
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:1020 +0x382

Goroutine 394 (running) created at:
  github.com/dgraph-io/badger/v3.(*DB).unblockWrite()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1757 +0xef
  github.com/dgraph-io/badger/v3.(*DB).prepareToDrop.func2()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1795 +0x7e
  github.com/dgraph-io/badger/v3.(*DB).dropAll.func1()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1832 +0x54
  github.com/dgraph-io/badger/v3.(*DB).DropAll()
      /home/algod/go/src/github.com/dgraph-io/badger/db.go:1815 +0x7e
  github.com/dgraph-io/dgraph/posting.DeleteAll()
      /home/algod/go/src/github.com/dgraph-io/dgraph/posting/index.go:1219 +0x74
  github.com/dgraph-io/dgraph/worker.(*node).applyMutations()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:579 +0x4d9
  github.com/dgraph-io/dgraph/worker.(*node).applyCommitted()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:744 +0x3bd
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh.func1()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:931 +0xacd
  github.com/dgraph-io/dgraph/worker.(*node).processApplyCh()
      /home/algod/go/src/github.com/dgraph-io/dgraph/worker/draft.go:1020 +0x382
==================
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1762)
<!-- Reviewable:end -->
