### PR TITLE
fix: update maxHeaderSize

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -72,8 +72,8 @@ type header struct {
 
 const (
 	// Maximum possible size of the header. The maximum size of header struct will be 18 but the
-	// maximum size of varint encoded header will be 21.
-	maxHeaderSize = 21
+	// maximum size of varint encoded header will be 22.
+	maxHeaderSize = 22
 )
 
 // Encode encodes the header into []byte. The provided []byte should be atleast 5 bytes. The


### PR DESCRIPTION
Based on [pkg-constants](https://pkg.go.dev/encoding/binary#pkg-constants), the `maxHeaderSize` should be 22=5+5+10+1+1, which is discussed on [Why is the `maxHeaderSize` 21 and not 22?](https://discuss.dgraph.io/t/why-is-the-maxheadersize-21-and-not-22/17644)

Signed-off-by: Liang Zheng <zhengliang0901@gmail.com>