### PR TITLE
fix(Logging): Fix invalid direct access to logger

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -168,7 +168,7 @@ func (item *Item) yieldItemValue() ([]byte, func(), error) {
 	db := item.txn.db
 	result, cb, err := db.vlog.Read(vp, item.slice)
 	if err != nil {
-		db.opt.Logger.Errorf("Unable to read: Key: %v, Version : %v, meta: %v, userMeta: %v"+
+		db.opt.Errorf("Unable to read: Key: %v, Version : %v, meta: %v, userMeta: %v"+
 			" Error: %v", key, item.version, item.meta, item.userMeta, err)
 		var txn *Txn
 		if db.opt.managedTxns {
@@ -191,7 +191,7 @@ func (item *Item) yieldItemValue() ([]byte, func(), error) {
 			if item.meta&bitValuePointer > 0 {
 				vp.Decode(item.vptr)
 			}
-			db.opt.Logger.Errorf("Key: %v, Version : %v, meta: %v, userMeta: %v valuePointer: %+v",
+			db.opt.Errorf("Key: %v, Version : %v, meta: %v, userMeta: %v valuePointer: %+v",
 				item.Key(), item.version, item.meta, item.userMeta, vp)
 		}
 	}

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -243,7 +243,7 @@ func (sw *StreamWriter) Write(buf *z.Buffer) error {
 	for streamId := range closedStreams {
 		writer, ok := sw.writers[streamId]
 		if !ok {
-			sw.db.opt.Logger.Warningf("Trying to close stream: %d, but no sorted "+
+			sw.db.opt.Warningf("Trying to close stream: %d, but no sorted "+
 				"writer found for it", streamId)
 			continue
 		}

--- a/value.go
+++ b/value.go
@@ -969,7 +969,7 @@ func (vlog *valueLog) Read(vp valuePointer, _ *y.Slice) ([]byte, func(), error) 
 		}
 	}
 	if uint32(len(kv)) < h.klen+h.vlen {
-		vlog.db.opt.Logger.Errorf("Invalid read: vp: %+v", vp)
+		vlog.db.opt.Errorf("Invalid read: vp: %+v", vp)
 		return nil, nil, errors.Errorf("Invalid read: Len: %d read at:[%d:%d]",
 			len(kv), h.klen, h.klen+h.vlen)
 	}


### PR DESCRIPTION
## Problem
Because the logger provided in the Options can be nil, directly interacting with it can cause panics. 

## Solution
This change fixes this issue by using the various logging methods provided by Options that wrap the Logger field.