### PR TITLE
fix(Test): Fix table checksum test. Test on uncompressed.

### DIFF
--- a/table/table_test.go
+++ b/table/table_test.go
@@ -682,10 +682,15 @@ func TestTableChecksum(t *testing.T) {
 	rand.Read(rb)
 	opts := getTestTableOptions()
 	opts.ChkMode = options.OnTableAndBlockRead
+	// When verifying checksum capability, we find it simpler to disable compression
+	// since randomly initializing bytes can kill the compression storage.
+	opts.Compression = options.None
 	tbl := buildTestTable(t, "k", 10000, opts)
 	defer func() { require.NoError(t, tbl.DecrRef()) }()
-	// Write random bytes at random location.
-	start := rand.Intn(len(tbl.Data) - len(rb))
+	// Write random bytes at location guaranteed to not be in range of
+	// metadata for block. (No particular reason for the value 128,
+	// it just avoids the sensitive block size or other metadata blocks).
+	start := 128
 	n := copy(tbl.Data[start:], rb)
 	require.Equal(t, n, len(rb))
 


### PR DESCRIPTION
## Problem
Fixes DGRAPHCORE-152

Previously, when testing to verify that a bad checksum would actually cause a checksum failure, we were overlooking the fact that our method of modifying the data could also modify the compressed data or even some of the metadata related to our block data.

The symptomatic results:

--- FAIL: TestTableChecksum (0.11s)
2640    table_test.go:698: 
2641        	Error Trace:	table_test.go:698
2642        	            				table_test.go:692
2643        	Error:      	Received unexpected error:
2644        	            	failed to initialize table error: failed to initialize biggest for table /tmp/2687635575.sst error: failed to decode compressed data in file: /tmp/2687635575.sst at offset: 51750, len: 149 error: failed to decompress err: unexpected EOF
2645        	Test:       	TestTableChecksum

or some similar error 

(There were earlier errors about failing to panic, but these were always generated before the secondary logged error was added).

## Solution
Now, when we want to test that our checksum process is valid, we check with uncompressed data rather than with compressed data. In addition, we still write random bytes, but we no longer place it randomly. Instead, we place it in a location that will avoid the metadata locations of the data blocks.