### PR TITLE
chore(all): fix staticcheck errors

### DIFF
--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -148,7 +148,7 @@ func min(a, b uint64) uint64 {
 	return b
 }
 
-var errAbandoned = errors.New("Transaction abandonded due to insufficient balance")
+var errAbandoned = errors.New("transaction abandonded due to insufficient balance")
 
 func moveMoney(db *badger.DB, from, to int) error {
 	return db.Update(func(txn *badger.Txn) error {
@@ -597,5 +597,5 @@ func runTest(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	log.Println("Test FAILED")
-	return fmt.Errorf("Test FAILED")
+	return fmt.Errorf("test FAILED")
 }

--- a/badger/cmd/restore.go
+++ b/badger/cmd/restore.go
@@ -59,7 +59,7 @@ func doRestore(cmd *cobra.Command, args []string) error {
 	// Check if the DB already exists
 	manifestFile := filepath.Join(sstDir, badger.ManifestFilename)
 	if _, err := os.Stat(manifestFile); err == nil { // No error. File already exists.
-		return errors.New("Cannot restore to an already existing database")
+		return errors.New("cannot restore to an already existing database")
 	} else if os.IsNotExist(err) {
 		// pass
 	} else { // Return an error if anything other than the error above

--- a/manifest.go
+++ b/manifest.go
@@ -380,13 +380,13 @@ func ReplayManifestFile(fp *os.File, extMagic uint16) (Manifest, int64, error) {
 			//nolint:lll
 			fmt.Errorf("manifest has unsupported version: %d (we support %d).\n"+
 				"Please see https://dgraph.io/docs/badger/faq/#i-see-manifest-has-unsupported-version-x-we-support-y-error"+
-				" on how to fix this.",
+				" on how to fix this",
 				version, badgerMagicVersion)
 	}
 	if extVersion != extMagic {
 		return Manifest{}, 0,
-			fmt.Errorf("Cannot open DB because the external magic number doesn't match. "+
-				"Expected: %d, version present in manifest: %d\n", extMagic, extVersion)
+			fmt.Errorf("cannot open DB because the external magic number doesn't match. "+
+				"Expected: %d, version present in manifest: %d", extMagic, extVersion)
 	}
 
 	stat, err := fp.Stat()

--- a/memtable.go
+++ b/memtable.go
@@ -278,7 +278,7 @@ type logFile struct {
 
 func (lf *logFile) Truncate(end int64) error {
 	if fi, err := lf.Fd.Stat(); err != nil {
-		return fmt.Errorf("while file.stat on file: %s, error: %v\n", lf.Fd.Name(), err)
+		return fmt.Errorf("while file.stat on file: %s, error: %v", lf.Fd.Name(), err)
 	} else if fi.Size() == end {
 		return nil
 	}
@@ -415,7 +415,7 @@ func (lf *logFile) read(p valuePointer) (buf []byte, err error) {
 func (lf *logFile) generateIV(offset uint32) []byte {
 	iv := make([]byte, aes.BlockSize)
 	// baseIV is of 12 bytes.
-	y.AssertTrue(12 == copy(iv[:12], lf.baseIV))
+	y.AssertTrue(copy(iv[:12], lf.baseIV) == 12)
 	// remaining 4 bytes is obtained from offset.
 	binary.BigEndian.PutUint32(iv[12:], offset)
 	return iv

--- a/stream_test.go
+++ b/stream_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/badger/v4/pb"
-	bpb "github.com/dgraph-io/badger/v4/pb"
 	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/z"
 )
@@ -50,7 +49,7 @@ func value(k int) []byte {
 }
 
 type collector struct {
-	kv []*bpb.KV
+	kv []*pb.KV
 }
 
 func (c *collector) Send(buf *z.Buffer) error {
@@ -62,7 +61,7 @@ func (c *collector) Send(buf *z.Buffer) error {
 		if kv.StreamDone == true {
 			return nil
 		}
-		cp := proto.Clone(kv).(*bpb.KV)
+		cp := proto.Clone(kv).(*pb.KV)
 		c.kv = append(c.kv, cp)
 	}
 	return err
@@ -193,7 +192,7 @@ func TestStreamWithThreadId(t *testing.T) {
 	stream := db.NewStreamAt(math.MaxUint64)
 	stream.LogPrefix = "Testing"
 	stream.KeyToList = func(key []byte, itr *Iterator) (
-		*bpb.KVList, error) {
+		*pb.KVList, error) {
 		require.Less(t, itr.ThreadId, stream.NumGo)
 		return stream.ToList(key, itr)
 	}

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -108,7 +108,7 @@ func (sw *StreamWriter) PrepareIncremental() error {
 	defer decr()
 	for _, m := range mts {
 		if !m.sl.Empty() {
-			return fmt.Errorf("Unable to do incremental writes because MemTable has data")
+			return fmt.Errorf("unable to do incremental writes because MemTable has data")
 		}
 	}
 

--- a/stream_writer_test.go
+++ b/stream_writer_test.go
@@ -685,7 +685,7 @@ func TestStreamWriterIncremental(t *testing.T) {
 
 			sw := db.NewStreamWriter()
 			defer sw.Cancel()
-			require.EqualError(t, sw.PrepareIncremental(), "Unable to do incremental writes because MemTable has data")
+			require.EqualError(t, sw.PrepareIncremental(), "unable to do incremental writes because MemTable has data")
 
 			txn := db.NewTransaction(false)
 			defer txn.Discard()

--- a/table/merge_iterator.go
+++ b/table/merge_iterator.go
@@ -115,9 +115,9 @@ func (mi *MergeIterator) fix() {
 	case cmp < 0: // Small is less than bigger().
 		if mi.reverse {
 			mi.swapSmall()
-		} else { //nolint:staticcheck
-			// we don't need to do anything. Small already points to the smallest.
 		}
+		// if mi.reverse is false, we don't need to do anything.
+		// Small already points to the smallest.
 		return
 	default: // bigger() is less than small.
 		if mi.reverse {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -67,7 +67,7 @@ func parseIgnoreBytes(ig string) ([]bool, error) {
 	for _, each := range strings.Split(strings.TrimSpace(ig), ",") {
 		r := strings.Split(strings.TrimSpace(each), "-")
 		if len(r) == 0 || len(r) > 2 {
-			return out, fmt.Errorf("Invalid range: %s", each)
+			return out, fmt.Errorf("invalid range: %s", each)
 		}
 		start, end := -1, -1 //nolint:ineffassign
 		if len(r) == 2 {
@@ -86,7 +86,7 @@ func parseIgnoreBytes(ig string) ([]bool, error) {
 			start = idx
 		}
 		if start == -1 {
-			return out, fmt.Errorf("Invalid range: %s", each)
+			return out, fmt.Errorf("invalid range: %s", each)
 		}
 		for start >= len(out) {
 			out = append(out, false)

--- a/value.go
+++ b/value.go
@@ -249,58 +249,59 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 			}
 			wb = append(wb, ne)
 			size += es
-		} else { //nolint:staticcheck
-			// It might be possible that the entry read from LSM Tree points to
-			// an older vlog file.  This can happen in the following situation.
-			// Assume DB is opened with
-			// numberOfVersionsToKeep=1
-			//
-			// Now, if we have ONLY one key in the system "FOO" which has been
-			// updated 3 times and the same key has been garbage collected 3
-			// times, we'll have 3 versions of the movekey
-			// for the same key "FOO".
-			//
-			// NOTE: moveKeyi is the gc'ed version of the original key with version i
-			// We're calling the gc'ed keys as moveKey to simplify the
-			// explanantion. We used to add move keys but we no longer do that.
-			//
-			// Assume we have 3 move keys in L0.
-			// - moveKey1 (points to vlog file 10),
-			// - moveKey2 (points to vlog file 14) and
-			// - moveKey3 (points to vlog file 15).
-			//
-			// Also, assume there is another move key "moveKey1" (points to
-			// vlog file 6) (this is also a move Key for key "FOO" ) on upper
-			// levels (let's say 3). The move key "moveKey1" on level 0 was
-			// inserted because vlog file 6 was GCed.
-			//
-			// Here's what the arrangement looks like
-			// L0 => (moveKey1 => vlog10), (moveKey2 => vlog14), (moveKey3 => vlog15)
-			// L1 => ....
-			// L2 => ....
-			// L3 => (moveKey1 => vlog6)
-			//
-			// When L0 compaction runs, it keeps only moveKey3 because the number of versions
-			// to keep is set to 1. (we've dropped moveKey1's latest version)
-			//
-			// The new arrangement of keys is
-			// L0 => ....
-			// L1 => (moveKey3 => vlog15)
-			// L2 => ....
-			// L3 => (moveKey1 => vlog6)
-			//
-			// Now if we try to GC vlog file 10, the entry read from vlog file
-			// will point to vlog10 but the entry read from LSM Tree will point
-			// to vlog6. The move key read from LSM tree will point to vlog6
-			// because we've asked for version 1 of the move key.
-			//
-			// This might seem like an issue but it's not really an issue
-			// because the user has set the number of versions to keep to 1 and
-			// the latest version of moveKey points to the correct vlog file
-			// and offset. The stale move key on L3 will be eventually dropped
-			// by compaction because there is a newer versions in the upper
-			// levels.
+			return nil
 		}
+
+		// Else, it might be possible that the entry read from LSM Tree points to
+		// an older vlog file.  This can happen in the following situation.
+		// Assume DB is opened with
+		// numberOfVersionsToKeep=1
+		//
+		// Now, if we have ONLY one key in the system "FOO" which has been
+		// updated 3 times and the same key has been garbage collected 3
+		// times, we'll have 3 versions of the movekey
+		// for the same key "FOO".
+		//
+		// NOTE: moveKeyi is the gc'ed version of the original key with version i
+		// We're calling the gc'ed keys as moveKey to simplify the
+		// explanantion. We used to add move keys but we no longer do that.
+		//
+		// Assume we have 3 move keys in L0.
+		// - moveKey1 (points to vlog file 10),
+		// - moveKey2 (points to vlog file 14) and
+		// - moveKey3 (points to vlog file 15).
+		//
+		// Also, assume there is another move key "moveKey1" (points to
+		// vlog file 6) (this is also a move Key for key "FOO" ) on upper
+		// levels (let's say 3). The move key "moveKey1" on level 0 was
+		// inserted because vlog file 6 was GCed.
+		//
+		// Here's what the arrangement looks like
+		// L0 => (moveKey1 => vlog10), (moveKey2 => vlog14), (moveKey3 => vlog15)
+		// L1 => ....
+		// L2 => ....
+		// L3 => (moveKey1 => vlog6)
+		//
+		// When L0 compaction runs, it keeps only moveKey3 because the number of versions
+		// to keep is set to 1. (we've dropped moveKey1's latest version)
+		//
+		// The new arrangement of keys is
+		// L0 => ....
+		// L1 => (moveKey3 => vlog15)
+		// L2 => ....
+		// L3 => (moveKey1 => vlog6)
+		//
+		// Now if we try to GC vlog file 10, the entry read from vlog file
+		// will point to vlog10 but the entry read from LSM Tree will point
+		// to vlog6. The move key read from LSM tree will point to vlog6
+		// because we've asked for version 1 of the move key.
+		//
+		// This might seem like an issue but it's not really an issue
+		// because the user has set the number of versions to keep to 1 and
+		// the latest version of moveKey points to the correct vlog file
+		// and offset. The stale move key on L3 will be eventually dropped
+		// by compaction because there is a newer versions in the upper
+		// levels.
 		return nil
 	}
 


### PR DESCRIPTION
## Problem

In my VSCode configuration, I have gopls setup with

```json
"gopls": {
    "staticcheck": true,
```

and therefore staticcheck is enabled even without golangci-lint, and also ignores `//nolint:staticcheck` commands. It might also be a different staticcheck since it complained about issues not `//nolint;staticcheck`-ed in the code.

Anyway, this spotted a few staticcheck related errors which I fixed so they won't show if someone has the same config as I do.

## Solution

- do not end error strings with punctuation or new line
- do not start error strings with uppercase letters
- do not use yoda conditions
- do not import package twice in the same file
- Remove empty branches and mention `Else` at the start of a comment