### PR TITLE
fix(test): add missing unlock in TestPersistLFDiscardStats

### DIFF
--- a/value_test.go
+++ b/value_test.go
@@ -522,7 +522,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	time.Sleep(4 * time.Second) // wait for compaction to complete
+	time.Sleep(2 * time.Second) // wait for compaction to complete
 
 	persistedMap := make(map[uint64]uint64)
 	db.vlog.discardStats.Lock()
@@ -539,7 +539,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 	db, err = Open(opt)
 	require.NoError(t, err)
 	defer db.Close()
-	time.Sleep(4 * time.Second) // Wait for discardStats to be populated by populateDiscardStats().
+	time.Sleep(1 * time.Second) // Wait for discardStats to be populated by populateDiscardStats().
 	db.vlog.discardStats.Lock()
 	statsMap := make(map[uint64]uint64)
 	db.vlog.discardStats.Iterate(func(fid, val uint64) {

--- a/value_test.go
+++ b/value_test.go
@@ -530,6 +530,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 	db.vlog.discardStats.Iterate(func(fid, val uint64) {
 		persistedMap[fid] = val
 	})
+
 	db.vlog.discardStats.Unlock()
 	require.NoError(t, db.Close())
 
@@ -538,7 +539,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 	db, err = Open(opt)
 	require.NoError(t, err)
 	defer db.Close()
-	time.Sleep(1 * time.Second) // Wait for discardStats to be populated by populateDiscardStats().
+	time.Sleep(4 * time.Second) // Wait for discardStats to be populated by populateDiscardStats().
 	db.vlog.discardStats.Lock()
 	statsMap := make(map[uint64]uint64)
 	db.vlog.discardStats.Iterate(func(fid, val uint64) {

--- a/value_test.go
+++ b/value_test.go
@@ -522,7 +522,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	time.Sleep(2 * time.Second) // wait for compaction to complete
+	time.Sleep(4 * time.Second) // wait for compaction to complete
 
 	persistedMap := make(map[uint64]uint64)
 	db.vlog.discardStats.Lock()
@@ -530,7 +530,7 @@ func TestPersistLFDiscardStats(t *testing.T) {
 	db.vlog.discardStats.Iterate(func(fid, val uint64) {
 		persistedMap[fid] = val
 	})
-
+	db.vlog.discardStats.Unlock()
 	require.NoError(t, db.Close())
 
 	// Avoid running compactors on reopening badger.


### PR DESCRIPTION
## Description

`TestPersistLFDiscardStats` is currently flaky.  E.g., [1](https://github.com/dgraphio/badger/actions/runs/4662647309/jobs/8253226059), [2](https://github.com/dgraph-io/badger/actions/runs/4660157619/jobs/8247868522), [3](https://github.com/dgraph-io/badger/actions/runs/4659474072/jobs/8246402042) (but this goes back further).  To reproduce the problem:
```
go test -run=TestPersistLFDiscardStats -count=80 -timeout=1500s
```

From the stack traces in the logs, this looks like a deadlock.  The test currently sleeps for 2 seconds to allow for compaction to complete.  Assuming compaction does not complete in this time, and we make the call to `db.vlog.discardStats.Lock()`, seems to be enough to put us into this deadlock.  This is supported experimentally; running the above test command with this change no longer produces the deadlock.

There is another sleep in the test to give discardStats a chance to be populated by the newly generated discardStats.  We have not seen this issue in CI, but when running this test at very high frequencies (i.e. with `-count=160`), we start to see this failure as well.  This is mitigated by increasing the sleep.
