### PR TITLE
chore(bloom): added Hash benchmark

### DIFF
--- a/y/bloom_test.go
+++ b/y/bloom_test.go
@@ -5,6 +5,8 @@
 package y
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -121,6 +123,20 @@ loop:
 
 	if nMediocreFilters > nGoodFilters/5 {
 		t.Errorf("%d mediocre filters but only %d good filters", nMediocreFilters, nGoodFilters)
+	}
+}
+func BenchmarkHash(b *testing.B) {
+	var acc uint32
+	for _, sz := range []int64{1, 3, 4, 7, 8, 16, 32, 256, 1024} {
+		d := make([]byte, sz)
+		b.Run(fmt.Sprintf("hasher-%d", sz), func(b *testing.B) {
+			b.SetBytes(sz)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				acc = Hash(d)
+			}
+			runtime.KeepAlive(acc)
+		})
 	}
 }
 


### PR DESCRIPTION
This adds an ability to replace hashing algorithms in the future and measure the impact.

For example [xxh3 w/ AVX2](https://github.com/zeebo/xxh3) is capable of 20.1 ns/op (12.0 GB/s) on medium sized keys, meanwhile the current perf is:
```
name                time/op
Hash/hasher-1-8       2.98ns ± 1%
Hash/hasher-3-8       3.57ns ± 2%
Hash/hasher-4-8       3.56ns ± 2%
Hash/hasher-7-8       4.71ns ± 1%
Hash/hasher-8-8       4.68ns ± 2%
Hash/hasher-16-8      7.30ns ±12%
Hash/hasher-32-8      11.7ns ± 5%
Hash/hasher-256-8      100ns ±13%
Hash/hasher-1024-8     422ns ± 3%

name                speed
Hash/hasher-1-8      336MB/s ± 1%
Hash/hasher-3-8      842MB/s ± 2%
Hash/hasher-4-8     1.12GB/s ± 2%
Hash/hasher-7-8     1.49GB/s ± 1%
Hash/hasher-8-8     1.71GB/s ± 2%
Hash/hasher-16-8    2.20GB/s ±11%
Hash/hasher-32-8    2.74GB/s ± 5%
Hash/hasher-256-8   2.57GB/s ±12%
Hash/hasher-1024-8  2.42GB/s ± 3%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/badger/1774)
<!-- Reviewable:end -->
