### PR TITLE
ci: change cron frequency to fix ghost jobs

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main 
   schedule:
-    - cron: "0 * * * *"
+    - cron: "1 * * * *"
 jobs:
   build:
     name: trivy-tests

--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main 
   schedule:
-    - cron: "1 * * * *"
+    - cron: "1 0 * * *"
 jobs:
   build:
     name: trivy-tests

--- a/.github/workflows/ci-badger-bank-tests-nightly.yml
+++ b/.github/workflows/ci-badger-bank-tests-nightly.yml
@@ -5,7 +5,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "1 3 * * *"
 jobs:
   badger-bank:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "*/31 * * * *"
+    - cron: "1 * * * *"
 jobs:
   badger-bank:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/31 * * * *"
 jobs:
   badger-bank:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "1 * * * *"
+    - cron: "1 0 * * *"
 jobs:
   badger-bank:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/31 * * * *"
 jobs:
   badger-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "*/31 * * * *"
+    - cron: "1 * * * *"
 jobs:
   badger-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "1 * * * *"
+    - cron: "1 0 * * *"
 jobs:
   badger-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   dgraph-tests:
-    runs-on: [self-hosted, x64]
+    runs-on: ubuntu-20.04-32gb
     steps:
       - name: Checkout Dgraph repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "1 * * * *"
+    - cron: "1 0 * * *"
 jobs:
   go-lint:
     name: lint

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/31 * * * *"
 jobs:
   go-lint:
     name: lint

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 'release/v*'
   schedule:
-    - cron: "*/31 * * * *"
+    - cron: "1 * * * *"
 jobs:
   go-lint:
     name: lint


### PR DESCRIPTION
Description: We see a number of "ghost jobs".  This is resolved by changing the cron frequency to reset who receives notifications.  We reduce the frequency to once per day.