### PR TITLE
fix(Test): BenchmarkDbGrowth

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -466,6 +466,8 @@ func BenchmarkDbGrowth(b *testing.B) {
 	opts.NumVersionsToKeep = 1
 	opts.NumLevelZeroTables = 1
 	opts.NumLevelZeroTablesStall = 2
+	opts.ValueThreshold = 1024
+	opts.MemTableSize = 1 << 20
 	db, err := Open(opts)
 	require.NoError(b, err)
 	for numWrites := 0; numWrites < maxWrites; numWrites++ {


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

It seems some parameter settings have been changed in the past. As a result, some tests (at least one) lose the ability to test what they want to test.
For `BenchmarkDbGrowth`, current default value of `ValueThreshold` makes no vlog will be created and current default value of `MemTableSize` makes no memtable will be flushed which means no compaction and thus no vlog gc will be performed.

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
Setting  `ValueThreshold` be 1024 and `MemTableSize` be 1MB in this case seems to be fine.