### PR TITLE
fix(CI): Update to pull_request trigger

### DIFF
--- a/.github/workflows/ci-badger-tests-coverage.yml
+++ b/.github/workflows/ci-badger-tests-coverage.yml
@@ -1,6 +1,6 @@
 name: ci-badger-tests-coverage
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 'release/v*'


### PR DESCRIPTION
## Problem
Using `pull_request_target` can expose secrets based on a quirk in how GitHub applies permissions to forks. See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Solution
Change trigger from `pull_request_target` to `pull_request`