### PR TITLE
Sync active memtable and value log on Db.Sync (#1847)

### DIFF
--- a/db.go
+++ b/db.go
@@ -676,7 +676,43 @@ const (
 // Sync syncs database content to disk. This function provides
 // more control to user to sync data whenever required.
 func (db *DB) Sync() error {
-	return db.vlog.sync()
+	/**
+	Make an attempt to sync both the logs, the active memtable's WAL and the vLog (1847).
+	Cases:
+	- All_ok			:: If both the logs sync successfully.
+
+	- Entry_Lost		:: If an entry with a value pointer was present in the active memtable's WAL,
+						:: and the WAL was synced but there was an error in syncing the vLog.
+						:: The entry will be considered lost and this case will need to be handled during recovery.
+
+	- Entries_Lost		:: If there were errors in syncing both the logs, multiple entries would be lost.
+
+	- Entries_Lost      :: If the active memtable's WAL is not synced but the vLog is synced, it will
+						:: result in entries being lost because recovery of the active memtable is done from its WAL.
+						:: Check `UpdateSkipList` in memtable.go.
+
+	- Nothing_lost		:: If an entry with its value was present in the active memtable's WAL, and the WAL was synced,
+						:: but there was an error in syncing the vLog.
+						:: Nothing is lost for this very specific entry because the entry is completely present in the memtable's WAL.
+
+	- Partially_lost    :: If entries were written partially in either of the logs, the logs will be truncated during recovery.
+						:: As a result of truncation, some entries might be lost. Assume that 4KB of data is to be synced and
+					    :: invoking `Sync` results only in syncing 3KB of data and then the machine shuts down or the disk failure happens,
+	                    :: this will result in partial writes. [[This case needs verification]]
+	*/
+
+	var err error
+
+	memtableSyncError := db.mt.SyncWAL()
+	if memtableSyncError != nil {
+		err = errors.Wrap(memtableSyncError, "sync failed for the active memtable WAL")
+	}
+
+	vLogSyncError := db.vlog.sync()
+	if vLogSyncError != nil {
+		err = errors.Wrap(vLogSyncError, "sync failed for the vLog")
+	}
+	return err
 }
 
 // getMemtables returns the current memtables and get references.

--- a/y/error.go
+++ b/y/error.go
@@ -87,13 +87,13 @@ func Wrapf(err error, format string, args ...interface{}) error {
 
 func CombineErrors(one, other error) error {
 	if one != nil && other != nil {
-		return fmt.Errorf("%w; %w", one, other)
+		return fmt.Errorf("%v; %v", one, other)
 	}
 	if one != nil && other == nil {
-		return fmt.Errorf("%w", one)
+		return fmt.Errorf("%v", one)
 	}
 	if one == nil && other != nil {
-		return fmt.Errorf("%w", other)
+		return fmt.Errorf("%v", other)
 	}
 	return nil
 }

--- a/y/error.go
+++ b/y/error.go
@@ -84,3 +84,16 @@ func Wrapf(err error, format string, args ...interface{}) error {
 	}
 	return errors.Wrapf(err, format, args...)
 }
+
+func CombineErrors(one, other error) error {
+	if one != nil && other != nil {
+		return fmt.Errorf("%w; %w", one, other)
+	}
+	if one != nil && other == nil {
+		return fmt.Errorf("%w", one)
+	}
+	if one == nil && other != nil {
+		return fmt.Errorf("%w", other)
+	}
+	return nil
+}

--- a/y/error_test.go
+++ b/y/error_test.go
@@ -2,8 +2,9 @@ package y
 
 import (
 	"errors"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCombineWithBothErrorsPresent(t *testing.T) {

--- a/y/error_test.go
+++ b/y/error_test.go
@@ -1,0 +1,27 @@
+package y
+
+import (
+	"errors"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCombineWithBothErrorsPresent(t *testing.T) {
+	combinedError := CombineErrors(errors.New("one"), errors.New("two"))
+	require.Equal(t, "one; two", combinedError.Error())
+}
+
+func TestCombineErrorsWithOneErrorPresent(t *testing.T) {
+	combinedError := CombineErrors(errors.New("one"), nil)
+	require.Equal(t, "one", combinedError.Error())
+}
+
+func TestCombineErrorsWithOtherErrorPresent(t *testing.T) {
+	combinedError := CombineErrors(nil, errors.New("other"))
+	require.Equal(t, "other", combinedError.Error())
+}
+
+func TestCombineErrorsWithBothErrorsAsNil(t *testing.T) {
+	combinedError := CombineErrors(nil, nil)
+	require.NoError(t, combinedError)
+}


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/badger/issues/1847

Currently, `DB.Sync()` only syncs the value log but not the WAL of the active memtable, however recovery happens from the WAL of the active memtable as a part of the `DB.Open()` method.

This change attempts to sync both the logs, however there can be an issue in syncing one of the logs. This change lists all of the possible cases that can arise during the sync operations. Some of these issues will be taken separately. For example, 
the issue https://github.com/dgraph-io/badger/issues/1954 can arise and shall be handled separately.

This change adds a few tests to ensure that the Sync behavior is not broken.  This change also adds a learning test `(db2_test.go -> TestAssertValueLogIsNotWrittenToOnStartup)` to ensure that value log is only read from (and not written to) during startup. This learning shall be used in the next issue (the one described above (*))