### PR TITLE
chore(ci): split off coverage workflow

### DIFF
--- a/.github/workflows/ci-badger-tests-coverage.yml
+++ b/.github/workflows/ci-badger-tests-coverage.yml
@@ -1,20 +1,16 @@
-name: ci-badger-tests
+name: ci-badger-tests-coverage
 on:
-  push:
+  pull_request_target:
     branches:
       - main
       - 'release/v*'
-  pull_request:
-    branches:
-      - main
-      - 'release/v*'
-  schedule:
-    - cron: "*/30 * * * *"
 jobs:
-  badger-tests:
+  badger-tests-coverage:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3 # checkout merge commit
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Get Go Version
         run: |
           #!/bin/bash

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - 'release/v*'
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 'release/v*'

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -4,14 +4,41 @@ on:
     branches:
       - main
       - 'release/v*'
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - 'release/v*'
   schedule:
     - cron: "*/30 * * * *"
 jobs:
+  badger-tests-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3 # checkout merge commit
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Install Dependencies
+        run: make dependency
+      - name: Run Badger Tests
+        run: make test
+      - name: Install Goveralls
+        run: go install github.com/mattn/goveralls@latest
+      - name: Send Coverage Results
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
+        run: goveralls -coverprofile=cover.out
   badger-tests:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -33,4 +60,4 @@ jobs:
       - name: Send Coverage Results
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
-        run: goveralls -coverprofile=cover.out
+        run: goveralls -coverprofile=cover.o

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Send Coverage Results
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
-        run: goveralls -coverprofile=cover.o
+        run: goveralls -coverprofile=cover.out

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -28,9 +28,3 @@ jobs:
         run: make dependency
       - name: Run Badger Tests
         run: make test
-      - name: Install Goveralls
-        run: go install github.com/mattn/goveralls@latest
-      - name: Send Coverage Results
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLSIO_TOKEN }}
-        run: goveralls -coverprofile=cover.out

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -14,7 +14,7 @@ jobs:
   badger-tests:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3 # checkout merge commit
+      - uses: actions/checkout@v3
       - name: Get Go Version
         run: |
           #!/bin/bash


### PR DESCRIPTION
In https://github.com/dgraph-io/badger/pull/1936 we observed that because we are using `pull_request_target` without a specific reference, we are not in fact checking out the PR branch.  This PR splits the workflow into two, one only to run badger CI tests, and the other to run tests & report coverage results (using pr_target with the appropriate commit).  This has the benefit that any issues with coverage are isolated to one workflow, which we could disable later if problems arise.  This does create duplication of compute (all tests run x2) but we are using github hosted runners so we do not pay for this cost.  This also aligns with our dgraph repo workflow setup.