### PR TITLE
feat(txn): Add PreCommit and PreCommitAt methods

### DIFF
--- a/managed_db.go
+++ b/managed_db.go
@@ -87,3 +87,13 @@ func (db *DB) SetDiscardTs(ts uint64) {
 	}
 	db.orc.setDiscardTs(ts)
 }
+
+// CanCommitAt will return true if commit will succeed at specified commit timestamp
+func (txn *Txn) CanCommitAt(commitTs uint64) bool {
+	if !txn.db.opt.managedTxns {
+		panic("Cannot use CommitAt with managedDB=false. Use Commit instead.")
+	}
+	txn.commitTs = commitTs
+
+	return !txn.db.orc.hasConflict(txn)
+}

--- a/managed_db.go
+++ b/managed_db.go
@@ -91,7 +91,7 @@ func (db *DB) SetDiscardTs(ts uint64) {
 // CanCommitAt will return true if commit will succeed at specified commit timestamp
 func (txn *Txn) CanCommitAt(commitTs uint64) bool {
 	if !txn.db.opt.managedTxns {
-		panic("Cannot use CommitAt with managedDB=false. Use Commit instead.")
+		panic("Cannot use CanCommitAt with managedDB=false. Use CanCommit instead.")
 	}
 	txn.commitTs = commitTs
 

--- a/txn.go
+++ b/txn.go
@@ -829,9 +829,9 @@ func (db *DB) Update(fn func(txn *Txn) error) error {
 
 // CanCommit will return true if commit will succeed for Txn.Commit()
 func (txn *Txn) CanCommit() bool {
-	// Commit will not succeed for Txn.Commit() when transactions are managed.
 	if txn.db.opt.managedTxns {
-		return false
+		panic("Cannot use CanCommit with managedDB=true. Use CanCommitAt instead.")
 	}
+
 	return !txn.db.orc.hasConflict(txn)
 }

--- a/txn.go
+++ b/txn.go
@@ -831,13 +831,3 @@ func (db *DB) Update(fn func(txn *Txn) error) error {
 func (txn *Txn) CanCommit() bool {
 	return !txn.db.orc.hasConflict(txn)
 }
-
-// CanCommitAt will return true if commit will succeed at specified commit timestamp
-func (txn *Txn) CanCommitAt(commitTs uint64) bool {
-	if !txn.db.opt.managedTxns {
-		panic("Cannot use CommitAt with managedDB=false. Use Commit instead.")
-	}
-	txn.commitTs = commitTs
-
-	return !txn.db.orc.hasConflict(txn)
-}

--- a/txn.go
+++ b/txn.go
@@ -827,7 +827,11 @@ func (db *DB) Update(fn func(txn *Txn) error) error {
 	return txn.Commit()
 }
 
-// CanCommit will return true if commit will succeed
+// CanCommit will return true if commit will succeed for Txn.Commit()
 func (txn *Txn) CanCommit() bool {
+	// Commit will not succeed for Txn.Commit() when transactions are managed.
+	if txn.db.opt.managedTxns {
+		return false
+	}
 	return !txn.db.orc.hasConflict(txn)
 }

--- a/txn.go
+++ b/txn.go
@@ -826,3 +826,18 @@ func (db *DB) Update(fn func(txn *Txn) error) error {
 
 	return txn.Commit()
 }
+
+// CanCommit will return true if commit will succeed
+func (txn *Txn) CanCommit() bool {
+	return !txn.db.orc.hasConflict(txn)
+}
+
+// CanCommitAt will return true if commit will succeed at specified commit timestamp
+func (txn *Txn) CanCommitAt(commitTs uint64) bool {
+	if !txn.db.opt.managedTxns {
+		panic("Cannot use CommitAt with managedDB=false. Use Commit instead.")
+	}
+	txn.commitTs = commitTs
+
+	return !txn.db.orc.hasConflict(txn)
+}

--- a/txn_test.go
+++ b/txn_test.go
@@ -770,9 +770,9 @@ func TestManagedDB(t *testing.T) {
 			require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
 		}
 
-		require.Panics(t, func() { _ = txn.CanCommit() })
-		require.True(t, txn.CanCommitAt(3))
+		require.False(t, txn.CanCommit())
 		require.Error(t, txn.Commit())
+		require.True(t, txn.CanCommitAt(3))
 		require.NoError(t, txn.CommitAt(3, nil))
 
 		// Read data at t=2.

--- a/txn_test.go
+++ b/txn_test.go
@@ -50,8 +50,8 @@ func TestTxnSimple(t *testing.T) {
 			return nil
 		}))
 
-		require.Panics(t, func() { _ = txn.CanCommitAt(100) })
-		require.True(t, txn.CanCommit())
+		require.Panics(t, func() { _ = txn.PreCommitAt(100) })
+		require.True(t, txn.PreCommit())
 
 		require.Panics(t, func() { _ = txn.CommitAt(100, nil) })
 		require.NoError(t, txn.Commit())
@@ -111,7 +111,7 @@ func TestTxnCommitAsync(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.True(t, txn.CanCommit())
+		require.True(t, txn.PreCommit())
 
 		require.NoError(t, txn.Commit())
 		txn.Discard()
@@ -327,9 +327,9 @@ func TestTxnWriteSkew(t *testing.T) {
 		require.Equal(t, 100, sum)
 
 		// Commit both now.
-		require.True(t, txn1.CanCommit())
+		require.True(t, txn1.PreCommit())
 		require.NoError(t, txn1.Commit())
-		require.False(t, txn2.CanCommit()) // This should be false.
+		require.False(t, txn2.PreCommit()) // This should be false.
 		require.Error(t, txn2.Commit())    // This should fail.
 
 		require.Equal(t, uint64(2), db.orc.readTs())
@@ -770,9 +770,9 @@ func TestManagedDB(t *testing.T) {
 			require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
 		}
 
-		require.Panics(t, func() { _ = txn.CanCommit() })
+		require.Panics(t, func() { _ = txn.PreCommit() })
 		require.Error(t, txn.Commit())
-		require.True(t, txn.CanCommitAt(3))
+		require.True(t, txn.PreCommitAt(3))
 		require.NoError(t, txn.CommitAt(3, nil))
 
 		// Read data at t=2.
@@ -804,7 +804,7 @@ func TestManagedDB(t *testing.T) {
 			}
 			require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
 		}
-		require.True(t, txn.CanCommitAt(7))
+		require.True(t, txn.PreCommitAt(7))
 		require.NoError(t, txn.CommitAt(7, nil))
 
 		// Read data at t=9.
@@ -837,7 +837,7 @@ func TestManagedDB(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, txn.SetEntry(NewEntry(key(0), val(0))))
 		require.NoError(t, txnb.SetEntry(NewEntry(key(0), val(1))))
-		require.True(t, txn.CanCommitAt(11))
+		require.True(t, txn.PreCommitAt(11))
 		require.NoError(t, txn.CommitAt(11, nil))
 		require.Equal(t, ErrConflict, txnb.CommitAt(11, nil))
 	}

--- a/txn_test.go
+++ b/txn_test.go
@@ -770,7 +770,7 @@ func TestManagedDB(t *testing.T) {
 			require.NoError(t, txn.SetEntry(NewEntry(key(i), val(i))))
 		}
 
-		require.False(t, txn.CanCommit())
+		require.Panics(t, func() { _ = txn.CanCommit() })
 		require.Error(t, txn.Commit())
 		require.True(t, txn.CanCommitAt(3))
 		require.NoError(t, txn.CommitAt(3, nil))


### PR DESCRIPTION
## Problem
There is no way to perform a 2 phase commit with badger directly. This PR adds pre-commit methods for 2 phase commits.

## Solution
The new `PreCommit` and `PreCommitAt` methods added to `Txn` performs the validation portion of a commit for observability without needing to write the commit.
