### PR TITLE
fix(test): The new test case PagebufferReader5 introduced an error.

### DIFF
--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - 'release/v*'
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 'release/v*'

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - 'release/v*'
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - 'release/v*'

--- a/y/y_test.go
+++ b/y/y_test.go
@@ -262,21 +262,16 @@ func TestPagebufferReader4(t *testing.T) {
 // Test when reading into 0 length readBuffer
 func TestPagebufferReader5(t *testing.T) {
 	b := NewPageBuffer(32)
-	readerWhenEmptyPageBuffer := b.NewReaderAt(0)
-
-	readBuffer := []byte{} // Intentionally empty readBuffer.
-	n, err := readerWhenEmptyPageBuffer.Read(readBuffer)
-	require.NoError(t, err, "reading into empty buffer should return no error")
-	require.Equal(t, 0, n, "read into empty buffer should return 0 bytes")
-
 	var wb [20]byte
 	rand.Read(wb[:])
 	n, err = b.Write(wb[:])
 	require.Equal(t, n, len(wb), "length of buffer and length written should be equal")
 	require.NoError(t, err, "unable to write bytes to buffer")
 
-	readerWhenNonEmptyPageBuffer := b.NewReaderAt(0)
-	n, err = readerWhenNonEmptyPageBuffer.Read(readBuffer)
+	reader := b.NewReaderAt(0)
+
+	readBuffer := []byte{} // Intentionally empty readBuffer.
+	n, err := reader.Read(readBuffer)
 	require.NoError(t, err, "reading into empty buffer should return no error")
 	require.Equal(t, 0, n, "read into empty buffer should return 0 bytes")
 }

--- a/y/y_test.go
+++ b/y/y_test.go
@@ -264,14 +264,14 @@ func TestPagebufferReader5(t *testing.T) {
 	b := NewPageBuffer(32)
 	var wb [20]byte
 	rand.Read(wb[:])
-	n, err = b.Write(wb[:])
+	n, err := b.Write(wb[:])
 	require.Equal(t, n, len(wb), "length of buffer and length written should be equal")
 	require.NoError(t, err, "unable to write bytes to buffer")
 
 	reader := b.NewReaderAt(0)
 
 	readBuffer := []byte{} // Intentionally empty readBuffer.
-	n, err := reader.Read(readBuffer)
+	n, err = reader.Read(readBuffer)
 	require.NoError(t, err, "reading into empty buffer should return no error")
 	require.Equal(t, 0, n, "read into empty buffer should return 0 bytes")
 }


### PR DESCRIPTION
## Problem
Fixes DGRAPHCORE-199
The intended fix for the CI issue for randomly getting EOF failures in PagebufferReader2 test introduced the test case FixPagebufferReader5 -- intended to avoid regressions. However, it did something that is not expected by the PageBuffer struct: it created a new PageBufferReader based on an empty PageBuffer. It seems that this is not allowed.
 
## Solution
Fix the test case for PagebufferReader5 by no longer attempting to create a new PageBufferReader based on an empty PageBuffer.

### Note
The CI build will still fail to allow this to pass because it will continue to use the prior version of the tests without the fix. However, locally tested, I get this result:
~/gitspace/github.com/dgraph-io/badger/y$ go test -run PagebufferReader5
PASS
ok  	github.com/dgraph-io/badger/v4/y	0.335s

