### PR TITLE
chore(ci): pin ubuntu deps

### DIFF
--- a/.github/workflows/cd-badger.yml
+++ b/.github/workflows/cd-badger.yml
@@ -2,7 +2,7 @@ name: cd-badger
 on: workflow_dispatch
 jobs:
   badger-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-badger-bank-tests-nightly.yml
+++ b/.github/workflows/ci-badger-bank-tests-nightly.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 3 * * *"
 jobs:
   badger-bank:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -12,7 +12,7 @@ on:
     - cron: "*/30 * * * *"
 jobs:
   badger-bank:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -12,7 +12,7 @@ on:
     - cron: "*/30 * * * *"
 jobs:
   badger-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   go-lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version


### PR DESCRIPTION
Latest runner tag now uses ubuntu-22.04.  We pin to ubuntu 20.04.