### PR TITLE
fix(level-handler): level handler - key with zero version can never be found

### DIFF
--- a/level_handler.go
+++ b/level_handler.go
@@ -295,7 +295,7 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 			continue
 		}
 		if y.SameKey(key, it.Key()) {
-			if version := y.ParseTs(it.Key()); maxVs.Version < version {
+			if version := y.ParseTs(it.Key()); maxVs.Version < version || maxVs.Value == nil {
 				maxVs = it.ValueCopy()
 				maxVs.Version = version
 			}

--- a/levels_test.go
+++ b/levels_test.go
@@ -959,6 +959,21 @@ func TestLevelGet(t *testing.T) {
 				{"foo", "bar10", 11, 0}, // Should return biggest version.
 			},
 		},
+		{
+			"zero version",
+			map[int][][]keyValVersion{
+				0: { // Level 1 has 1 table with a single key.
+					{{"fool0", "barl0", 0, 0}},
+				},
+				1: { // Level 1 has 1 table with a single key.
+					{{"foo", "bar", 0, 0}},
+				},
+			},
+			[]keyValVersion{
+				{"fool0", "barl0", 0, 0},
+				{"foo", "bar", 0, 0},
+			},
+		},
 	}
 	for _, ti := range tt {
 		t.Run(ti.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

After importing database from protobuf (with `StreamWriter`), I can't find keys with zero version.

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
