### PR TITLE
fix(Transactions): Fix resource consumption on empty write transaction

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -661,7 +661,9 @@ func (txn *Txn) Commit() error {
 	// txn.conflictKeys can be zero if conflict detection is turned off. So we
 	// should check txn.pendingWrites.
 	if len(txn.pendingWrites) == 0 {
-		return nil // Nothing to do.
+		// Discard the transaction so that the read is marked done.
+		txn.Discard()
+		return nil
 	}
 	// Precheck before discarding txn.
 	if err := txn.commitPrecheck(); err != nil {


### PR DESCRIPTION
## Problem
If a write transaction is opened without doing any updates, e.g. 
```
txn := db.NewTransaction(true)
txn.Commit()
```
the read mark is never marked done, because `txn.Discard` has not been called and neither has the commit logic because of the early return in `Commit()`:
```
if len(txn.pendingWrites) == 0 {
    return nil // Nothing to do.
}
```
This causes unbounded storage growth until the service is restarted. The watermark process in `y/watermark.go` never receives a mark for that transaction, and so never updates the `DoneUntil`. This value is used in `levels.go` for compaction to determine the `discardTS` value, and since it never updates, compaction can never occur.

## Solution
The solution here is to call `txn.Discard` in the case when there are no writes on the transaction. This marks the read as done and allows the watermark process to properly update.