### PR TITLE
fix(test): rm upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ jemalloc:
 dependency:
 	@echo "Installing dependencies..."
 	@sudo apt-get update
-	@sudo apt-get -y upgrade
 	@sudo apt-get -y install \
     	ca-certificates \
     	curl \


### PR DESCRIPTION
## Problem
We don't need an `apt upgrade`* step here. this is an overkill - plus it's causing some dependency issue on the environment layer. it's also causing a bunch of tests to fail in the installation step - https://github.com/dgraph-io/badger/actions .. we don't have a consistent baseline mostly because of the failing environment setup step.

we should have a tight pinning on our environments. operations like `upgrade` etc. can induce failures suddenly based on upstream changes.

issue 
- https://github.com/dgraph-io/badger/actions/runs/3909870547/jobs/6681427503
- https://github.com/dgraph-io/badger/actions?query=event%3Aschedule

## Solution
rm upgrade* 