### PR TITLE
Reduce memory used when backing up small database

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -51,6 +51,7 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 	stream := db.NewStream()
 	stream.LogPrefix = "DB.Backup"
 	stream.SinceTs = since
+	stream.BatchSize = db.opt.BackupBatchSize
 	return stream.Backup(w, since)
 }
 

--- a/backup_oom_test.go
+++ b/backup_oom_test.go
@@ -1,0 +1,56 @@
+package badger
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupTemp(t *testing.T) {
+	// Create a small db and create a backup. The total memory used by this should not be
+	// more than 300 mb.
+	opt := DefaultOptions("")
+	opt.BackupBatchSize = 1 << 20
+	opt.NumGoroutines = 1
+	runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+		N := 5
+		for i := 0; i < N; i++ {
+			require.NoError(t, populateEntries(db, createEntries(100000)))
+		}
+		totalMemUsed := ReadMemoryStatsAndRunTest(db, t)
+		require.LessOrEqual(t, totalMemUsed, uint64(300<<20), "Extra memory used")
+	})
+}
+
+func BackUpBadger(db *DB, t *testing.T) {
+	ti := time.Now()
+	formatted := fmt.Sprintf("%d-%02d-%02d_%02d_%02d",
+		ti.Year(), ti.Month(), ti.Day(),
+		ti.Hour(), ti.Minute())
+	err := os.MkdirAll("/tmp/timestone/", os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	f, _ := os.OpenFile("/tmp/timestone/backup_"+formatted, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	w := io.Writer(f)
+	_, err = db.Backup(w, 0)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ReadMemoryStatsAndRunTest(db *DB, t *testing.T) uint64 {
+	var m1, m2 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	BackUpBadger(db, t)
+
+	runtime.ReadMemStats(&m2)
+	return m2.TotalAlloc - m1.TotalAlloc
+}

--- a/options.go
+++ b/options.go
@@ -116,6 +116,11 @@ type Options struct {
 	// with incompatible data format.
 	ExternalMagicVersion uint16
 
+	// Backup happens in batches. We create mutiple batches over ranges on keys in badger.
+	// This is useful to change in case you want to have a lower memory footprint during
+	// badger. Default is 16 MB, reduce this if the size of the db is less than 100MB.
+	BackupBatchSize int
+
 	// Transaction start and commit timestamps are managed by end-user.
 	// This is only useful for databases built on top of Badger (like Dgraph).
 	// Not recommended for most users.
@@ -187,6 +192,8 @@ func DefaultOptions(path string) Options {
 		EncryptionKeyRotationDuration: 10 * 24 * time.Hour, // Default 10 days.
 		DetectConflicts:               true,
 		NamespaceOffset:               -1,
+
+		BackupBatchSize: 16 << 20, // Default is 16MB
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -118,7 +118,7 @@ type Options struct {
 
 	// Backup happens in batches. We create mutiple batches over ranges on keys in badger.
 	// This is useful to change in case you want to have a lower memory footprint during
-	// badger. Default is 16 MB, reduce this if the size of the db is less than 100MB.
+	// badger. Default is 16 MB, reduce this to 1MB if the size of the db is less than 100MB.
 	BackupBatchSize int
 
 	// Transaction start and commit timestamps are managed by end-user.

--- a/options.go
+++ b/options.go
@@ -118,7 +118,8 @@ type Options struct {
 
 	// Backup happens in batches. We create mutiple batches over ranges on keys in badger.
 	// This is useful to change in case you want to have a lower memory footprint during
-	// badger. Default is 16 MB, reduce this to 1MB if the size of the db is less than 100MB.
+	// badger. Default is 16 MB, reduce this to 1MB if the total memory available to badger
+	// is less than 2GB.
 	BackupBatchSize int
 
 	// Transaction start and commit timestamps are managed by end-user.

--- a/stream.go
+++ b/stream.go
@@ -80,7 +80,7 @@ type Stream struct {
 	// single goroutine, i.e. logic within Send method can expect single threaded execution.
 	Send func(buf *z.Buffer) error
 
-	// Batch size for the buffers recieved by Send
+	// Batch size for the buffers recieved by Send.
 	BatchSize int
 
 	// Read data above the sinceTs. All keys with version =< sinceTs will be ignored.

--- a/stream.go
+++ b/stream.go
@@ -80,7 +80,7 @@ type Stream struct {
 	// single goroutine, i.e. logic within Send method can expect single threaded execution.
 	Send func(buf *z.Buffer) error
 
-	// Batch size for the buffers recieved by Send.
+	// Batch size for the buffers recieved by Send. Default is 16MB.
 	BatchSize int
 
 	// Read data above the sinceTs. All keys with version =< sinceTs will be ignored.
@@ -453,6 +453,7 @@ func (db *DB) newStream() *Stream {
 		db:        db,
 		NumGo:     db.opt.NumGoroutines,
 		LogPrefix: "Badger.Stream",
+		BatchSize: 16 << 20,
 	}
 }
 


### PR DESCRIPTION
## Problem
When backing up small database, we end up using around 2GB memory. This would happen for db that are around 10MB in size. This happens because we create ranges to backup, (around 53), and for each range we allocate 16MB. To allocate 16MB is not required.  This sums up to around 2GB.

## Solution
We introduce a flag that the users can use in case that their db is failing. This flag sets how much memory to allocate for each range. If the db is small, these small allocs would mean less memory used. It would work for bigger db's too, however can be a little bit slower.

Fixes #1931