### PR TITLE
fix(bloom): optimize the calculation of k

### DIFF
--- a/y/bloom.go
+++ b/y/bloom.go
@@ -50,7 +50,7 @@ func NewFilter(keys []uint32, bitsPerKey int) Filter {
 // the false positive rate.
 func BloomBitsPerKey(numEntries int, fp float64) int {
 	size := -1 * float64(numEntries) * math.Log(fp) / math.Pow(float64(0.69314718056), 2)
-	locs := math.Ceil(float64(0.69314718056) * size / float64(numEntries))
+	locs := math.Ceil(size / float64(numEntries))
 	return int(locs)
 }
 


### PR DESCRIPTION
Accroding to the[WIKIPEDIA]( https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions), optimized the calculation of k (the number of hash functions) in bloomFilter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1763)
<!-- Reviewable:end -->
