### PR TITLE
fix: update code comments for WithNumCompactors

### DIFF
--- a/options.go
+++ b/options.go
@@ -615,7 +615,7 @@ func (opt Options) WithValueLogMaxEntries(val uint32) Options {
 // WithNumCompactors sets the number of compaction workers to run concurrently.  Setting this to
 // zero stops compactions, which could eventually cause writes to block forever.
 //
-// The default value of NumCompactors is 2. One is dedicated just for L0 and L1.
+// The default value of NumCompactors is 4. One is dedicated just for L0 and L1.
 func (opt Options) WithNumCompactors(val int) Options {
 	opt.NumCompactors = val
 	return opt


### PR DESCRIPTION
😁 I think the default value of NumCompactors is `4` in comments for WithNumCompactors,  it's not 2. 

Because the value of NumCompactors is 4 in `DefaultOptions` function.

[https://github.com/dgraph-io/badger/blob/main/options.go#L148](https://github.com/dgraph-io/badger/blob/main/options.go#L148)

### DefaultOptions

```go
// DefaultOptions sets a list of recommended options for good performance.
// Feel free to modify these to suit your needs with the WithX methods.
func DefaultOptions(path string) Options {
	return Options{
		// ...

		NumCompactors:           4, // Run at least 2 compactors. Zero-th compactor prioritizes L0.

		// ...
}
```

### code comments for WithNumCompactors.

```go
// WithNumCompactors sets the number of compaction workers to run concurrently.  Setting this to
// zero stops compactions, which could eventually cause writes to block forever.
//
// The default value of NumCompactors is 2. One is dedicated just for L0 and L1.
func (opt Options) WithNumCompactors(val int) Options {
	opt.NumCompactors = val
	return opt
}
```