### PR TITLE
chore(ci): clean up ci-badger-test workflow

### DIFF
--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Get Go Version
         run: |
           #!/bin/bash
-          DEFAULT_VERSION="1.19"
-          GOVERSION=$({ [ -f .go-version ] && cat .go-version; } || echo $DEFAULT_VERSION)
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
           echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -15,13 +15,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-        with: 
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Get Go Version
         run: |
           #!/bin/bash
-          DEFAULT_VERSION="1.19"
-          GOVERSION=$({ [ -f .go-version ] && cat .go-version; } || echo $DEFAULT_VERSION)
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
           echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
       - name: Setup Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
Remove redundant checkout and default go version.