### PR TITLE
removed immudb which hasn't used badger since 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Below is a list of known projects that use Badger:
 * [Sandglass](https://github.com/celrenheit/sandglass) - distributed, horizontally scalable, persistent, time sorted message queue.
 * [TalariaDB](https://github.com/grab/talaria) - Grab's Distributed, low latency time-series database.
 * [Sloop](https://github.com/salesforce/sloop) - Salesforce's Kubernetes History Visualization Project.
-* [Immudb](https://github.com/codenotary/immudb) - Lightweight, high-speed immutable database for systems and applications.
 * [Usenet Express](https://usenetexpress.com/) - Serving over 300TB of data with Badger.
 * [gorush](https://github.com/appleboy/gorush) - A push notification server written in Go.
 * [0-stor](https://github.com/zero-os/0-stor) - Single device object store.


### PR DESCRIPTION
immudb introduced its own database engine back in 2020, so for correctness of the readme.md, I removed it from the list of projects based on badgerdb. 

Many thanks

M

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1767)
<!-- Reviewable:end -->
