### PR TITLE
feat(stream): add support for incremental stream writer (#1722)

### DIFF
--- a/badger/cmd/stream.go
+++ b/badger/cmd/stream.go
@@ -118,6 +118,7 @@ func stream(cmd *cobra.Command, args []string) error {
 			WithValueDir(so.outDir).
 			WithNumVersionsToKeep(so.numVersions).
 			WithCompression(options.CompressionType(so.compressionType)).
+			WithEncryptionKey(encKey).
 			WithReadOnly(false)
 		err = inDB.StreamDB(outOpt)
 

--- a/db.go
+++ b/db.go
@@ -1623,7 +1623,7 @@ func (db *DB) prepareToDrop() (func(), error) {
 	// write it to db. Then, flush all the pending memtable. So that, we
 	// don't miss any entries.
 	if err := db.blockWrite(); err != nil {
-		return nil, err
+		return func() {}, err
 	}
 	reqs := make([]*request, 0, 10)
 	for {


### PR DESCRIPTION
This PR adds support for stream writing incrementally to the DB.
Adds an API: StreamWriter.PrepareIncremental