### PR TITLE
fix(table cache) block cache logic for table with no compression

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -595,6 +595,11 @@ func (t *Table) block(idx int, useCache bool) (*block, error) {
 			"corrupted or the table options are incorrectly set")
 	}
 
+	if useCache && t.opt.BlockCache != nil && t.opt.Compression == options.None && !t.shouldDecrypt() {
+		// make a copy for caching later
+		blk.data = y.Copy(blk.data)
+	}
+
 	// Read checksum and store it
 	readPos -= blk.chkLen
 	blk.checksum = blk.data[readPos : readPos+blk.chkLen]


### PR DESCRIPTION
## Problem
 Fixes #2021.

The problem is in the `block()` function in table.go. `blk.data` takes a slice of the t.Data. If there is no decryption or decompression, it will hold this slice and added to the cache, which means it will always hold a reference of t.Data. That will also preventing GC of the mmap file buffer,  so long as a block of it is in cache.  

## Solution

Make a copy of the block data, when no decryption nor compression.