### PR TITLE
fix(manifest): fix manifest corruption due to race condition in concurrent compactions (#1756)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [3.2103.3] - 2022-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [3.2103.3] - 2022-10-14

--- a/manifest.go
+++ b/manifest.go
@@ -208,15 +208,14 @@ func (mf *manifestFile) addChanges(changesParam []*pb.ManifestChange) error {
 
 	// Maybe we could use O_APPEND instead (on certain file systems)
 	mf.appendLock.Lock()
+	defer mf.appendLock.Unlock()
 	if err := applyChangeSet(&mf.manifest, &changes); err != nil {
-		mf.appendLock.Unlock()
 		return err
 	}
 	// Rewrite manifest if it'd shrink by 1/10 and it's big enough to care
 	if mf.manifest.Deletions > mf.deletionsRewriteThreshold &&
 		mf.manifest.Deletions > manifestDeletionsRatio*(mf.manifest.Creations-mf.manifest.Deletions) {
 		if err := mf.rewrite(); err != nil {
-			mf.appendLock.Unlock()
 			return err
 		}
 	} else {
@@ -225,14 +224,15 @@ func (mf *manifestFile) addChanges(changesParam []*pb.ManifestChange) error {
 		binary.BigEndian.PutUint32(lenCrcBuf[4:8], crc32.Checksum(buf, y.CastagnoliCrcTable))
 		buf = append(lenCrcBuf[:], buf...)
 		if _, err := mf.fp.Write(buf); err != nil {
-			mf.appendLock.Unlock()
 			return err
 		}
 	}
 
-	mf.appendLock.Unlock()
-	return mf.fp.Sync()
+	return syncFunc(mf.fp)
 }
+
+// this function is saved here to allow injection of fake filesystem latency at test time.
+var syncFunc = func(f *os.File) error { return f.Sync() }
 
 // Has to be 4 bytes.  The value can never change, ever, anyway.
 var magicText = [4]byte{'B', 'd', 'g', 'r'}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -253,9 +253,6 @@ func TestConcurrentManifestCompaction(t *testing.T) {
 	require.NoError(t, err)
 	defer removeDir(dir)
 
-	// set this low so rewrites will happen more often
-	deletionsThreshold := 1
-
 	// overwrite the sync function to make this race condition easily reproducible
 	syncFunc = func(f *os.File) error {
 		// effectively making the Sync() take around 1s makes this reproduce every time
@@ -263,7 +260,7 @@ func TestConcurrentManifestCompaction(t *testing.T) {
 		return f.Sync()
 	}
 
-	mf, _, err := helpOpenOrCreateManifestFile(dir, false, 0, deletionsThreshold)
+	mf, _, err := helpOpenOrCreateManifestFile(dir, false, 0)
 	require.NoError(t, err)
 
 	cs := &pb.ManifestChangeSet{}


### PR DESCRIPTION
This PR is a cherry pick of #1756.  Addresses [this issue](https://discuss.dgraph.io/t/badgerdb-manifest-corruption-issue-solution/15915) on Discuss and[ this issue](https://github.com/dgraph-io/badger/issues/1819) on Badger.