### PR TITLE
fix(table): Prevent unnecessary os.Exit

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -222,7 +222,7 @@ func (b *block) incrRef() bool {
 	}
 }
 func (b *block) decrRef() {
-	if b == nil {
+	if b == nil || b.ref.Load() == 0 {
 		return
 	}
 
@@ -239,7 +239,6 @@ func (b *block) decrRef() {
 		NumBlocks.Add(-1)
 		// blockPool.Put(&b.data)
 	}
-	y.AssertTrue(b.ref.Load() >= 0)
 }
 func (b *block) size() int64 {
 	return int64(3*intSize /* Size of the offset, entriesIndexStart and chkLen */ +


### PR DESCRIPTION
## Problem
We are using Badger as the datastore for DefraDB and while doing integration test and running our change detector, we run tests from both our develop branch and PR branch. The develop tests each use a unique set of Badger storage files but those files are then reused for the same test in the PR branch. This means that we close the Badger instance in after the tests in develop and run it again in the PR branch. On that second close, we often get an asset Failure on close because the block.decRef method tries to decrease the reference even though it's already zero. https://github.com/sourcenetwork/defradb/actions/runs/5628956063/job/15253408371

Fixes: #1983 

## Solution
What seems to solve the issue is to stop `block.decrRef` from bringing `block.ref` bellow zero. This may not be preferred solution of the Badger team as it might have broader implications but I thought we could use this as a starting point.