### PR TITLE
fix(docs): update docs removing cgo and non semver versioning

### DIFF
--- a/docs/content/get-started/index.md
+++ b/docs/content/get-started/index.md
@@ -5,46 +5,19 @@ aliases = ["/get-started"]
 
 
 ## Installing
-To start using Badger, install Go 1.19 or above. Badger v2 needs go modules. Run the following command to retrieve the library.
+To start using Badger, install Go 1.19 or above. Run the following command to retrieve the library.
 
 ```sh
 $ go get github.com/dgraph-io/badger/v4
 ```
 This will retrieve the library.
 
-{{% notice "note" %}} Badger does not directly use CGO but it relies on https://github.com/DataDog/zstd for compression and it requires gcc/cgo. If you wish to use badger without gcc/cgo, you can run `CGO_ENABLED=0 go get github.com/dgraph-io/badger/...` which will download badger without the support for ZSTD compression algorithm.{{% /notice %}}
-
 ### Installing Badger Command Line Tool
 
-Download and extract the latest Badger DB release from https://github.com/dgraph-io/badger/releases and then run the following commands.
-
 ```sh
-$ cd badger-<version>/badger
-$ go install
+$ go install github.com/dgraph-io/badger/v4/badger@latest
 ```
 This will install the badger command line utility into your $GOBIN path.
-
-### Choosing a version
-
-BadgerDB is a pretty special package from the point of view that the most important change we can
-make to it is not on its API but rather on how data is stored on disk.
-
-This is why we follow a version naming schema that differs from Semantic Versioning.
-
-- New major versions are released when the data format on disk changes in an incompatible way.
-- New minor versions are released whenever the API changes but data compatibility is maintained.
- Note that the changes on the API could be backward-incompatible - unlike Semantic Versioning.
-- New patch versions are released when there's no changes to the data format nor the API.
-
-Following these rules:
-
-- v1.5.0 and v1.6.0 can be used on top of the same files without any concerns, as their major
- version is the same, therefore the data format on disk is compatible.
-- v1.6.0 and v2.0.0 are data incompatible as their major version implies, so files created with
- v1.6.0 will need to be converted into the new format before they can be used by v2.0.0.
-
-For a longer explanation on the reasons behind using a new versioning naming schema, you can read
-[VERSIONING.md](https://github.com/dgraph-io/badger/blob/master/VERSIONING.md)
 
 ## Opening a database
 The top-level object in Badger is a `DB`. It represents multiple files on disk


### PR DESCRIPTION
I have updated the docs to include a simpler way of installing the badger tool. I also removed outdated information about CGO and non SEMVER versioning. 