### PR TITLE
chore: run workflows on release branch

### DIFF
--- a/.github/workflows/ci-badger-bank-tests-nightly.yml
+++ b/.github/workflows/ci-badger-bank-tests-nightly.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release/v3.2103
   schedule:
     - cron: "0 3 * * *"
 jobs:

--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - release/v3.2103
   pull_request:
     branches:
       - main
+      - release/v3.2103
   schedule:
     - cron: "*/30 * * * *"
 jobs:

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - release/v3.2103
   pull_request:
     branches:
       - main
+      - release/v3.2103
   schedule:
     - cron: "*/30 * * * *"
 jobs:

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - release/v3.2103
   pull_request:
     branches:
       - main
+      - release/v3.2103
   schedule:
     - cron: "*/30 * * * *"
 jobs:


### PR DESCRIPTION
## Problem

CI jobs are not running when updates are made to release branch.

## Solution

Run all CI jobs when PR's are opened against release branch.