### PR TITLE
chore(cd): cd steps for badger

### DIFF
--- a/.github/workflows/cd-badger.yml
+++ b/.github/workflows/cd-badger.yml
@@ -28,6 +28,8 @@ jobs:
           BADGER_RELEASE_VERSION=$(git rev-parse --abbrev-ref HEAD | sed  's/release\///')
           echo "making a new release for "$BADGER_RELEASE_VERSION
           echo "BADGER_RELEASE_VERSION=$BADGER_RELEASE_VERSION" >> $GITHUB_ENV
+      - name: Fetch dependencies
+        run: sudo apt-get -y install build-essential
       - name: Build badger linux/amd64
         run: make badger
       - name: Generate SHA for Linux Build

--- a/.github/workflows/cd-badger.yml
+++ b/.github/workflows/cd-badger.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate SHA for Linux Build
         run: cd badger && sha256sum badger-linux-amd64 | cut -c-64 > badger-checksum-linux-amd64.sha256
       - name: Tar Archive for Linux Build
-        run: cd badger && tar -zcvf badger-linux-amd64.tar.gz badger
+        run: cd badger && tar -zcvf badger-linux-amd64.tar.gz badger-linux-amd64
       - name: Upload Badger Binary Build Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cd-badger.yml
+++ b/.github/workflows/cd-badger.yml
@@ -1,0 +1,42 @@
+name: cd-badger
+on: workflow_dispatch
+jobs:
+  badger-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Set Badger Release Version
+        run: |
+          #!/bin/bash
+          GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          if [[ "$GIT_BRANCH_NAME" == "release/v"* ]]; 
+          then
+            echo "this is a release branch"
+          else
+            echo "this is NOT a release branch"
+            exit 1
+          fi
+          BADGER_RELEASE_VERSION=$(git rev-parse --abbrev-ref HEAD | sed  's/release\///')
+          echo "making a new release for "$BADGER_RELEASE_VERSION
+          echo "BADGER_RELEASE_VERSION=$BADGER_RELEASE_VERSION" >> $GITHUB_ENV
+      - name: Build badger linux/amd64
+        run: make badger
+      - name: Generate SHA for Linux Build
+        run: cd badger && sha256sum badger-linux-amd64 | cut -c-64 > badger-checksum-linux-amd64.sha256
+      - name: Tar Archive for Linux Build
+        run: cd badger && tar -zcvf badger-linux-amd64.tar.gz badger
+      - name: Upload Badger Binary Build Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            badger/badger-checksum-linux-amd64.sha256
+            badger/badger-linux-amd64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ HAS_JEMALLOC = $(shell test -f /usr/local/lib/libjemalloc.a && echo "jemalloc")
 JEMALLOC_URL = "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
 
 
-.PHONY: all test jemalloc dependency
+.PHONY: all badger test jemalloc dependency
+
+badger: jemalloc
+	@echo "Compiling Badger binary..."
+	@(MAKE) -C badger badger
+	@echo "Badger binary located in badger directory."
 
 test: jemalloc
 	@echo "Running Badger tests..."

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ JEMALLOC_URL = "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jem
 
 badger: jemalloc
 	@echo "Compiling Badger binary..."
-	@(MAKE) -C badger badger
+	@$(MAKE) -C badger badger
 	@echo "Badger binary located in badger directory."
 
 test: jemalloc

--- a/badger/Makefile
+++ b/badger/Makefile
@@ -24,3 +24,4 @@ all: badger
 badger: 
 # 	build badger binary
 	@go build -a --tags=jemalloc -o badger-$(GOOS)-$(GOARCH) .
+	

--- a/badger/Makefile
+++ b/badger/Makefile
@@ -1,0 +1,26 @@
+#
+# Copyright 2022 Dgraph Labs, Inc. and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GOOS          ?= $(shell go env GOOS)
+GOARCH        ?= $(shell go env GOARCH)
+
+.PHONY: test badger
+
+all: badger
+
+badger: 
+# 	build badger binary
+	@go build -a --tags=jemalloc -o badger-$(GOOS)-$(GOARCH) .

--- a/badger/Makefile
+++ b/badger/Makefile
@@ -17,11 +17,10 @@
 GOOS          ?= $(shell go env GOOS)
 GOARCH        ?= $(shell go env GOARCH)
 
-.PHONY: test badger
+.PHONY: badger
 
 all: badger
 
 badger: 
 # 	build badger binary
-	@go build -a --tags=jemalloc -o badger-$(GOOS)-$(GOARCH) .
-	
+	@go build --tags=jemalloc -o badger-$(GOOS)-$(GOARCH) .


### PR DESCRIPTION
This PR adds CD steps for Badger releases.  Artifacts (badger binary and checksum) will be uploaded automatically to Github.  Final step will be to add artifacts to release.  This reflects the process we already have in place for Dgraph.

Badger build flags were taken from the [Dgraph release script](https://github.com/dgraph-io/dgraph/blob/main/contrib/release.sh).  We add a Makefile to streamline the build process.