### PR TITLE
chore: add github templates + cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS info: https://help.github.com/en/articles/about-code-owners
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
-* @manishrjain @ashish-goswami @jarifibrahim
+* @akon-dey @nosql22 @billprovince @joshua-goldstein @skrdgraph 

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,1 +1,0 @@
-**GitHub Issues are deprecated. Use [Discuss Issues](https://discuss.dgraph.io/c/issues/badger/37) for reporting issues about this repository.**

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: "🐞 Bug Report"
+description: File a bug report
+title: "[BUG]: <Title>"
+labels: ["kind/bug", "status/triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting an issue.
+        If you suspect this could be a bug, please follow this template.
+  - type: textarea
+    attributes:
+      label: What version of Ristretto are you using?
+      description: Copy and paste the tag or commit hash used in your application's go.mod file.
+      placeholder: |
+        Paste here.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: What version of Go are you using?
+      description: Copy and paste all you see using the command 'go version'.
+      placeholder: |
+        Paste here.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Have you tried reproducing the issue with the latest release?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: What is the hardware spec (RAM, CPU, OS)?
+      description: Share all possible context of your machine.
+      placeholder: |
+        Type here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What steps will reproduce the bug?
+      description: Enter details about your bug (command/config used to set up Ristretto).
+      placeholder: |
+        Type here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior and actual result.
+      description: Enter details about your expectations.
+      placeholder: |
+        Type here.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Tell us anything else you think we should know.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         If you suspect this could be a bug, please follow this template.
   - type: textarea
     attributes:
-      label: What version of Ristretto are you using?
+      label: What version of Badger are you using?
       description: Copy and paste the tag or commit hash used in your application's go.mod file.
       placeholder: |
         Paste here.

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -1,0 +1,30 @@
+name: "📃 Documentation Request"
+description: Suggest improvements, additions, or revisions to Ristretto documentation
+title: "[Documentation]: <Title>"
+labels: ["area/documentation", "status/triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting an issue.
+        If you think Ristretto's documentation is lacking, please explain it here.
+  - type: textarea
+    attributes:
+      label: What version of Ristretto is the target?
+      description: Is it the latest version? 
+      placeholder: |
+        Type here.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Documentation.
+      description: Explain which part of the documentation is lacking.
+      placeholder: |
+          Type here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information.
+      description: Tell us anything else you think we should know.

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -1,5 +1,5 @@
 name: "📃 Documentation Request"
-description: Suggest improvements, additions, or revisions to Ristretto documentation
+description: Suggest improvements, additions, or revisions to Badger documentation
 title: "[Documentation]: <Title>"
 labels: ["area/documentation", "status/triage"]
 body:
@@ -7,10 +7,10 @@ body:
     attributes:
       value: |
         Thank you for reporting an issue.
-        If you think Ristretto's documentation is lacking, please explain it here.
+        If you think Badger's documentation is lacking, please explain it here.
   - type: textarea
     attributes:
-      label: What version of Ristretto is the target?
+      label: What version of Badger is the target?
       description: Is it the latest version? 
       placeholder: |
         Type here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: "⚡ Feature Request"
+description: Suggest a new feature
+title: "[FEATURE]: <Title>"
+labels: ["kind/feature ", "status/triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting an issue.
+        If you think we can make Badger better, describe your feature request here.
+        Note: Feature requests are judged based on user experience and modeled on 
+        [Go Experience Reports](https://github.com/golang/go/wiki/ExperienceReports). 
+        These reports should focus on the problems - they should not focus on and need not propose solutions.
+  - type: dropdown
+    attributes:
+      label: Have you tried Badger before this proposal? and did not find anything similar?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: What you wanted to do.
+      description: Enter details about your expectations.
+      placeholder: |
+          Type here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What you actually did.
+      description: Enter details about your experience with Badger.
+      placeholder: |
+          Type here.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Why wasn't it great, with examples.
+      description: Enter details about your expectations.
+      placeholder: |
+          Type here.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional information.
+      description: Any external references to support your case.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,14 @@
+name: "🙋 Question"
+description: Question related to Badger
+title: "[QUESTION]: <Title>"
+labels: ["kind/question ", "status/triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The issue tracker is primarily for code related issues, bug reports, missing documentation, or feature requests.
+        - If you have a question, please consider asking it on https://discuss.dgraph.io
+  - type: textarea
+    attributes:
+      label: Question.
+      description: Ask your Question.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+ Change Github PR Title 
+
+ Your title must be in the following format: 
+ - `topic(Area): Feature`
+ - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`
+
+ Sample Titles:
+ - `feat(Enterprise)`: Backups can now get credentials from IAM
+ - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
+ - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
+ - `chore`: all chores/tests will be excluded from the CHANGELOG
+ -->
+
+## Problem
+ <!--
+ Please add a description with these things:
+ 1. Explain the problem by providing a good description.
+ 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
+ 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
+ 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
+ -->
+
+## Solution
+ <!--
+ Please add a description with these things:
+ 1. Explain the solution to make it easier to review the PR.
+ 2. Make it easier for the reviewer by describing complex sections with comments.
+ -->

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ in pure Go. It is the underlying database for [Dgraph](https://dgraph.io), a
 fast, distributed graph database. It's meant to be a performant alternative to
 non-Go-based key-value stores like RocksDB.
 
-**Use [Discuss Issues](https://discuss.dgraph.io/c/issues/badger/37) for reporting issues about this repository.**
-
-## Project Status [March 24, 2020]
+## Project Status
 
 Badger is stable and is being used to serve data sets worth hundreds of
 terabytes. Badger supports concurrent ACID transactions with serializable
@@ -27,7 +25,9 @@ with v1.0 is v1.6.0.
 Badger v2.0 was released in Nov 2019 with a new storage format which won't
 be compatible with all of the v1.x. Badger v2.0 supports compression, encryption and uses a cache to speed up lookup.
 
-The [Changelog] is kept fairly up-to-date.
+Badger v3.0 was released in January 2021.  This release improves compaction performance.
+
+Please consult the [Changelog] for more detailed information on releases.
 
 For more details on our version naming schema please read [Choosing a version](#choosing-a-version).
 
@@ -51,7 +51,7 @@ For more details on our version naming schema please read [Choosing a version](#
 ## Getting Started
 
 ### Installing
-To start using Badger, install Go 1.12 or above. Badger v2 needs go modules. Run the following command to retrieve the library.
+To start using Badger, install Go 1.12 or above. Badger v3 needs go modules. From your project, run the following command
 
 ```sh
 $ go get github.com/dgraph-io/badger/v3
@@ -60,13 +60,12 @@ This will retrieve the library.
 
 #### Installing Badger Command Line Tool
 
-Download and extract the latest Badger DB release from https://github.com/dgraph-io/badger/releases and then run the following commands.
+Badger provides a CLI tool which can perform certain operations like offline backup/restore.  To install the Badger CLI, run
 
 ```sh
-$ cd badger-<version>/badger
-$ go install
+$ go install github.com/dgraph-io/badger/v3@latest
 ```
-This will install the badger command line utility into your $GOBIN path.
+This will install the badger command line utility into your $GOBIN path. 
 
 #### Choosing a version
 
@@ -86,9 +85,12 @@ Following these rules:
  version is the same, therefore the data format on disk is compatible.
 - v1.6.0 and v2.0.0 are data incompatible as their major version implies, so files created with
  v1.6.0 will need to be converted into the new format before they can be used by v2.0.0.
+ - v2.x.x and v3.x.x are data incompatible as their major version implies, so files created with
+ v2.x.x will need to be converted into the new format before they can be used by v3.0.0.
+
 
 For a longer explanation on the reasons behind using a new versioning naming schema, you can read
-[VERSIONING.md](VERSIONING.md).
+[VERSIONING](VERSIONING.md).
 
 ## Badger Documentation
 
@@ -99,9 +101,9 @@ Badger Documentation is available at https://dgraph.io/docs/badger
 ### Blog Posts
 1. [Introducing Badger: A fast key-value store written natively in
 Go](https://open.dgraph.io/post/badger/)
-2. [Make Badger crash resilient with ALICE](https://blog.dgraph.io/post/alice/)
-3. [Badger vs LMDB vs BoltDB: Benchmarking key-value databases in Go](https://blog.dgraph.io/post/badger-lmdb-boltdb/)
-4. [Concurrent ACID Transactions in Badger](https://blog.dgraph.io/post/badger-txn/)
+2. [Make Badger crash resilient with ALICE](https://open.dgraph.io/post/alice/)
+3. [Badger vs LMDB vs BoltDB: Benchmarking key-value databases in Go](https://open.dgraph.io/post/badger-lmdb-boltdb/)
+4. [Concurrent ACID Transactions in Badger](https://open.dgraph.io/post/badger-txn/)
 
 ## Design
 Badger was written with these design goals in mind:
@@ -204,7 +206,7 @@ If you are using Badger in a project please send a pull request to add it to the
 
 ## Contributing
 
-If you're interested in contributing to Badger see [CONTRIBUTING.md](./CONTRIBUTING.md).
+If you're interested in contributing to Badger see [CONTRIBUTING](./CONTRIBUTING.md).
 
 ## Contact
 - Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.

--- a/README.md
+++ b/README.md
@@ -210,3 +210,4 @@ If you're interested in contributing to Badger see [CONTRIBUTING.md](./CONTRIBUT
 - Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
 - Please use [discuss.dgraph.io](https://discuss.dgraph.io) for filing bugs or feature requests.
 - Follow us on Twitter [@dgraphlabs](https://twitter.com/dgraphlabs).
+- 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ in pure Go. It is the underlying database for [Dgraph](https://dgraph.io), a
 fast, distributed graph database. It's meant to be a performant alternative to
 non-Go-based key-value stores like RocksDB.
 
-## Project Status
+**Use [Discuss Issues](https://discuss.dgraph.io/c/issues/badger/37) for reporting issues about this repository.**
+
+## Project Status [March 24, 2020]
 
 Badger is stable and is being used to serve data sets worth hundreds of
 terabytes. Badger supports concurrent ACID transactions with serializable
@@ -25,9 +27,7 @@ with v1.0 is v1.6.0.
 Badger v2.0 was released in Nov 2019 with a new storage format which won't
 be compatible with all of the v1.x. Badger v2.0 supports compression, encryption and uses a cache to speed up lookup.
 
-Badger v3.0 was released in January 2021.  This release improves compaction performance.
-
-Please consult the [Changelog] for more detailed information on releases.
+The [Changelog] is kept fairly up-to-date.
 
 For more details on our version naming schema please read [Choosing a version](#choosing-a-version).
 
@@ -51,7 +51,7 @@ For more details on our version naming schema please read [Choosing a version](#
 ## Getting Started
 
 ### Installing
-To start using Badger, install Go 1.12 or above. Badger v3 needs go modules. From your project, run the following command
+To start using Badger, install Go 1.12 or above. Badger v2 needs go modules. Run the following command to retrieve the library.
 
 ```sh
 $ go get github.com/dgraph-io/badger/v3
@@ -60,12 +60,13 @@ This will retrieve the library.
 
 #### Installing Badger Command Line Tool
 
-Badger provides a CLI tool which can perform certain operations like offline backup/restore.  To install the Badger CLI, run
+Download and extract the latest Badger DB release from https://github.com/dgraph-io/badger/releases and then run the following commands.
 
 ```sh
-$ go install github.com/dgraph-io/badger/v3@latest
+$ cd badger-<version>/badger
+$ go install
 ```
-This will install the badger command line utility into your $GOBIN path. 
+This will install the badger command line utility into your $GOBIN path.
 
 #### Choosing a version
 
@@ -85,12 +86,9 @@ Following these rules:
  version is the same, therefore the data format on disk is compatible.
 - v1.6.0 and v2.0.0 are data incompatible as their major version implies, so files created with
  v1.6.0 will need to be converted into the new format before they can be used by v2.0.0.
- - v2.x.x and v3.x.x are data incompatible as their major version implies, so files created with
- v2.x.x will need to be converted into the new format before they can be used by v3.0.0.
-
 
 For a longer explanation on the reasons behind using a new versioning naming schema, you can read
-[VERSIONING](VERSIONING.md).
+[VERSIONING.md](VERSIONING.md).
 
 ## Badger Documentation
 
@@ -101,9 +99,9 @@ Badger Documentation is available at https://dgraph.io/docs/badger
 ### Blog Posts
 1. [Introducing Badger: A fast key-value store written natively in
 Go](https://open.dgraph.io/post/badger/)
-2. [Make Badger crash resilient with ALICE](https://open.dgraph.io/post/alice/)
-3. [Badger vs LMDB vs BoltDB: Benchmarking key-value databases in Go](https://open.dgraph.io/post/badger-lmdb-boltdb/)
-4. [Concurrent ACID Transactions in Badger](https://open.dgraph.io/post/badger-txn/)
+2. [Make Badger crash resilient with ALICE](https://blog.dgraph.io/post/alice/)
+3. [Badger vs LMDB vs BoltDB: Benchmarking key-value databases in Go](https://blog.dgraph.io/post/badger-lmdb-boltdb/)
+4. [Concurrent ACID Transactions in Badger](https://blog.dgraph.io/post/badger-txn/)
 
 ## Design
 Badger was written with these design goals in mind:
@@ -206,7 +204,7 @@ If you are using Badger in a project please send a pull request to add it to the
 
 ## Contributing
 
-If you're interested in contributing to Badger see [CONTRIBUTING](./CONTRIBUTING.md).
+If you're interested in contributing to Badger see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Contact
 - Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.

--- a/README.md
+++ b/README.md
@@ -210,4 +210,3 @@ If you're interested in contributing to Badger see [CONTRIBUTING.md](./CONTRIBUT
 - Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
 - Please use [discuss.dgraph.io](https://discuss.dgraph.io) for filing bugs or feature requests.
 - Follow us on Twitter [@dgraphlabs](https://twitter.com/dgraphlabs).
-- 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,5 +43,5 @@ For more background on our decision to adopt Serialization Versioning, read the 
 [Semantic Versioning, Go Modules, and Databases][blog] and the original proposal on
 [this comment on Dgraph's Discuss forum][discuss].
 
-[blog]: https://blog.dgraph.io/post/serialization-versioning/
+[blog]: https://open.dgraph.io/post/serialization-versioning/
 [discuss]: https://discuss.dgraph.io/t/go-modules-on-badger-and-dgraph/4662/7


### PR DESCRIPTION
## Problem

Links are broken, and issue / PR templates don't exist.  Codeowners is out of date.

## Solution

We also add github templates to bring the repo to parity with Dgraph and Ristretto.  We update the codeowners file and fix some links.