### PR TITLE
chore(ci): update changelog + import paths for v4

### DIFF
--- a/.github/workflows/ci-badger-bank-tests-nightly.yml
+++ b/.github/workflows/ci-badger-bank-tests-nightly.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - main
-      - release/v3.2103
-      - release/v4.0
+      - 'release/v*'
   schedule:
     - cron: "0 3 * * *"
 jobs:

--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-      - release/v3.2103
-      - release/v4.0
+      - 'release/v*'
   pull_request:
     branches:
       - main
-      - release/v3.2103
-      - release/v4.0
+      - 'release/v*'
   schedule:
     - cron: "*/30 * * * *"
 jobs:

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-      - release/v3.2103
-      - release/v4.0
+      - 'release/v*'
   pull_request:
     branches:
       - main
-      - release/v3.2103
-      - release/v4.0
+      - 'release/v*'
   schedule:
     - cron: "*/30 * * * *"
 jobs:

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-      - release/v3.2103
-      - release/v4.0
+      - 'release/v*'
   pull_request:
     branches:
       - main
-      - release/v3.2103
-      - release/v4.0
+      - 'release/v*'
   schedule:
     - cron: "*/30 * * * *"
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [4.0.0] - 2022-02-24
+## [4.0.0] - 2023-02-24
 
 This release fixes a bug in the maxHeaderSize parameter that could lead
 to panics. We introduce an external magic number to keep track of external

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to understand when breaking API and data format changes are made.
 - enable linters (gosimple, govet, lll, unused, staticcheck, errcheck, ineffassign, gofmt) #1871 #1870 #1876 
 - remove dependency on io/ioutil #1879 
 - various doc and comment fixes #1857
+- moving from CalVer to SemVer
 
 ## [3.2103.5] - 2022-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [4.0.0] - 2022-02-24
+
+This release fixes a bug in the maxHeaderSize parameter that could lead
+to panics. We introduce an external magic number to keep track of external
+dependencies. We bump up the minimum required Go version to 1.19. No changes
+were made to the format of data on disk.  This is a major release because
+we are making a switch to SemVer in order to make it easier for the community
+to understand when breaking API and data format changes are made.
+
+### Fixed
+- fix: update maxHeaderSize #1877
+- feat(externalMagic): Introduce external magic number (#1745) #1852
+- fix(bench): bring in benchmark fixes from main #1863 
+
+### Chores
+- upgrade go to 1.19 #1868 
+- enable linters (gosimple, govet, lll, unused, staticcheck, errcheck, ineffassign, gofmt) #1871 #1870 #1876 
+- remove dependency on io/ioutil #1879 
+- various doc and comment fixes #1857
+
 ## [3.3.0] - 2022-02-23
 
 This minor release fixes a bug in the maxHeaderSize parameter that could lead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,24 +23,6 @@ to understand when breaking API and data format changes are made.
 - remove dependency on io/ioutil #1879 
 - various doc and comment fixes #1857
 
-## [3.3.0] - 2022-02-23
-
-This minor release fixes a bug in the maxHeaderSize parameter that could lead
-to panics. We introduce an external magic number to keep track of external
-dependencies. We bump up the minimum required Go version to 1.19. No changes
-were made to the format of data on disk.
-
-### Fixed
-- fix: update maxHeaderSize #1877
-- feat(externalMagic): Introduce external magic number (#1745) #1852
-- fix(bench): bring in benchmark fixes from main #1863 
-
-### Chores
-- upgrade go to 1.19 #1868 
-- enable linters (gosimple, govet, lll, unused, staticcheck, errcheck, ineffassign, gofmt) #1871 #1870 #1876 
-- remove dependency on io/ioutil #1879 
-- various doc and comment fixes #1857 
-
 ## [3.2103.5] - 2022-12-15
 
 We release Badger CLI tool binaries for amd64 and now arm64. This release does not involve any core code changes to Badger. We add a CD job for building Badger for arm64.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BadgerDB 
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/dgraph-io/badger/v3.svg)](https://pkg.go.dev/github.com/dgraph-io/badger/v3) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/badger/v3)](https://goreportcard.com/report/github.com/dgraph-io/badger/v3) 
+[![Go Reference](https://pkg.go.dev/badge/github.com/dgraph-io/badger/v4.svg)](https://pkg.go.dev/github.com/dgraph-io/badger/v4) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/badger/v4)](https://goreportcard.com/report/github.com/dgraph-io/badger/v4) 
 [![Sourcegraph](https://sourcegraph.com/github.com/dgraph-io/badger/-/badge.svg)](https://sourcegraph.com/github.com/dgraph-io/badger?badge)
 [![ci-badger-tests](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-tests.yml/badge.svg)](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-tests.yml)
 [![ci-badger-bank-tests](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-bank-tests.yml/badge.svg)](https://github.com/dgraph-io/badger/actions/workflows/ci-badger-bank-tests.yml)
@@ -65,7 +65,7 @@ For more details on our version naming schema please read [Choosing a version](#
 To start using Badger, install Go 1.19 or above. Badger v3 needs go modules. From your project, run the following command
 
 ```sh
-$ go get github.com/dgraph-io/badger/v3
+$ go get github.com/dgraph-io/badger/v4
 ```
 This will retrieve the library.
 

--- a/backup.go
+++ b/backup.go
@@ -26,8 +26,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/backup_test.go
+++ b/backup_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/badger/v4/pb"
 )
 
 func TestBackupRestore1(t *testing.T) {

--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 )
 
 var bo = struct {

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -32,9 +32,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -23,8 +23,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 )
 
 var flattenCmd = &cobra.Command{

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -31,10 +31,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 type flagOptions struct {

--- a/badger/cmd/pick_table_bench.go
+++ b/badger/cmd/pick_table_bench.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 var pickBenchCmd = &cobra.Command{

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -28,9 +28,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/badger/cmd/restore.go
+++ b/badger/cmd/restore.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 )
 
 var restoreFile string

--- a/badger/cmd/rotate.go
+++ b/badger/cmd/rotate.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v4"
 )
 
 var oldKeyPath string

--- a/badger/cmd/rotate_test.go
+++ b/badger/cmd/rotate_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 func TestRotate(t *testing.T) {

--- a/badger/cmd/stream.go
+++ b/badger/cmd/stream.go
@@ -25,9 +25,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 var streamCmd = &cobra.Command{

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -32,10 +32,10 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/badger/main.go
+++ b/badger/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"go.opencensus.io/zpages"
 
-	"github.com/dgraph-io/badger/v3/badger/cmd"
+	"github.com/dgraph-io/badger/v4/badger/cmd"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/batch.go
+++ b/batch.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 func TestWriteBatch(t *testing.T) {

--- a/compaction.go
+++ b/compaction.go
@@ -23,8 +23,8 @@ import (
 	"math"
 	"sync"
 
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 type keyRange struct {

--- a/db.go
+++ b/db.go
@@ -34,11 +34,11 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/skl"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/skl"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto"
 	"github.com/dgraph-io/ristretto/z"
 )

--- a/db2_test.go
+++ b/db2_test.go
@@ -35,10 +35,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/db_test.go
+++ b/db_test.go
@@ -34,9 +34,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/dir_plan9.go
+++ b/dir_plan9.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 // directoryLockGuard holds a lock on a directory and a pid file inside.  The pid file isn't part

--- a/dir_unix.go
+++ b/dir_unix.go
@@ -26,7 +26,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 // directoryLockGuard holds a lock on a directory and a pid file inside.  The pid file isn't part

--- a/dir_windows.go
+++ b/dir_windows.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 // FILE_ATTRIBUTE_TEMPORARY - A file that is being used for temporary storage.

--- a/discard.go
+++ b/discard.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/docs/content/get-started/index.md
+++ b/docs/content/get-started/index.md
@@ -8,7 +8,7 @@ aliases = ["/get-started"]
 To start using Badger, install Go 1.19 or above. Badger v2 needs go modules. Run the following command to retrieve the library.
 
 ```sh
-$ go get github.com/dgraph-io/badger/v3
+$ go get github.com/dgraph-io/badger/v4
 ```
 This will retrieve the library.
 
@@ -60,7 +60,7 @@ package main
 import (
 	"log"
 
-	badger "github.com/dgraph-io/badger/v3"
+	badger "github.com/dgraph-io/badger/v4"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dgraph-io/badger/v3
+module github.com/dgraph-io/badger/v4
 
 go 1.19
 

--- a/integration/testgc/main.go
+++ b/integration/testgc/main.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/iterator.go
+++ b/iterator.go
@@ -25,8 +25,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 type tableMock struct {

--- a/key_registry.go
+++ b/key_registry.go
@@ -28,8 +28,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 const (

--- a/level_handler.go
+++ b/level_handler.go
@@ -21,8 +21,8 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 type levelHandler struct {

--- a/levels.go
+++ b/levels.go
@@ -33,9 +33,9 @@ import (
 	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/levels_test.go
+++ b/levels_test.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 // createAndOpen creates a table with the given data and adds it to the given level.

--- a/managed_db_test.go
+++ b/managed_db_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/manifest.go
+++ b/manifest.go
@@ -31,9 +31,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 // Manifest represents the contents of the MANIFEST file in a Badger store.

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -30,10 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 	otrace "go.opencensus.io/trace"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 func TestManifestBasic(t *testing.T) {

--- a/memtable.go
+++ b/memtable.go
@@ -35,9 +35,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/skl"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/skl"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/merge.go
+++ b/merge.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/options.go
+++ b/options.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/options_test.go
+++ b/options_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/dgraph-io/badger/v3/options"
+	"github.com/dgraph-io/badger/v4/options"
 )
 
 func TestOptions(t *testing.T) {

--- a/pb/badgerpb3.proto
+++ b/pb/badgerpb3.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 
 package badgerpb3;
 
-option go_package = "github.com/dgraph-io/badger/v3/pb";
+option go_package = "github.com/dgraph-io/badger/v4/pb";
 
 message KV {
   bytes key = 1;

--- a/publisher.go
+++ b/publisher.go
@@ -20,9 +20,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/trie"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/trie"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/badger/v4/pb"
 )
 
 // This test will result in deadlock for commits before this.

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -20,7 +20,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 const (

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -37,7 +37,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/skl/skl_test.go
+++ b/skl/skl_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 const arenaSize = 1 << 20

--- a/stream.go
+++ b/stream.go
@@ -26,8 +26,8 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	bpb "github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	bpb "github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -24,9 +24,9 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/table/builder.go
+++ b/table/builder.go
@@ -29,10 +29,10 @@ import (
 	fbs "github.com/google/flatbuffers/go"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/fb"
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/fb"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/fb"
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/fb"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto"
 )
 

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -22,8 +22,8 @@ import (
 	"io"
 	"sort"
 
-	"github.com/dgraph-io/badger/v3/fb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/fb"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 type blockIterator struct {

--- a/table/merge_iterator.go
+++ b/table/merge_iterator.go
@@ -19,7 +19,7 @@ package table
 import (
 	"bytes"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 // MergeIterator merges multiple iterators.

--- a/table/merge_iterator_test.go
+++ b/table/merge_iterator_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 type SimpleIterator struct {

--- a/table/table.go
+++ b/table/table.go
@@ -35,10 +35,10 @@ import (
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/fb"
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/fb"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto"
 	"github.com/dgraph-io/ristretto/z"
 )

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/cespare/xxhash"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/options"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto"
 )
 

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ fi
 # Run `go list` BEFORE setting GOFLAGS so that the output is in the right
 # format for grep.
 # export packages because the test will run in a sub process.
-export packages=$(go list ./... | grep "github.com/dgraph-io/badger/v3/")
+export packages=$(go list ./... | grep "github.com/dgraph-io/badger/v4/")
 
 tags="-tags=jemalloc"
 
@@ -66,7 +66,7 @@ manual() {
 
 root() {
   # Run the normal tests.
-  # go test -timeout=25m -v -race github.com/dgraph-io/badger/v3/...
+  # go test -timeout=25m -v -race github.com/dgraph-io/badger/v4/...
 
   echo "==> Running root level tests."
   set -e

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 type node struct {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/badger/v4/pb"
 )
 
 func TestGet(t *testing.T) {

--- a/txn.go
+++ b/txn.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/txn_test.go
+++ b/txn_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/util.go
+++ b/util.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/table"
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/table"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 func (s *levelsController) validate() error {

--- a/value.go
+++ b/value.go
@@ -34,7 +34,7 @@ import (
 	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/value_test.go
+++ b/value_test.go
@@ -31,7 +31,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/badger/v4/y"
 )
 
 func TestDynamicValueThreshold(t *testing.T) {

--- a/y/checksum.go
+++ b/y/checksum.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cespare/xxhash"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/badger/v4/pb"
 )
 
 // ErrChecksumMismatch is returned at checksum mismatch.

--- a/y/y.go
+++ b/y/y.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/badger/v4/pb"
 	"github.com/dgraph-io/ristretto/z"
 )
 

--- a/y/y_test.go
+++ b/y/y_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/badger/v4/pb"
 	"github.com/dgraph-io/ristretto/z"
 )
 


### PR DESCRIPTION
Changelog should reflect that we are switching to SemVer.  This requires moving to a new major version.  We also update all import paths in Badger.