### PR TITLE
fix(Transaction): discard empty transactions on CommitWith 

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -103,8 +103,11 @@ func TestEmptyWriteBatch(t *testing.T) {
 			wb = db.NewWriteBatch()
 			require.NoError(t, wb.Flush())
 			wb = db.NewWriteBatch()
+			// Flush commits inner txn and sets a new one instead.
+			// Thus we need to save it to check if it was discarded.
 			txn := wb.txn
 			require.NoError(t, wb.Flush())
+			// check that flushed txn was discarded and marked as read.
 			require.True(t, txn.discarded)
 		})
 	})

--- a/batch_test.go
+++ b/batch_test.go
@@ -103,7 +103,9 @@ func TestEmptyWriteBatch(t *testing.T) {
 			wb = db.NewWriteBatch()
 			require.NoError(t, wb.Flush())
 			wb = db.NewWriteBatch()
+			txn := wb.txn
 			require.NoError(t, wb.Flush())
+			require.True(t, txn.discarded)
 		})
 	})
 	t.Run("managed mode", func(t *testing.T) {

--- a/txn.go
+++ b/txn.go
@@ -718,6 +718,8 @@ func (txn *Txn) CommitWith(cb func(error)) {
 		// callback might be acquiring the same locks. Instead run the callback
 		// from another goroutine.
 		go runTxnCallback(&txnCb{user: cb, err: nil})
+		// Discard the transaction so that the read is marked done.
+		txn.Discard()
 		return
 	}
 


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problems
* Transactions with empty `pendingWrites` were never discarded(and marked as done) for `CommitWith`
	* This is similar to https://github.com/dgraph-io/badger/pull/2018, which solved the same problem for `Commit`, but not for `CommitWith`
	* The `CommitWith` is used by `WriteBatch`, so flushing an empty batch never discarded the inner shadowed transaction, causing a multitude of issues.

## Solution
Make sure `Discard` is called for `CommitWith` when `pendingWrites` are empty. The existing unit test is updated to assert that.