### PR TITLE
Added a test for fill tables

### DIFF
--- a/levels_test.go
+++ b/levels_test.go
@@ -1201,7 +1201,7 @@ func TestFillTableCleanup(t *testing.T) {
 		buildLevel := func(level int, num_tab int) {
 			lh := db.lc.levels[level]
 			for i := byte(1); i < byte(num_tab); i++ {
-				tab := buildTable(byte(i))
+				tab := buildTable(i)
 				require.NoError(t, db.manifest.addChanges([]*pb.ManifestChange{
 					newCreateChange(tab.ID(), level, 0, tab.CompressionType()),
 				}))

--- a/levels_test.go
+++ b/levels_test.go
@@ -17,7 +17,6 @@
 package badger
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -27,7 +26,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	otrace "go.opencensus.io/trace"
 
 	"github.com/dgraph-io/badger/v4/options"
 	"github.com/dgraph-io/badger/v4/pb"
@@ -1225,12 +1223,10 @@ func TestFillTableCleanup(t *testing.T) {
 		tt := db.lc.levelTargets()
 		tt.fileSz[6] = 1 << 30
 		prio := compactionPriority{level: 6, t: tt}
-		_, span := otrace.StartSpan(context.Background(), "Badger.Compaction")
-		defer span.End()
 
 		cd := compactDef{
 			compactorId: 0,
-			span:        span,
+			span:        nil,
 			p:           prio,
 			t:           prio.t,
 			thisLevel:   db.lc.levels[level-1],


### PR DESCRIPTION
Add a test to make sure fill tables part of compaction is reverted properly without any issues.
Ran the test 1000 times locally to verify that its not flaky.