### PR TITLE
chore: remove dependency on io/ioutil

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -19,7 +19,6 @@ package badger
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -34,7 +33,7 @@ import (
 )
 
 func TestBackupRestore1(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	db, err := Open(getTestOptions(dir))
@@ -72,10 +71,10 @@ func TestBackupRestore1(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use different directory.
-	dir, err = ioutil.TempDir("", "badger-test")
+	dir, err = os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
-	bak, err := ioutil.TempFile(dir, "badgerbak")
+	bak, err := os.CreateTemp(dir, "badgerbak")
 	require.NoError(t, err)
 	_, err = db.Backup(bak, 0)
 	require.NoError(t, err)
@@ -118,7 +117,7 @@ func TestBackupRestore1(t *testing.T) {
 }
 
 func TestBackupRestore2(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "badger-test")
+	tmpdir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 
 	defer removeDir(tmpdir)
@@ -306,7 +305,7 @@ func TestBackup(t *testing.T) {
 		require.NoError(t, err)
 	}
 	t.Run("disk mode", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "badger-test")
+		tmpdir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 
 		defer removeDir(tmpdir)
@@ -326,7 +325,7 @@ func TestBackup(t *testing.T) {
 
 func TestBackupRestore3(t *testing.T) {
 	var bb bytes.Buffer
-	tmpdir, err := ioutil.TempDir("", "badger-test")
+	tmpdir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 
 	defer removeDir(tmpdir)
@@ -387,7 +386,7 @@ func TestBackupRestore3(t *testing.T) {
 }
 
 func TestBackupLoadIncremental(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "badger-test")
+	tmpdir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 
 	defer removeDir(tmpdir)
@@ -507,7 +506,7 @@ func TestBackupLoadIncremental(t *testing.T) {
 }
 
 func TestBackupBitClear(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -528,11 +527,11 @@ func TestBackupBitClear(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use different directory.
-	dir, err = ioutil.TempDir("", "badger-test")
+	dir, err = os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
-	bak, err := ioutil.TempFile(dir, "badgerbak")
+	bak, err := os.CreateTemp(dir, "badgerbak")
 	require.NoError(t, err)
 	_, err = db.Backup(bak, 0)
 	require.NoError(t, err)

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -21,10 +21,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"math/rand"
+	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -382,7 +382,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 	var tmpDb *badger.DB
 	var subscribeDB *badger.DB
 	if checkSubscriber {
-		dir, err := ioutil.TempDir("", "bank_subscribe")
+		dir, err := os.MkdirTemp("", "bank_subscribe")
 		y.Check(err)
 
 		subscribeDB, err = badger.Open(badger.DefaultOptions(dir).WithSyncWrites(false))
@@ -393,7 +393,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 	}
 
 	if checkStream {
-		dir, err := ioutil.TempDir("", "bank_stream")
+		dir, err := os.MkdirTemp("", "bank_stream")
 		y.Check(err)
 
 		tmpDb, err = badger.Open(badger.DefaultOptions(dir).WithSyncWrites(false))

--- a/badger/cmd/rotate.go
+++ b/badger/cmd/rotate.go
@@ -17,7 +17,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -79,5 +79,5 @@ func getKey(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(fp)
+	return io.ReadAll(fp)
 }

--- a/badger/cmd/rotate_test.go
+++ b/badger/cmd/rotate_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestRotate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -38,7 +37,7 @@ func TestRotate(t *testing.T) {
 	_, err = rand.Read(key)
 	require.NoError(t, err)
 
-	fp, err := ioutil.TempFile("", "*.key")
+	fp, err := os.CreateTemp("", "*.key")
 	require.NoError(t, err)
 	_, err = fp.Write(key)
 	require.NoError(t, err)
@@ -64,7 +63,7 @@ func TestRotate(t *testing.T) {
 	key2 := make([]byte, 32)
 	_, err = rand.Read(key2)
 	require.NoError(t, err)
-	fp2, err := ioutil.TempFile("", "*.key")
+	fp2, err := os.CreateTemp("", "*.key")
 	require.NoError(t, err)
 	_, err = fp2.Write(key2)
 	require.NoError(t, err)
@@ -99,7 +98,7 @@ func TestRotate(t *testing.T) {
 
 // This test shows that rotate tool can be used to enable encryption.
 func TestRotatePlainTextToEncrypted(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -117,7 +116,7 @@ func TestRotatePlainTextToEncrypted(t *testing.T) {
 	// Create an encryption key.
 	key := make([]byte, 32)
 	y.Check2(rand.Read(key))
-	fp, err := ioutil.TempFile("", "*.key")
+	fp, err := os.CreateTemp("", "*.key")
 	require.NoError(t, err)
 	_, err = fp.Write(key)
 	require.NoError(t, err)

--- a/batch_test.go
+++ b/batch_test.go
@@ -18,7 +18,7 @@ package badger
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -150,7 +150,7 @@ func TestFlushPanic(t *testing.T) {
 }
 
 func TestBatchErrDeadlock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 

--- a/db2_test.go
+++ b/db2_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"math/rand"
@@ -54,7 +53,7 @@ func TestTruncateVlogWithClose(t *testing.T) {
 		return m
 	}
 
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -425,7 +424,7 @@ func TestBigValues(t *testing.T) {
 // tables on level 3 and 3 tables on level 2. Tables on level 2 have overlap with 2, 4, 3 tables on
 // level 3.
 func TestCompactionFilePicking(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -578,7 +577,7 @@ func TestReadSameVlog(t *testing.T) {
 func TestL0GCBug(t *testing.T) {
 	t.Skipf("TestL0GCBug is DISABLED. TODO(ibrahim): Do we need this?")
 
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -673,7 +672,7 @@ func TestWindowsDataLoss(t *testing.T) {
 		t.Skip("The test is only for Windows.")
 	}
 
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -826,7 +825,7 @@ func TestIsClosed(t *testing.T) {
 		if inMemory {
 			opt.InMemory = true
 		} else {
-			dir, err := ioutil.TempDir("", "badger-test")
+			dir, err := os.MkdirTemp("", "badger-test")
 			require.NoError(t, err)
 			defer removeDir(dir)
 
@@ -867,7 +866,7 @@ func TestMaxVersion(t *testing.T) {
 		})
 	})
 	t.Run("multiple versions", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 
@@ -893,7 +892,7 @@ func TestMaxVersion(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 	t.Run("Managed mode", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 
@@ -919,7 +918,7 @@ func TestMaxVersion(t *testing.T) {
 }
 
 func TestTxnReadTs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -1017,7 +1016,7 @@ func TestKeyCount(t *testing.T) {
 	}
 
 	N := uint64(10 * 1e6) // 10 million entries
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := DefaultOptions(dir).

--- a/db_test.go
+++ b/db_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -106,7 +105,7 @@ func txnDelete(t *testing.T, kv *DB, key []byte) {
 
 // Opens a badger db and runs a a test on it.
 func runBadgerTest(t *testing.T, opts *Options, test func(t *testing.T, db *DB)) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	if opts == nil {
@@ -336,7 +335,7 @@ func TestTxnTooBig(t *testing.T) {
 }
 
 func TestForceCompactL0(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -385,7 +384,7 @@ func TestStreamDB(t *testing.T) {
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir).
@@ -407,7 +406,7 @@ func TestStreamDB(t *testing.T) {
 	require.NoError(t, writer.Flush())
 	check(db)
 
-	outDir, err := ioutil.TempDir("", "badger-test")
+	outDir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	outOpt := getTestOptions(outDir)
 	require.NoError(t, db.StreamDB(outOpt))
@@ -448,7 +447,7 @@ func dirSize(path string) (int64, error) {
 // Also with PR #1303, the delete keys are properly cleaned which
 // further reduces disk size.
 func BenchmarkDbGrowth(b *testing.B) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(b, err)
 	defer removeDir(dir)
 
@@ -780,7 +779,7 @@ func TestIterate2Basic(t *testing.T) {
 
 func TestLoad(t *testing.T) {
 	testLoad := func(t *testing.T, opt Options) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 		opt.Dir = dir
@@ -1013,7 +1012,7 @@ func TestIterateParallel(t *testing.T) {
 }
 
 func TestDeleteWithoutSyncWrite(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	kv, err := Open(DefaultOptions(dir))
@@ -1126,7 +1125,7 @@ func TestIteratorPrefetchSize(t *testing.T) {
 }
 
 func TestSetIfAbsentAsync(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	kv, _ := Open(getTestOptions(dir))
@@ -1359,7 +1358,7 @@ func TestExpiryImproperDBClose(t *testing.T) {
 	}
 
 	t.Run("Test plain text", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 		opt := getTestOptions(dir)
@@ -1367,7 +1366,7 @@ func TestExpiryImproperDBClose(t *testing.T) {
 	})
 
 	t.Run("Test encryption", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 		opt := getTestOptions(dir)
@@ -1432,7 +1431,7 @@ func TestLargeKeys(t *testing.T) {
 		require.NoError(t, db.Close())
 	}
 	t.Run("disk mode", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 		opt := DefaultOptions(dir).WithValueLogFileSize(1024 * 1024 * 1024)
@@ -1446,7 +1445,7 @@ func TestLargeKeys(t *testing.T) {
 }
 
 func TestCreateDirs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "parent")
+	dir, err := os.MkdirTemp("", "parent")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -1458,7 +1457,7 @@ func TestCreateDirs(t *testing.T) {
 }
 
 func TestGetSetDeadlock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	fmt.Println(dir)
 	require.NoError(t, err)
 	defer removeDir(dir)
@@ -1501,7 +1500,7 @@ func TestGetSetDeadlock(t *testing.T) {
 }
 
 func TestWriteDeadlock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -1680,7 +1679,7 @@ func TestTestSequence2(t *testing.T) {
 func TestReadOnly(t *testing.T) {
 	t.Skipf("TODO: ReadOnly needs truncation, so this fails")
 
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -1750,7 +1749,7 @@ func TestReadOnly(t *testing.T) {
 }
 
 func TestLSMOnly(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -1878,7 +1877,7 @@ func TestGoroutineLeak(t *testing.T) {
 }
 
 func ExampleOpen() {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		panic(err)
 	}
@@ -1933,7 +1932,7 @@ func ExampleOpen() {
 }
 
 func ExampleTxn_NewIterator() {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		panic(err)
 	}
@@ -1990,7 +1989,7 @@ func ExampleTxn_NewIterator() {
 }
 
 func TestSyncForRace(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -2038,7 +2037,7 @@ func TestSyncForRace(t *testing.T) {
 }
 
 func TestForceFlushMemtable(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err, "temp dir for badger count not be created")
 
 	ops := getTestOptions(dir)
@@ -2077,7 +2076,7 @@ func TestForceFlushMemtable(t *testing.T) {
 
 func TestVerifyChecksum(t *testing.T) {
 	testVerfiyCheckSum := func(t *testing.T, opt Options) {
-		path, err := ioutil.TempDir("", "badger-test")
+		path, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer os.Remove(path)
 		opt.ValueDir = path
@@ -2179,7 +2178,7 @@ func TestMinCacheSize(t *testing.T) {
 }
 
 func TestUpdateMaxCost(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err, "temp dir for badger count not be created")
 	defer os.RemoveAll(dir)
 
@@ -2209,7 +2208,7 @@ func TestUpdateMaxCost(t *testing.T) {
 }
 
 func TestOpenDBReadOnly(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -2286,7 +2285,7 @@ func TestOpenDBReadOnly(t *testing.T) {
 }
 
 func TestBannedPrefixes(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err, "temp dir for badger count not be created")
 	defer os.RemoveAll(dir)
 

--- a/dir_unix.go
+++ b/dir_unix.go
@@ -21,7 +21,6 @@ package badger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -72,7 +71,7 @@ func acquireDirectoryLock(dirPath string, pidFileName string, readOnly bool) (
 	if !readOnly {
 		// Yes, we happily overwrite a pre-existing pid file.  We're the
 		// only read-write badger process using this directory.
-		err = ioutil.WriteFile(absPidFilePath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0666)
+		err = os.WriteFile(absPidFilePath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0666)
 		if err != nil {
 			f.Close()
 			return nil, y.Wrapf(err,

--- a/discard_test.go
+++ b/discard_test.go
@@ -17,14 +17,14 @@
 package badger
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestDiscardStats(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -54,7 +54,7 @@ func TestDiscardStats(t *testing.T) {
 }
 
 func TestReloadDiscardStats(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -19,7 +19,6 @@ package badger
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -294,7 +293,7 @@ func TestIteratePrefix(t *testing.T) {
 
 // Sanity test to verify the iterator does not crash the db in readonly mode if data does not exist.
 func TestIteratorReadOnlyWithNoData(t *testing.T) {
-	dir, err := ioutil.TempDir(".", "badger-test")
+	dir, err := os.MkdirTemp(".", "badger-test")
 	y.Check(err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -359,7 +358,7 @@ func TestIteratorReadOnlyWithNoData(t *testing.T) {
 //
 // Only my laptop there's a 20% improvement in latency with ~80 files.
 func BenchmarkIteratePrefixSingleKey(b *testing.B) {
-	dir, err := ioutil.TempDir(".", "badger-test")
+	dir, err := os.MkdirTemp(".", "badger-test")
 	y.Check(err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)

--- a/key_registry_test.go
+++ b/key_registry_test.go
@@ -16,8 +16,8 @@
 package badger
 
 import (
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,7 +32,7 @@ func getRegistryTestOptions(dir string, key []byte) KeyRegistryOptions {
 }
 func TestBuildRegistry(t *testing.T) {
 	encryptionKey := make([]byte, 32)
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -64,7 +64,7 @@ func TestBuildRegistry(t *testing.T) {
 
 func TestRewriteRegistry(t *testing.T) {
 	encryptionKey := make([]byte, 32)
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	_, err = rand.Read(encryptionKey)
@@ -90,7 +90,7 @@ func TestRewriteRegistry(t *testing.T) {
 
 func TestMismatch(t *testing.T) {
 	encryptionKey := make([]byte, 32)
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	_, err = rand.Read(encryptionKey)
@@ -115,7 +115,7 @@ func TestMismatch(t *testing.T) {
 
 func TestEncryptionAndDecryption(t *testing.T) {
 	encryptionKey := make([]byte, 32)
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	_, err = rand.Read(encryptionKey)

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -2,9 +2,9 @@ package badger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
+	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -58,7 +58,7 @@ func numKeysManaged(db *DB, readTs uint64) int {
 }
 
 func TestDropAllManaged(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -103,7 +103,7 @@ func TestDropAllManaged(t *testing.T) {
 }
 
 func TestDropAll(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -167,7 +167,7 @@ func TestDropAllTwice(t *testing.T) {
 		require.NoError(t, db.Close())
 	}
 	t.Run("disk mode", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 		opts := getTestOptions(dir)
@@ -182,7 +182,7 @@ func TestDropAllTwice(t *testing.T) {
 }
 
 func TestDropAllWithPendingTxn(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -253,7 +253,7 @@ func TestDropAllWithPendingTxn(t *testing.T) {
 }
 
 func TestDropReadOnly(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -286,7 +286,7 @@ func TestDropReadOnly(t *testing.T) {
 }
 
 func TestWriteAfterClose(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -312,7 +312,7 @@ func TestWriteAfterClose(t *testing.T) {
 }
 
 func TestDropAllRace(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -376,7 +376,7 @@ func TestDropAllRace(t *testing.T) {
 }
 
 func TestDropPrefix(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -428,7 +428,7 @@ func TestDropPrefix(t *testing.T) {
 }
 
 func TestDropPrefixWithPendingTxn(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -500,7 +500,7 @@ func TestDropPrefixWithPendingTxn(t *testing.T) {
 }
 
 func TestDropPrefixReadOnly(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)
@@ -533,7 +533,7 @@ func TestDropPrefixReadOnly(t *testing.T) {
 }
 
 func TestDropPrefixRace(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opts := getTestOptions(dir)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -19,7 +19,6 @@ package badger
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ import (
 )
 
 func TestManifestBasic(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -73,7 +72,7 @@ func TestManifestBasic(t *testing.T) {
 }
 
 func helpTestManifestFileCorruption(t *testing.T, off int64, errorContent string) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -163,7 +162,7 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 	// linter, I realized that the runCompactDef function below always returns error.
 	t.Skip()
 
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	kv, err := Open(DefaultOptions(dir))
@@ -215,7 +214,7 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 }
 
 func TestManifestRewrite(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	deletionsThreshold := 10
@@ -253,7 +252,7 @@ func TestManifestRewrite(t *testing.T) {
 }
 
 func TestConcurrentManifestCompaction(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 

--- a/memtable.go
+++ b/memtable.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -59,7 +58,7 @@ func (db *DB) openMemTables(opt Options) error {
 	if db.opt.InMemory {
 		return nil
 	}
-	files, err := ioutil.ReadDir(db.opt.Dir)
+	files, err := os.ReadDir(db.opt.Dir)
 	if err != nil {
 		return errFile(err, db.opt.Dir, "Unable to open mem dir.")
 	}

--- a/merge_test.go
+++ b/merge_test.go
@@ -18,7 +18,7 @@ package badger
 
 import (
 	"encoding/binary"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -130,7 +130,7 @@ func TestGetMergeOperator(t *testing.T) {
 		})
 	})
 	t.Run("Old keys should be removed after compaction", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -19,8 +19,8 @@ package badger
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -71,7 +71,7 @@ func (c *collector) Send(buf *z.Buffer) error {
 var ctxb = context.Background()
 
 func TestStream(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -173,7 +173,7 @@ func TestStream(t *testing.T) {
 }
 
 func TestStreamWithThreadId(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -232,7 +232,7 @@ func TestBigStream(t *testing.T) {
 	}()
 
 	testSize := int(1e6)
-	dir, err := ioutil.TempDir("", "badger-big-test")
+	dir, err := os.MkdirTemp("", "badger-big-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -276,7 +276,7 @@ func TestBigStream(t *testing.T) {
 // There was a bug in the stream writer code which would cause allocators to be
 // freed up twice if the default keyToList was not used. This test verifies that issue.
 func TestStreamCustomKeyToList(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -438,7 +437,7 @@ func TestStreamDone(t *testing.T) {
 }
 
 func TestSendOnClosedStream(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.RemoveAll(dir))
@@ -488,7 +487,7 @@ func TestSendOnClosedStream(t *testing.T) {
 }
 
 func TestSendOnClosedStream2(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.RemoveAll(dir))
@@ -535,7 +534,7 @@ func TestSendOnClosedStream2(t *testing.T) {
 }
 
 func TestStreamWriterEncrypted(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 
 	opts := DefaultOptions(dir)

--- a/txn_test.go
+++ b/txn_test.go
@@ -18,8 +18,8 @@ package badger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -733,7 +733,7 @@ func TestIteratorAllVersionsWithDeleted2(t *testing.T) {
 }
 
 func TestManagedDB(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -847,7 +847,7 @@ func TestManagedDB(t *testing.T) {
 }
 
 func TestArmV7Issue311Fix(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	defer removeDir(dir)

--- a/util.go
+++ b/util.go
@@ -18,8 +18,8 @@ package badger
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -97,7 +97,7 @@ func (s *levelsController) reserveFileID() uint64 {
 }
 
 func getIDMap(dir string) map[uint64]struct{} {
-	fileInfos, err := ioutil.ReadDir(dir)
+	fileInfos, err := os.ReadDir(dir)
 	y.Check(err)
 	idMap := make(map[uint64]struct{})
 	for _, info := range fileInfos {

--- a/value.go
+++ b/value.go
@@ -23,7 +23,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"sort"
@@ -473,7 +472,7 @@ func (vlog *valueLog) fpath(fid uint32) string {
 func (vlog *valueLog) populateFilesMap() error {
 	vlog.filesMap = make(map[uint32]*logFile)
 
-	files, err := ioutil.ReadDir(vlog.dirPath)
+	files, err := os.ReadDir(vlog.dirPath)
 	if err != nil {
 		return errFile(err, vlog.dirPath, "Unable to open log dir.")
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -37,7 +36,7 @@ import (
 
 func TestDynamicValueThreshold(t *testing.T) {
 	t.Skip()
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	y.Check(err)
 	defer removeDir(dir)
 	kv, _ := Open(getTestOptions(dir).WithValueThreshold(32).WithVLogPercentile(0.99))
@@ -78,7 +77,7 @@ func TestDynamicValueThreshold(t *testing.T) {
 }
 
 func TestValueBasic(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	y.Check(err)
 	defer removeDir(dir)
 
@@ -138,7 +137,7 @@ func TestValueBasic(t *testing.T) {
 }
 
 func TestValueGCManaged(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -186,9 +185,11 @@ func TestValueGCManaged(t *testing.T) {
 		}))
 	}
 	wg.Wait()
-	files, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	for _, fi := range files {
+	for _, e := range entries {
+		fi, err := e.Info()
+		require.NoError(t, err)
 		t.Logf("File: %s. Size: %s\n", fi.Name(), humanize.IBytes(uint64(fi.Size())))
 	}
 
@@ -205,7 +206,7 @@ func TestValueGCManaged(t *testing.T) {
 }
 
 func TestValueGC(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
@@ -258,7 +259,7 @@ func TestValueGC(t *testing.T) {
 }
 
 func TestValueGC2(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
@@ -335,7 +336,7 @@ func TestValueGC2(t *testing.T) {
 }
 
 func TestValueGC3(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
@@ -410,7 +411,7 @@ func TestValueGC3(t *testing.T) {
 }
 
 func TestValueGC4(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
@@ -484,7 +485,7 @@ func TestValueGC4(t *testing.T) {
 }
 
 func TestPersistLFDiscardStats(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
@@ -548,7 +549,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 }
 
 func TestValueChecksums(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -578,7 +579,7 @@ func TestValueChecksums(t *testing.T) {
 		{Key: k2, Value: v2},
 	})
 	buf[offset-1]++ // Corrupt last byte
-	require.NoError(t, ioutil.WriteFile(kv.mtFilePath(1), buf, 0777))
+	require.NoError(t, os.WriteFile(kv.mtFilePath(1), buf, 0777))
 
 	// K1 should exist, but K2 shouldn't.
 	kv, err = Open(opts)
@@ -631,7 +632,7 @@ func TestValueChecksums(t *testing.T) {
 
 // TODO: Do we need this test?
 func TestPartialAppendToWAL(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -664,7 +665,7 @@ func TestPartialAppendToWAL(t *testing.T) {
 		{Key: k2, Value: v2},
 	})
 	buf = buf[:offset-6]
-	require.NoError(t, ioutil.WriteFile(kv.mtFilePath(1), buf, 0777))
+	require.NoError(t, os.WriteFile(kv.mtFilePath(1), buf, 0777))
 
 	// Badger should now start up
 	kv, err = Open(opts)
@@ -693,7 +694,7 @@ func TestPartialAppendToWAL(t *testing.T) {
 }
 
 func TestReadOnlyOpenWithPartialAppendToWAL(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -721,7 +722,7 @@ func TestReadOnlyOpenWithPartialAppendToWAL(t *testing.T) {
 		{Key: k2, Value: v2},
 	})
 	buf = buf[:offset-6]
-	require.NoError(t, ioutil.WriteFile(kv.mtFilePath(1), buf, 0777))
+	require.NoError(t, os.WriteFile(kv.mtFilePath(1), buf, 0777))
 
 	opts.ReadOnly = true
 	// Badger should fail a read-only open with values to replay
@@ -732,7 +733,7 @@ func TestReadOnlyOpenWithPartialAppendToWAL(t *testing.T) {
 
 func TestValueLogTrigger(t *testing.T) {
 	t.Skip("Difficult to trigger compaction, so skipping. Re-enable after fixing #226")
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -769,7 +770,7 @@ func TestValueLogTrigger(t *testing.T) {
 
 // createMemFile creates a new memFile and returns the last valid offset.
 func createMemFile(t *testing.T, entries []*Entry) ([]byte, uint32) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -789,14 +790,14 @@ func createMemFile(t *testing.T, entries []*Entry) ([]byte, uint32) {
 	require.NoError(t, txn.Commit())
 
 	filename := kv.mtFilePath(1)
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	require.NoError(t, err)
 	return buf, kv.mt.wal.writeAt
 }
 
 // This test creates two mem files and corrupts the last bit of the first file.
 func TestPenultimateMemCorruption(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 	opt := getTestOptions(dir)
@@ -923,7 +924,7 @@ func (th *testHelper) readRange(from, to int) {
 // older version can end up at a higher level in the LSM tree than a newer
 // version, causing the data to not be returned.
 func TestBug578(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	y.Check(err)
 	defer removeDir(dir)
 
@@ -965,7 +966,7 @@ func BenchmarkReadWrite(b *testing.B) {
 	for _, vsz := range valueSize {
 		for _, rw := range rwRatio {
 			b.Run(fmt.Sprintf("%3.1f,%04d", rw, vsz), func(b *testing.B) {
-				dir, err := ioutil.TempDir("", "vlog-benchmark")
+				dir, err := os.MkdirTemp("", "vlog-benchmark")
 				y.Check(err)
 				defer removeDir(dir)
 
@@ -1021,7 +1022,7 @@ func BenchmarkReadWrite(b *testing.B) {
 // Regression test for https://github.com/dgraph-io/badger/issues/817
 // This test verifies if fully corrupted memtables are deleted on reopen.
 func TestValueLogTruncate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 
@@ -1037,8 +1038,8 @@ func TestValueLogTruncate(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	// Create two mem files with corrupted data. These will be truncated when DB starts next time
-	require.NoError(t, ioutil.WriteFile(db.mtFilePath(2), []byte("foo"), 0664))
-	require.NoError(t, ioutil.WriteFile(db.mtFilePath(3), []byte("foo"), 0664))
+	require.NoError(t, os.WriteFile(db.mtFilePath(2), []byte("foo"), 0664))
+	require.NoError(t, os.WriteFile(db.mtFilePath(3), []byte("foo"), 0664))
 
 	db, err = Open(DefaultOptions(dir))
 	require.NoError(t, err)
@@ -1081,7 +1082,7 @@ func TestValueEntryChecksum(t *testing.T) {
 	k := []byte("KEY")
 	v := []byte(fmt.Sprintf("val%100d", 10))
 	t.Run("ok", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 
@@ -1110,7 +1111,7 @@ func TestValueEntryChecksum(t *testing.T) {
 	})
 	// Regression test for https://github.com/dgraph-io/badger/issues/1049
 	t.Run("Corruption", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "badger-test")
+		dir, err := os.MkdirTemp("", "badger-test")
 		require.NoError(t, err)
 		defer removeDir(dir)
 
@@ -1219,7 +1220,7 @@ func TestValidateWrite(t *testing.T) {
 }
 
 func TestValueLogMeta(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	y.Check(err)
 	defer removeDir(dir)
 
@@ -1263,7 +1264,7 @@ func TestValueLogMeta(t *testing.T) {
 // This tests asserts the condition that vlog fids start from 1.
 // TODO(naman): should this be changed to assert instead?
 func TestFirstVlogFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)
 


### PR DESCRIPTION
we stil have a couple of places where we are using io/ioutil.