### PR TITLE
chore(go.mod): add retraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ We issue a follow up release in order to resolve a bug in subscriber.  We also g
   - chore(cd): tag based deployments #1887
   - chore(ci): fail fast when testing #1890
 
-## [4.0.0] - 2023-02-26
+## [4.0.0] - 2023-02-27
 
 > **Warning**
 > The tag v4.0.0 has been retracted due to a bug in publisher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [4.0.1] - 2023-02-28
+
+We issue a follow up release in order to resolve a bug in subscriber.  We also generate updated protobufs for Badger v4.
+
+### Fixed
+  - fix(pb): fix generated protos #1888
+  - fix(publisher): initialize the atomic variable #1889
+
+### Chores
+  - chore(cd): tag based deployments #1887
+  - chore(ci): fail fast when testing #1890
+
 ## [4.0.0] - 2023-02-24
+
+> **Warning**
+> The tag v4.0.0 has been retracted due to a bug in publisher.
+> Use v4.0.1 (see #1889)
 
 This release fixes a bug in the maxHeaderSize parameter that could lead
 to panics. We introduce an external magic number to keep track of external

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ We issue a follow up release in order to resolve a bug in subscriber.  We also g
   - chore(cd): tag based deployments #1887
   - chore(ci): fail fast when testing #1890
 
-## [4.0.0] - 2023-02-24
+## [4.0.0] - 2023-02-26
 
 > **Warning**
 > The tag v4.0.0 has been retracted due to a bug in publisher.

--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+retract v4.0.0 // see #1888 and #1889


### PR DESCRIPTION
Since the v4.0.0 tag cannot be removed from the goproxy service, we added a retraction directive so users do not accidentally use v4.0.0 tag.