### PR TITLE
feat(txn): add public method for getting the value of discarded field

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -760,6 +760,11 @@ func (txn *Txn) ReadTs() uint64 {
 	return txn.readTs
 }
 
+// Discarded returns the discarded value of the transaction.
+func (txn *Txn) Discarded() bool {
+	return txn.discarded
+}
+
 // NewTransaction creates a new transaction. Badger supports concurrent execution of transactions,
 // providing serializable snapshot isolation, avoiding write skews. Badger achieves this by tracking
 // the keys read and at Commit time, ensuring that these read keys weren't concurrently modified by

--- a/txn_test.go
+++ b/txn_test.go
@@ -952,3 +952,15 @@ func TestConflict(t *testing.T) {
 		runTest(t, testAndSetItr)
 	})
 }
+
+func TestTxnGetters(t *testing.T) {
+	t.Run("TxnDiscarded", func(t *testing.T) {
+		runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+			txn := db.NewTransaction(true)
+			require.Equal(t, false, txn.Discarded())
+
+			txn.Discard()
+			require.Equal(t, true, txn.Discarded())
+		})
+	})
+}


### PR DESCRIPTION
I have a use case, where there's a network service on top of the BadgerDB. The client can start transaction, do their stuff, and finally commit, all via separate network calls. This makes it impossible to `defer` transaction `Discard` call, as the commit/rollback is executed in a different context. With the current design, I need to send a "ping" `Get` call, to check if the transaction is discarded, with the proposed change things get much simpler.