### PR TITLE
chore(ci): use pull request target

### DIFF
--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - 'release/v*'
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - 'release/v*'
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with: 
+          ref: ${{ github.event.pull_request.head.sha }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Get Go Version
         run: |
           #!/bin/bash
@@ -34,5 +37,4 @@ jobs:
       - name: Send Coverage Results
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: goveralls -coverprofile=cover.out


### PR DESCRIPTION
Secrets are not accessible to community PR's.  This is a problem when reporting code coverage, since our goveralls token is stored as a secret, resulting in CI failure.  See discussion https://github.com/dependabot/dependabot-core/issues/3253 for workaround.  More details about permissions here: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token