### PR TITLE
chore(ci): remove unnecessary token

### DIFF
--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v3
         with: 
           ref: ${{ github.event.pull_request.head.sha }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Get Go Version
         run: |
           #!/bin/bash


### PR DESCRIPTION
We added a token because we thought there was a permission issue, however the issue was the action secrets were not available to community PR's.  See discussion https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544