### PR TITLE
update blog links

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Badger Documentation is available at https://dgraph.io/docs/badger
 ### Blog Posts
 1. [Introducing Badger: A fast key-value store written natively in
 Go](https://open.dgraph.io/post/badger/)
-2. [Make Badger crash resilient with ALICE](https://blog.dgraph.io/post/alice/)
-3. [Badger vs LMDB vs BoltDB: Benchmarking key-value databases in Go](https://blog.dgraph.io/post/badger-lmdb-boltdb/)
-4. [Concurrent ACID Transactions in Badger](https://blog.dgraph.io/post/badger-txn/)
+2. [Make Badger crash resilient with ALICE](https://dgraph.io/blog/post/alice/)
+3. [Badger vs LMDB vs BoltDB: Benchmarking key-value databases in Go](https://dgraph.io/blog/post/badger-lmdb-boltdb/)
+4. [Concurrent ACID Transactions in Badger](https://dgraph.io/blog/post/badger-txn/)
 
 ## Design
 Badger was written with these design goals in mind:


### PR DESCRIPTION
Fix links since the current ones take the user to the dgraph homepage instead of the linked articles.