### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -310,21 +310,21 @@ func tableInfo(dir, valueDir string, db *badger.DB) {
 	fmt.Println()
 }
 
-func readDir(dir string) (fileInfos []fs.FileInfo, err error) {
+func readDir(dir string) ([]fs.FileInfo, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return
+		return nil, err
 	}
-	fileInfos = make([]fs.FileInfo, 0, len(entries))
+	infos := make([]fs.FileInfo, 0, len(entries))
 	for _, entry := range entries {
 		var info fs.FileInfo
 		info, err = entry.Info()
 		if err != nil {
-			return
+			return nil, err
 		}
-		fileInfos = append(fileInfos, info)
+		infos = append(infos, info)
 	}
-	return
+	return infos, err
 }
 
 func printInfo(dir, valueDir string) error {


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
remove refs to deprecated io/ioutil