### PR TITLE
chore: Remove errorcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - errcheck
+#   - errcheck
     - ineffassign
     - gas
     - gofmt

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # BadgerDB 
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/dgraph-io/badger/v3.svg)](https://pkg.go.dev/github.com/dgraph-io/badger/v3) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/badger/v3)](https://goreportcard.com/report/github.com/dgraph-io/badger) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/badger/v3)](https://goreportcard.com/report/github.com/dgraph-io/badger/v3) 
 [![Sourcegraph](https://sourcegraph.com/github.com/dgraph-io/badger/-/badge.svg)](https://sourcegraph.com/github.com/dgraph-io/badger?badge)
 [![ci-badger-tests](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-tests.yml/badge.svg)](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-tests.yml)
-[![ci-badger-tests-bank](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-tests-bank.yml/badge.svg)](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-tests-bank.yml)
+[![ci-badger-bank-tests](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-bank-tests.yml/badge.svg)](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-bank-tests.yml)
 [![ci-golang-lint](https://github.com/dgraph-io/badger/actions/workflows/ci-golang-lint.yml/badge.svg)](https://github.com/dgraph-io/badger/actions/workflows/ci-golang-lint.yml)
 
 


### PR DESCRIPTION
## Problem
 
Errcheck linter is failing.

## Solution

On [Dgraph](https://github.com/dgraph-io/dgraph/blob/main/.golangci.yml) and [Ristretto](https://github.com/dgraph-io/ristretto/blob/main/.golangci.yml) repositories, neither is running errcheck.  We temporarily disable errcheck here to bring this repository to parity.  We also do some cleanup in the Readme.