### PR TITLE
fix(CI) branch reference

### DIFF
--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Get Go Version
         run: |
           #!/bin/bash


### PR DESCRIPTION
## Problem
pull_request_target event when a pull request is opened, edited, closed, or synchronized on the main branch. The workflow then checks out the code from the head repository and branch, and deploys the code

## Solution
pull_request_target is needed for coverage tests
and to make it work correctly on PRs we need the `with` clause.

NOTE: we may have an issue with `${{ github.event.pull_request.head.ref }}` on scheduled runs ... if it does we will raise a fix for it later. 