### PR TITLE
(WIP) Close memtable wal when it's flushed to disk

### DIFF
--- a/db.go
+++ b/db.go
@@ -512,6 +512,7 @@ func (db *DB) BlockCacheMetrics() *ristretto.Metrics {
 
 // IndexCacheMetrics returns the metrics for the underlying index cache.
 func (db *DB) IndexCacheMetrics() *ristretto.Metrics {
+	fmt.Println("Is index cache on", db.indexCache != nil)
 	if db.indexCache != nil {
 		return db.indexCache.Metrics
 	}
@@ -575,7 +576,8 @@ func (db *DB) close() (err error) {
 					select {
 					case db.flushChan <- db.mt:
 						db.imm = append(db.imm, db.mt) // Flusher will attempt to remove this from s.imm.
-						db.mt = nil                    // Will segfault if we try writing!
+						db.mt.wal.Close()
+						db.mt = nil // Will segfault if we try writing!
 						db.opt.Debugf("pushed to flush chan\n")
 						return true
 					default:

--- a/db.go
+++ b/db.go
@@ -512,7 +512,6 @@ func (db *DB) BlockCacheMetrics() *ristretto.Metrics {
 
 // IndexCacheMetrics returns the metrics for the underlying index cache.
 func (db *DB) IndexCacheMetrics() *ristretto.Metrics {
-	fmt.Println("Is index cache on", db.indexCache != nil)
 	if db.indexCache != nil {
 		return db.indexCache.Metrics
 	}
@@ -576,7 +575,7 @@ func (db *DB) close() (err error) {
 					select {
 					case db.flushChan <- db.mt:
 						db.imm = append(db.imm, db.mt) // Flusher will attempt to remove this from s.imm.
-						db.mt.wal.Close()
+						db.mt.wal.Close(0)
 						db.mt = nil // Will segfault if we try writing!
 						db.opt.Debugf("pushed to flush chan\n")
 						return true


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->