### PR TITLE
perf: upgrade compress package test and benchmark. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,8 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
-	github.com/golang/snappy v0.0.3
 	github.com/google/flatbuffers v1.12.1
-	github.com/klauspost/compress v1.12.3
+	github.com/klauspost/compress v1.15.15
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
-github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/flatbuffers v1.12.1 h1:MVlul7pQNoDzWRLTw5imwYsl+usrS1TXG2H4jg6ImGw=
 github.com/google/flatbuffers v1.12.1/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -37,8 +35,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.12.3 h1:G5AfA94pHPysR56qqrkO2pxEexdDzrpFJ6yt/VqWxVU=
-github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
+github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/table/builder.go
+++ b/table/builder.go
@@ -25,8 +25,8 @@ import (
 	"unsafe"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/snappy"
 	fbs "github.com/google/flatbuffers/go"
+	"github.com/klauspost/compress/s2"
 	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/badger/v4/fb"
@@ -159,7 +159,7 @@ func NewTableBuilder(opts Options) *Builder {
 func maxEncodedLen(ctype options.CompressionType, sz int) int {
 	switch ctype {
 	case options.Snappy:
-		return snappy.MaxEncodedLen(sz)
+		return s2.MaxEncodedLen(sz)
 	case options.ZSTD:
 		return y.ZSTDCompressBound(sz)
 	}
@@ -523,9 +523,9 @@ func (b *Builder) compressData(data []byte) ([]byte, error) {
 	case options.None:
 		return data, nil
 	case options.Snappy:
-		sz := snappy.MaxEncodedLen(len(data))
+		sz := s2.MaxEncodedLen(len(data))
 		dst := b.alloc.Allocate(sz)
-		return snappy.Encode(dst, data), nil
+		return s2.EncodeSnappy(dst, data), nil
 	case options.ZSTD:
 		sz := y.ZSTDCompressBound(len(data))
 		dst := b.alloc.Allocate(sz)

--- a/table/builder_test.go
+++ b/table/builder_test.go
@@ -178,12 +178,15 @@ func BenchmarkBuilder(b *testing.B) {
 		opt.BlockSize = 4 * 1024
 		opt.BloomFalsePositive = 0.01
 		opt.TableSize = 5 << 20
+
 		b.ResetTimer()
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			builder := NewTableBuilder(*opt)
 			for j := 0; j < keysCount; j++ {
 				builder.Add(keyList[j], vs, 0)
 			}
+
 			_ = builder.Finish()
 			builder.Close()
 		}
@@ -206,6 +209,11 @@ func BenchmarkBuilder(b *testing.B) {
 		key := make([]byte, 32)
 		rand.Read(key)
 		opt.DataKey = &pb.DataKey{Data: key}
+		bench(b, &opt)
+	})
+	b.Run("snappy compression", func(b *testing.B) {
+		var opt Options
+		opt.Compression = options.Snappy
 		bench(b, &opt)
 	})
 	b.Run("zstd compression", func(b *testing.B) {

--- a/table/table.go
+++ b/table/table.go
@@ -32,7 +32,8 @@ import (
 	"unsafe"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/snappy"
+	"github.com/klauspost/compress/snappy"
+	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/badger/v4/fb"
@@ -818,6 +819,11 @@ func (t *Table) decompress(b *block) error {
 		}
 	case options.ZSTD:
 		sz := int(float64(t.opt.BlockSize) * 1.2)
+		// Get frame content size from header.
+		var hdr zstd.Header
+		if err := hdr.Decode(b.data); err == nil && hdr.HasFCS && hdr.FrameContentSize < uint64(t.opt.BlockSize*2) {
+			sz = int(hdr.FrameContentSize)
+		}
 		dst = z.Calloc(sz, "Table.Decompress")
 		b.data, err = y.ZSTDDecompress(dst, b.data)
 		if err != nil {

--- a/value_test.go
+++ b/value_test.go
@@ -977,7 +977,7 @@ func BenchmarkReadWrite(b *testing.B) {
 				opts.ValueThreshold = 0
 				db, err := Open(opts)
 				y.Check(err)
-
+				defer db.Close()
 				vl := &db.vlog
 				b.ResetTimer()
 


### PR DESCRIPTION
Rebased #1880 to the current main. Benchmarking in progress. 

`benchstat` comparison of all benchmarks with and without the upgraded compress package.:
```
goos: linux
goarch: amd64
pkg: github.com/dgraph-io/badger/v4
cpu: AMD Ryzen 7 6800H with Radeon Graphics
                                      │ without_s2.txt  │               with_s2.txt                │
                                      │     sec/op      │     sec/op       vs base                 │
DbGrowth-16                               3.486 ±   ∞ ¹     3.829 ±   ∞ ¹        ~ (p=1.000 n=1) ²
IteratePrefixSingleKey/Key_lookups-16    59.02µ ±  3%      58.56µ ±  2%          ~ (p=0.240 n=6)
ReadWrite/0.1,0064-16                    1.545µ ±  6%      1.477µ ± 17%          ~ (p=0.394 n=6)
ReadWrite/0.2,0064-16                    1.617µ ± 11%      1.471µ ±  6%          ~ (p=0.065 n=6)
ReadWrite/0.5,0064-16                    1.433µ ±  5%      1.422µ ±  3%          ~ (p=0.394 n=6)
ReadWrite/1.0,0064-16                    1.255µ ± 21%      1.276µ ±  7%          ~ (p=0.818 n=6)
ReadWrite/0.1,0128-16                    1.732µ ± 12%      1.684µ ±  4%          ~ (p=0.394 n=6)
ReadWrite/0.2,0128-16                    1.657µ ± 18%      1.637µ ±  5%          ~ (p=0.509 n=6)
ReadWrite/0.5,0128-16                    1.544µ ±  6%      1.595µ ±  2%          ~ (p=0.180 n=6)
ReadWrite/1.0,0128-16                    1.471µ ±  9%      1.580µ ± 22%     +7.41% (p=0.026 n=6)
ReadWrite/0.1,0256-16                    1.861µ ±  4%      1.897µ ± 12%     +1.96% (p=0.009 n=6)
ReadWrite/0.2,0256-16                    1.884µ ±  9%      2.038µ ±  9%          ~ (p=0.132 n=6)
ReadWrite/0.5,0256-16                    1.989µ ± 16%      1.944µ ± 18%          ~ (p=0.818 n=6)
ReadWrite/1.0,0256-16                    1.847µ ±  6%      2.040µ ± 23%    +10.45% (p=0.002 n=6)
ReadWrite/0.1,0512-16                    2.292µ ±  5%      2.483µ ± 13%          ~ (p=0.132 n=6)
ReadWrite/0.2,0512-16                    2.272µ ±  5%      2.500µ ± 20%    +10.06% (p=0.009 n=6)
ReadWrite/0.5,0512-16                    2.427µ ±  8%      2.787µ ± 14%    +14.81% (p=0.041 n=6)
ReadWrite/1.0,0512-16                    2.711µ ±  9%      2.914µ ± 16%     +7.51% (p=0.026 n=6)
ReadWrite/0.1,1024-16                    3.144µ ±  3%      3.618µ ±  8%    +15.09% (p=0.002 n=6)
ReadWrite/0.2,1024-16                    3.302µ ±  2%      3.984µ ±  9%    +20.67% (p=0.002 n=6)
ReadWrite/0.5,1024-16                    3.659µ ±  4%      4.482µ ±  5%    +22.50% (p=0.002 n=6)
ReadWrite/1.0,1024-16                    4.058µ ±  2%      5.020µ ± 10%    +23.72% (p=0.002 n=6)
ReadWrite/0.1,2048-16                    5.361µ ± 51%      5.913µ ± 20%          ~ (p=0.180 n=6)
ReadWrite/0.2,2048-16                    5.433µ ±  8%      6.210µ ± 17%    +14.28% (p=0.041 n=6)
ReadWrite/0.5,2048-16                    5.786µ ±  4%      7.123µ ± 17%    +23.10% (p=0.002 n=6)
ReadWrite/1.0,2048-16                    7.514µ ± 15%      8.859µ ± 14%    +17.91% (p=0.009 n=6)
ReadWrite/0.1,4096-16                    8.634µ ± 48%      9.986µ ± 15%          ~ (p=0.065 n=6)
ReadWrite/0.2,4096-16                    9.165µ ± 10%     10.957µ ±  9%    +19.55% (p=0.009 n=6)
ReadWrite/0.5,4096-16                    11.59µ ± 10%      12.36µ ± 10%          ~ (p=0.132 n=6)
ReadWrite/1.0,4096-16                    13.20µ ±  7%      16.00µ ± 12%    +21.18% (p=0.004 n=6)
ReadWrite/0.1,8192-16                    15.19µ ±  4%      16.53µ ± 17%     +8.83% (p=0.002 n=6)
ReadWrite/0.2,8192-16                    17.01µ ± 29%      20.09µ ± 15%          ~ (p=0.065 n=6)
ReadWrite/0.5,8192-16                    20.85µ ±  9%      23.59µ ± 12%    +13.13% (p=0.041 n=6)
ReadWrite/1.0,8192-16                    30.35µ ± 11%      31.33µ ± 18%          ~ (p=0.937 n=6)
ReadWrite/0.1,16384-16                   35.34µ ±  8%      33.31µ ± 13%          ~ (p=0.180 n=6)
ReadWrite/0.2,16384-16                   40.23µ ±  6%      36.56µ ± 16%          ~ (p=0.180 n=6)
ReadWrite/0.5,16384-16                   52.58µ ±  7%      42.01µ ±  6%    -20.11% (p=0.002 n=6)
ReadWrite/1.0,16384-16                  176.05µ ± 59%      56.74µ ± 11%    -67.77% (p=0.002 n=6)
geomean                                  7.909µ            8.207µ           +3.76%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

pkg: github.com/dgraph-io/badger/v4/skl
                    │ without_s2.txt │            with_s2.txt             │
                    │     sec/op     │    sec/op     vs base              │
ReadWrite/frac_0-16      310.4n ± 2%   306.6n ±  3%       ~ (p=0.132 n=6)
ReadWrite/frac_1-16      289.9n ± 4%   287.9n ±  8%       ~ (p=0.509 n=6)
ReadWrite/frac_2-16      273.0n ± 3%   273.1n ±  2%       ~ (p=0.818 n=6)
ReadWrite/frac_3-16      256.1n ± 1%   257.8n ±  1%       ~ (p=0.288 n=6)
ReadWrite/frac_4-16      239.8n ± 2%   242.2n ± 12%       ~ (p=0.329 n=6)
ReadWrite/frac_5-16      218.7n ± 4%   232.5n ±  5%  +6.33% (p=0.045 n=6)
ReadWrite/frac_6-16      200.7n ± 1%   220.3n ±  9%  +9.77% (p=0.032 n=6)
ReadWrite/frac_7-16      176.5n ± 3%   184.6n ±  8%       ~ (p=0.310 n=6)
ReadWrite/frac_8-16      154.6n ± 5%   154.8n ±  8%       ~ (p=0.623 n=6)
ReadWrite/frac_9-16      120.1n ± 5%   117.5n ±  8%       ~ (p=0.589 n=6)
geomean                  215.6n        219.4n        +1.78%

pkg: github.com/dgraph-io/badger/v4/table
                                     │ without_s2.txt │             with_s2.txt             │
                                     │     sec/op     │    sec/op     vs base               │
Builder/no_compression-16                136.2m ±  6%   137.7m ±  5%        ~ (p=0.699 n=6)
Builder/encryption-16                    183.9m ±  9%   180.9m ±  4%        ~ (p=0.394 n=6)
Builder/zstd_compression/level_1-16      173.2m ±  2%   172.0m ±  3%        ~ (p=0.699 n=6)
Builder/zstd_compression/level_3-16      172.1m ±  5%   171.4m ±  4%        ~ (p=0.699 n=6)
Builder/zstd_compression/level_15-16     171.6m ±  2%   170.4m ±  3%        ~ (p=0.818 n=6)
Read-16                                  519.8m ± 11%   403.1m ± 24%  -22.45% (p=0.002 n=6)
ReadAndBuild-16                           1.474 ±  4%    1.353 ±  5%   -8.21% (p=0.002 n=6)
ReadMerged-16                            851.5m ±  3%   721.2m ±  6%  -15.31% (p=0.002 n=6)
Checksum/CRC_1024-16                     66.03n ±  5%   64.64n ±  4%        ~ (p=0.310 n=6)
Checksum/xxHash64_1024-16                64.70n ±  2%   64.23n ±  7%        ~ (p=0.310 n=6)
Checksum/SHA256_1024-16                  513.0n ±  1%   522.9n ±  1%   +1.94% (p=0.004 n=6)
Checksum/CRC_2048-16                     121.0n ±  2%   123.2n ±  2%   +1.73% (p=0.045 n=6)
Checksum/xxHash64_2048-16                123.6n ±  2%   124.7n ±  1%        ~ (p=0.147 n=6)
Checksum/SHA256_2048-16                  960.4n ±  1%   970.2n ±  2%   +1.03% (p=0.015 n=6)
Checksum/CRC_4096-16                     241.5n ±  2%   240.3n ±  4%        ~ (p=0.900 n=6)
Checksum/xxHash64_4096-16                244.5n ±  2%   251.9n ±  2%   +3.07% (p=0.004 n=6)
Checksum/SHA256_4096-16                  1.864µ ±  2%   1.884µ ±  1%        ~ (p=0.310 n=6)
Checksum/CRC_8192-16                     477.5n ±  1%   496.3n ±  4%   +3.95% (p=0.026 n=6)
Checksum/xxHash64_8192-16                475.7n ±  2%   486.3n ±  2%   +2.25% (p=0.015 n=6)
Checksum/SHA256_8192-16                  3.674µ ±  1%   3.700µ ±  1%        ~ (p=0.065 n=6)
Checksum/CRC_16384-16                    943.1n ±  3%   965.2n ±  3%        ~ (p=0.093 n=6)
Checksum/xxHash64_16384-16               946.1n ±  2%   954.3n ±  1%        ~ (p=0.093 n=6)
Checksum/SHA256_16384-16                 7.260µ ±  1%   7.351µ ±  1%        ~ (p=0.065 n=6)
Checksum/CRC_32768-16                    1.878µ ±  2%   1.877µ ±  3%        ~ (p=0.970 n=6)
Checksum/xxHash64_32768-16               1.870µ ±  1%   1.899µ ±  2%   +1.58% (p=0.009 n=6)
Checksum/SHA256_32768-16                 14.74µ ±  5%   14.66µ ±  1%        ~ (p=0.589 n=6)
Checksum/CRC_65536-16                    3.807µ ±  2%   3.785µ ±  2%        ~ (p=0.333 n=6)
Checksum/xxHash64_65536-16               3.943µ ±  5%   3.825µ ±  3%        ~ (p=0.240 n=6)
Checksum/SHA256_65536-16                 29.64µ ±  1%   29.03µ ±  2%        ~ (p=0.065 n=6)
Checksum/CRC_131072-16                   7.564µ ±  5%   7.612µ ±  3%        ~ (p=0.699 n=6)
Checksum/xxHash64_131072-16              7.521µ ±  3%   7.595µ ±  1%        ~ (p=0.093 n=6)
Checksum/SHA256_131072-16                58.56µ ±  4%   58.02µ ±  1%        ~ (p=0.093 n=6)
Checksum/CRC_262144-16                   15.31µ ±  3%   15.06µ ±  2%   -1.63% (p=0.030 n=6)
Checksum/xxHash64_262144-16              16.43µ ±  6%   15.16µ ±  1%   -7.77% (p=0.002 n=6)
Checksum/SHA256_262144-16                120.6µ ±  1%   116.8µ ±  1%   -3.16% (p=0.002 n=6)
Checksum/CRC_1048576-16                  62.68µ ± 13%   60.48µ ±  2%   -3.50% (p=0.004 n=6)
Checksum/xxHash64_1048576-16             61.77µ ±  1%   61.50µ ±  2%        ~ (p=0.589 n=6)
Checksum/SHA256_1048576-16               468.9µ ±  2%   471.8µ ±  1%        ~ (p=0.240 n=6)
RandomRead-16                            20.49µ ±  8%   14.98µ ±  4%  -26.90% (p=0.002 n=6)
Builder/snappy_compression-16                           157.2m ±  6%
geomean                                  32.82µ         39.69µ         -2.21%

                                     │ without_s2.txt │            with_s2.txt             │
                                     │      B/s       │     B/s       vs base              │
Builder/no_compression-16                582.4Mi ± 5%   576.3Mi ± 5%       ~ (p=0.699 n=6)
Builder/encryption-16                    431.5Mi ± 8%   438.7Mi ± 4%       ~ (p=0.394 n=6)
Builder/zstd_compression/level_1-16      458.2Mi ± 2%   461.4Mi ± 3%       ~ (p=0.699 n=6)
Builder/zstd_compression/level_3-16      461.0Mi ± 4%   463.1Mi ± 4%       ~ (p=0.699 n=6)
Builder/zstd_compression/level_15-16     462.3Mi ± 2%   465.5Mi ± 3%       ~ (p=0.818 n=6)
Builder/snappy_compression-16                           504.7Mi ± 5%
geomean                                  476.4Mi        483.0Mi       +0.49%

                                     │ with_s2.txt  │
                                     │     B/op     │
Builder/no_compression-16              217.5Mi ± 0%
Builder/encryption-16                  362.9Mi ± 0%
Builder/zstd_compression/level_1-16    295.0Mi ± 0%
Builder/zstd_compression/level_3-16    295.0Mi ± 0%
Builder/zstd_compression/level_15-16   295.0Mi ± 0%
Builder/snappy_compression-16          300.8Mi ± 0%
geomean                                291.2Mi

                                     │ with_s2.txt │
                                     │  allocs/op  │
Builder/no_compression-16              177.4k ± 0%
Builder/encryption-16                  297.3k ± 0%
Builder/zstd_compression/level_1-16    177.4k ± 0%
Builder/zstd_compression/level_3-16    177.4k ± 0%
Builder/zstd_compression/level_15-16   177.4k ± 0%
Builder/snappy_compression-16          177.4k ± 0%
geomean                                193.3k

pkg: github.com/dgraph-io/badger/v4/y
                                     │ without_s2.txt │             with_s2.txt             │
                                     │     sec/op     │    sec/op      vs base              │
Buffer/bytes-buffer-16                 1.088µ ± 1535%   1.046µ ± 678%       ~ (p=0.937 n=6)
Buffer/page-buffer/page-size-1024-16   520.5n ± 1833%   560.3n ±   6%       ~ (p=0.485 n=6)
geomean                                752.4n           765.6n         +1.75%```