### PR TITLE
Feature: Allow stream custom maxsize per batch

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -14,479 +14,489 @@
  * limitations under the License.
  */
 
-package badger
+ package badger
 
-import (
-	"bytes"
-	"context"
-	"sort"
-	"sync"
-	"sync/atomic"
-	"time"
-
-	humanize "github.com/dustin/go-humanize"
-
-	"github.com/dgraph-io/badger/v4/pb"
-	"github.com/dgraph-io/badger/v4/y"
-	"github.com/dgraph-io/ristretto/z"
-)
-
-const batchSize = 16 << 20 // 16 MB
-
-// maxStreamSize is the maximum allowed size of a stream batch. This is a soft limit
-// as a single list that is still over the limit will have to be sent as is since it
-// cannot be split further. This limit prevents the framework from creating batches
-// so big that sending them causes issues (e.g running into the max size gRPC limit).
-var maxStreamSize = uint64(100 << 20) // 100MB
-
-// Stream provides a framework to concurrently iterate over a snapshot of Badger, pick up
-// key-values, batch them up and call Send. Stream does concurrent iteration over many smaller key
-// ranges. It does NOT send keys in lexicographical sorted order. To get keys in sorted
-// order, use Iterator.
-type Stream struct {
-	// Prefix to only iterate over certain range of keys. If set to nil (default), Stream would
-	// iterate over the entire DB.
-	Prefix []byte
-
-	// Number of goroutines to use for iterating over key ranges. Defaults to 8.
-	NumGo int
-
-	// Badger would produce log entries in Infof to indicate the progress of Stream. LogPrefix can
-	// be used to help differentiate them from other activities. Default is "Badger.Stream".
-	LogPrefix string
-
-	// ChooseKey is invoked each time a new key is encountered. Note that this is not called
-	// on every version of the value, only the first encountered version (i.e. the highest version
-	// of the value a key has). ChooseKey can be left nil to select all keys.
-	//
-	// Note: Calls to ChooseKey are concurrent.
-	ChooseKey func(item *Item) bool
-
-	// KeyToList, similar to ChooseKey, is only invoked on the highest version of the value. It
-	// is upto the caller to iterate over the versions and generate zero, one or more KVs. It
-	// is expected that the user would advance the iterator to go through the versions of the
-	// values. However, the user MUST immediately return from this function on the first encounter
-	// with a mismatching key. See example usage in ToList function. Can be left nil to use ToList
-	// function by default.
-	//
-	// KeyToList has access to z.Allocator accessible via stream.Allocator(itr.ThreadId). This
-	// allocator can be used to allocate KVs, to decrease the memory pressure on Go GC. Stream
-	// framework takes care of releasing those resources after calling Send. AllocRef does
-	// NOT need to be set in the returned KVList, as Stream framework would ignore that field,
-	// instead using the allocator assigned to that thread id.
-	//
-	// Note: Calls to KeyToList are concurrent.
-	KeyToList func(key []byte, itr *Iterator) (*pb.KVList, error)
-
-	// This is the method where Stream sends the final output. All calls to Send are done by a
-	// single goroutine, i.e. logic within Send method can expect single threaded execution.
-	Send func(buf *z.Buffer) error
-
-	// Read data above the sinceTs. All keys with version =< sinceTs will be ignored.
-	SinceTs      uint64
-	readTs       uint64
-	db           *DB
-	rangeCh      chan keyRange
-	kvChan       chan *z.Buffer
-	nextStreamId atomic.Uint32
-	doneMarkers  bool
-	scanned      atomic.Uint64 // used to estimate the ETA for data scan.
-	numProducers atomic.Int32
-}
-
-// SendDoneMarkers when true would send out done markers on the stream. False by default.
-func (st *Stream) SendDoneMarkers(done bool) {
-	st.doneMarkers = done
-}
-
-// ToList is a default implementation of KeyToList. It picks up all valid versions of the key,
-// skipping over deleted or expired keys.
-func (st *Stream) ToList(key []byte, itr *Iterator) (*pb.KVList, error) {
-	a := itr.Alloc
-	ka := a.Copy(key)
-
-	list := &pb.KVList{}
-	for ; itr.Valid(); itr.Next() {
-		item := itr.Item()
-		if item.IsDeletedOrExpired() {
-			break
-		}
-		if !bytes.Equal(key, item.Key()) {
-			// Break out on the first encounter with another key.
-			break
-		}
-
-		kv := y.NewKV(a)
-		kv.Key = ka
-
-		if err := item.Value(func(val []byte) error {
-			kv.Value = a.Copy(val)
-			return nil
-
-		}); err != nil {
-			return nil, err
-		}
-		kv.Version = item.Version()
-		kv.ExpiresAt = item.ExpiresAt()
-		kv.UserMeta = a.Copy([]byte{item.UserMeta()})
-
-		list.Kv = append(list.Kv, kv)
-		if st.db.opt.NumVersionsToKeep == 1 {
-			break
-		}
-
-		if item.DiscardEarlierVersions() {
-			break
-		}
-	}
-	return list, nil
-}
-
-// keyRange is [start, end), including start, excluding end. Do ensure that the start,
-// end byte slices are owned by keyRange struct.
-func (st *Stream) produceRanges(ctx context.Context) {
-	ranges := st.db.Ranges(st.Prefix, 16)
-	y.AssertTrue(len(ranges) > 0)
-	y.AssertTrue(ranges[0].left == nil)
-	y.AssertTrue(ranges[len(ranges)-1].right == nil)
-	st.db.opt.Infof("Number of ranges found: %d\n", len(ranges))
-
-	// Sort in descending order of size.
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].size > ranges[j].size
-	})
-	for i, r := range ranges {
-		st.rangeCh <- *r
-		st.db.opt.Infof("Sent range %d for iteration: [%x, %x) of size: %s\n",
-			i, r.left, r.right, humanize.IBytes(uint64(r.size)))
-	}
-	close(st.rangeCh)
-}
-
-// produceKVs picks up ranges from rangeCh, generates KV lists and sends them to kvChan.
-func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
-	st.numProducers.Add(1)
-	defer st.numProducers.Add(-1)
-
-	var txn *Txn
-	if st.readTs > 0 {
-		txn = st.db.NewTransactionAt(st.readTs, false)
-	} else {
-		txn = st.db.NewTransaction(false)
-	}
-	defer txn.Discard()
-
-	// produceKVs is running iterate serially. So, we can define the outList here.
-	outList := z.NewBuffer(2*batchSize, "Stream.ProduceKVs")
-	defer func() {
-		// The outList variable changes. So, we need to evaluate the variable in the defer. DO NOT
-		// call `defer outList.Release()`.
-		_ = outList.Release()
-	}()
-
-	iterate := func(kr keyRange) error {
-		iterOpts := DefaultIteratorOptions
-		iterOpts.AllVersions = true
-		iterOpts.Prefix = st.Prefix
-		iterOpts.PrefetchValues = false
-		iterOpts.SinceTs = st.SinceTs
-		itr := txn.NewIterator(iterOpts)
-		itr.ThreadId = threadId
-		defer itr.Close()
-
-		itr.Alloc = z.NewAllocator(1<<20, "Stream.Iterate")
-		defer itr.Alloc.Release()
-
-		// This unique stream id is used to identify all the keys from this iteration.
-		streamId := st.nextStreamId.Add(1)
-		var scanned int
-
-		sendIt := func() error {
-			select {
-			case st.kvChan <- outList:
-				outList = z.NewBuffer(2*batchSize, "Stream.ProduceKVs")
-				st.scanned.Add(uint64(itr.scanned - scanned))
-				scanned = itr.scanned
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-			return nil
-		}
-
-		var prevKey []byte
-		for itr.Seek(kr.left); itr.Valid(); {
-			// it.Valid would only return true for keys with the provided Prefix in iterOpts.
-			item := itr.Item()
-			if bytes.Equal(item.Key(), prevKey) {
-				itr.Next()
-				continue
-			}
-			prevKey = append(prevKey[:0], item.Key()...)
-
-			// Check if we reached the end of the key range.
-			if len(kr.right) > 0 && bytes.Compare(item.Key(), kr.right) >= 0 {
-				break
-			}
-
-			// Check if we should pick this key.
-			if st.ChooseKey != nil && !st.ChooseKey(item) {
-				continue
-			}
-
-			// Now convert to key value.
-			itr.Alloc.Reset()
-			list, err := st.KeyToList(item.KeyCopy(nil), itr)
-			if err != nil {
-				st.db.opt.Warningf("While reading key: %x, got error: %v", item.Key(), err)
-				continue
-			}
-			if list == nil || len(list.Kv) == 0 {
-				continue
-			}
-			for _, kv := range list.Kv {
-				kv.StreamId = streamId
-				KVToBuffer(kv, outList)
-				if outList.LenNoPadding() < batchSize {
-					continue
-				}
-				if err := sendIt(); err != nil {
-					return err
-				}
-			}
-		}
-		// Mark the stream as done.
-		if st.doneMarkers {
-			kv := &pb.KV{
-				StreamId:   streamId,
-				StreamDone: true,
-			}
-			KVToBuffer(kv, outList)
-		}
-		return sendIt()
-	}
-
-	for {
-		select {
-		case kr, ok := <-st.rangeCh:
-			if !ok {
-				// Done with the keys.
-				return nil
-			}
-			if err := iterate(kr); err != nil {
-				return err
-			}
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-func (st *Stream) streamKVs(ctx context.Context) error {
-	onDiskSize, uncompressedSize := st.db.EstimateSize(st.Prefix)
-	// Manish has seen uncompressed size to be in 20% error margin.
-	uncompressedSize = uint64(float64(uncompressedSize) * 1.2)
-	st.db.opt.Infof("%s Streaming about %s of uncompressed data (%s on disk)\n",
-		st.LogPrefix, humanize.IBytes(uncompressedSize), humanize.IBytes(onDiskSize))
-
-	tickerDur := 5 * time.Second
-	var bytesSent uint64
-	t := time.NewTicker(tickerDur)
-	defer t.Stop()
-	now := time.Now()
-
-	sendBatch := func(batch *z.Buffer) error {
-		defer func() { _ = batch.Release() }()
-		sz := uint64(batch.LenNoPadding())
-		if sz == 0 {
-			return nil
-		}
-		bytesSent += sz
-		// st.db.opt.Infof("%s Sending batch of size: %s.\n", st.LogPrefix, humanize.IBytes(sz))
-		if err := st.Send(batch); err != nil {
-			st.db.opt.Warningf("Error while sending: %v\n", err)
-			return err
-		}
-		return nil
-	}
-
-	slurp := func(batch *z.Buffer) error {
-	loop:
-		for {
-			// Send the batch immediately if it already exceeds the maximum allowed size.
-			// If the size of the batch exceeds maxStreamSize, break from the loop to
-			// avoid creating a batch that is so big that certain limits are reached.
-			if batch.LenNoPadding() > int(maxStreamSize) {
-				break loop
-			}
-			select {
-			case kvs, ok := <-st.kvChan:
-				if !ok {
-					break loop
-				}
-				y.AssertTrue(kvs != nil)
-				y.Check2(batch.Write(kvs.Bytes()))
-				y.Check(kvs.Release())
-
-			default:
-				break loop
-			}
-		}
-		return sendBatch(batch)
-	} // end of slurp.
-
-	writeRate := y.NewRateMonitor(20)
-	scanRate := y.NewRateMonitor(20)
-outer:
-	for {
-		var batch *z.Buffer
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-
-		case <-t.C:
-			// Instead of calculating speed over the entire lifetime, we average the speed over
-			// ticker duration.
-			writeRate.Capture(bytesSent)
-			scanned := st.scanned.Load()
-			scanRate.Capture(scanned)
-			numProducers := st.numProducers.Load()
-
-			st.db.opt.Infof("%s [%s] Scan (%d): ~%s/%s at %s/sec. Sent: %s at %s/sec."+
-				" jemalloc: %s\n",
-				st.LogPrefix, y.FixedDuration(time.Since(now)), numProducers,
-				y.IBytesToString(scanned, 1), humanize.IBytes(uncompressedSize),
-				humanize.IBytes(scanRate.Rate()),
-				y.IBytesToString(bytesSent, 1), humanize.IBytes(writeRate.Rate()),
-				humanize.IBytes(uint64(z.NumAllocBytes())))
-
-		case kvs, ok := <-st.kvChan:
-			if !ok {
-				break outer
-			}
-			y.AssertTrue(kvs != nil)
-			batch = kvs
-
-			// Otherwise, slurp more keys into this batch.
-			if err := slurp(batch); err != nil {
-				return err
-			}
-		}
-	}
-
-	st.db.opt.Infof("%s Sent data of size %s\n", st.LogPrefix, humanize.IBytes(bytesSent))
-	return nil
-}
-
-// Orchestrate runs Stream. It picks up ranges from the SSTables, then runs NumGo number of
-// goroutines to iterate over these ranges and batch up KVs in lists. It concurrently runs a single
-// goroutine to pick these lists, batch them up further and send to Output.Send. Orchestrate also
-// spits logs out to Infof, using provided LogPrefix. Note that all calls to Output.Send
-// are serial. In case any of these steps encounter an error, Orchestrate would stop execution and
-// return that error. Orchestrate can be called multiple times, but in serial order.
-func (st *Stream) Orchestrate(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	st.rangeCh = make(chan keyRange, 3) // Contains keys for posting lists.
-
-	// kvChan should only have a small capacity to ensure that we don't buffer up too much data if
-	// sending is slow. Page size is set to 4MB, which is used to lazily cap the size of each
-	// KVList. To get 128MB buffer, we can set the channel size to 32.
-	st.kvChan = make(chan *z.Buffer, 32)
-
-	if st.KeyToList == nil {
-		st.KeyToList = st.ToList
-	}
-
-	// Picks up ranges from Badger, and sends them to rangeCh.
-	go st.produceRanges(ctx)
-
-	errCh := make(chan error, st.NumGo) // Stores error by consumeKeys.
-	var wg sync.WaitGroup
-	for i := 0; i < st.NumGo; i++ {
-		wg.Add(1)
-
-		go func(threadId int) {
-			defer wg.Done()
-			// Picks up ranges from rangeCh, generates KV lists, and sends them to kvChan.
-			if err := st.produceKVs(ctx, threadId); err != nil {
-				select {
-				case errCh <- err:
-				default:
-				}
-			}
-		}(i)
-	}
-
-	// Pick up key-values from kvChan and send to stream.
-	kvErr := make(chan error, 1)
-	go func() {
-		// Picks up KV lists from kvChan, and sends them to Output.
-		err := st.streamKVs(ctx)
-		if err != nil {
-			cancel() // Stop all the go routines.
-		}
-		kvErr <- err
-	}()
-	wg.Wait()        // Wait for produceKVs to be over.
-	close(st.kvChan) // Now we can close kvChan.
-	defer func() {
-		// If due to some error, we have buffers left in kvChan, we should release them.
-		for buf := range st.kvChan {
-			_ = buf.Release()
-		}
-	}()
-
-	select {
-	case err := <-errCh: // Check error from produceKVs.
-		return err
-	default:
-	}
-
-	// Wait for key streaming to be over.
-	err := <-kvErr
-	return err
-}
-
-func (db *DB) newStream() *Stream {
-	return &Stream{
-		db:        db,
-		NumGo:     db.opt.NumGoroutines,
-		LogPrefix: "Badger.Stream",
-	}
-}
-
-// NewStream creates a new Stream.
-func (db *DB) NewStream() *Stream {
-	if db.opt.managedTxns {
-		panic("This API can not be called in managed mode.")
-	}
-	return db.newStream()
-}
-
-// NewStreamAt creates a new Stream at a particular timestamp. Should only be used with managed DB.
-func (db *DB) NewStreamAt(readTs uint64) *Stream {
-	if !db.opt.managedTxns {
-		panic("This API can only be called in managed mode.")
-	}
-	stream := db.newStream()
-	stream.readTs = readTs
-	return stream
-}
-
-func BufferToKVList(buf *z.Buffer) (*pb.KVList, error) {
-	var list pb.KVList
-	err := buf.SliceIterate(func(s []byte) error {
-		kv := new(pb.KV)
-		if err := kv.Unmarshal(s); err != nil {
-			return err
-		}
-		list.Kv = append(list.Kv, kv)
-		return nil
-	})
-	return &list, err
-}
-
-func KVToBuffer(kv *pb.KV, buf *z.Buffer) {
-	out := buf.SliceAllocate(kv.Size())
-	y.Check2(kv.MarshalToSizedBuffer(out))
-}
+ import (
+	 "bytes"
+	 "context"
+	 "sort"
+	 "sync"
+	 "sync/atomic"
+	 "time"
+ 
+	 humanize "github.com/dustin/go-humanize"
+ 
+	 "github.com/dgraph-io/badger/v4/pb"
+	 "github.com/dgraph-io/badger/v4/y"
+	 "github.com/dgraph-io/ristretto/z"
+ )
+ 
+ const batchSize = 16 << 20 // 16 MB
+ 
+ // maxStreamSize is the maximum allowed size of a stream batch. This is a soft limit
+ // as a single list that is still over the limit will have to be sent as is since it
+ // cannot be split further. This limit prevents the framework from creating batches
+ // so big that sending them causes issues (e.g running into the max size gRPC limit).
+ var maxStreamSize = uint64(100 << 20) // 100MB
+ 
+ // Stream provides a framework to concurrently iterate over a snapshot of Badger, pick up
+ // key-values, batch them up and call Send. Stream does concurrent iteration over many smaller key
+ // ranges. It does NOT send keys in lexicographical sorted order. To get keys in sorted
+ // order, use Iterator.
+ type Stream struct {
+	 // Prefix to only iterate over certain range of keys. If set to nil (default), Stream would
+	 // iterate over the entire DB.
+	 Prefix []byte
+ 
+	 // Number of goroutines to use for iterating over key ranges. Defaults to 8.
+	 NumGo int
+ 
+	 // Badger would produce log entries in Infof to indicate the progress of Stream. LogPrefix can
+	 // be used to help differentiate them from other activities. Default is "Badger.Stream".
+	 LogPrefix string
+ 
+	 // ChooseKey is invoked each time a new key is encountered. Note that this is not called
+	 // on every version of the value, only the first encountered version (i.e. the highest version
+	 // of the value a key has). ChooseKey can be left nil to select all keys.
+	 //
+	 // Note: Calls to ChooseKey are concurrent.
+	 ChooseKey func(item *Item) bool
+ 
+	 // MaxSize is the maximum allowed size of a stream batch. This is a soft limit
+	 // as a single list that is still over the limit will have to be sent as is since it
+	 // cannot be split further. This limit prevents the framework from creating batches
+	 // so big that sending them causes issues (e.g running into the max size gRPC limit).
+	 // If necessary, set it up before the Stream starts synchronisation
+	 // This is not a concurrency-safe setting
+	 MaxSize uint64
+ 
+	 // KeyToList, similar to ChooseKey, is only invoked on the highest version of the value. It
+	 // is upto the caller to iterate over the versions and generate zero, one or more KVs. It
+	 // is expected that the user would advance the iterator to go through the versions of the
+	 // values. However, the user MUST immediately return from this function on the first encounter
+	 // with a mismatching key. See example usage in ToList function. Can be left nil to use ToList
+	 // function by default.
+	 //
+	 // KeyToList has access to z.Allocator accessible via stream.Allocator(itr.ThreadId). This
+	 // allocator can be used to allocate KVs, to decrease the memory pressure on Go GC. Stream
+	 // framework takes care of releasing those resources after calling Send. AllocRef does
+	 // NOT need to be set in the returned KVList, as Stream framework would ignore that field,
+	 // instead using the allocator assigned to that thread id.
+	 //
+	 // Note: Calls to KeyToList are concurrent.
+	 KeyToList func(key []byte, itr *Iterator) (*pb.KVList, error)
+ 
+	 // This is the method where Stream sends the final output. All calls to Send are done by a
+	 // single goroutine, i.e. logic within Send method can expect single threaded execution.
+	 Send func(buf *z.Buffer) error
+ 
+	 // Read data above the sinceTs. All keys with version =< sinceTs will be ignored.
+	 SinceTs      uint64
+	 readTs       uint64
+	 db           *DB
+	 rangeCh      chan keyRange
+	 kvChan       chan *z.Buffer
+	 nextStreamId atomic.Uint32
+	 doneMarkers  bool
+	 scanned      atomic.Uint64 // used to estimate the ETA for data scan.
+	 numProducers atomic.Int32
+ }
+ 
+ // SendDoneMarkers when true would send out done markers on the stream. False by default.
+ func (st *Stream) SendDoneMarkers(done bool) {
+	 st.doneMarkers = done
+ }
+ 
+ // ToList is a default implementation of KeyToList. It picks up all valid versions of the key,
+ // skipping over deleted or expired keys.
+ func (st *Stream) ToList(key []byte, itr *Iterator) (*pb.KVList, error) {
+	 a := itr.Alloc
+	 ka := a.Copy(key)
+ 
+	 list := &pb.KVList{}
+	 for ; itr.Valid(); itr.Next() {
+		 item := itr.Item()
+		 if item.IsDeletedOrExpired() {
+			 break
+		 }
+		 if !bytes.Equal(key, item.Key()) {
+			 // Break out on the first encounter with another key.
+			 break
+		 }
+ 
+		 kv := y.NewKV(a)
+		 kv.Key = ka
+ 
+		 if err := item.Value(func(val []byte) error {
+			 kv.Value = a.Copy(val)
+			 return nil
+ 
+		 }); err != nil {
+			 return nil, err
+		 }
+		 kv.Version = item.Version()
+		 kv.ExpiresAt = item.ExpiresAt()
+		 kv.UserMeta = a.Copy([]byte{item.UserMeta()})
+ 
+		 list.Kv = append(list.Kv, kv)
+		 if st.db.opt.NumVersionsToKeep == 1 {
+			 break
+		 }
+ 
+		 if item.DiscardEarlierVersions() {
+			 break
+		 }
+	 }
+	 return list, nil
+ }
+ 
+ // keyRange is [start, end), including start, excluding end. Do ensure that the start,
+ // end byte slices are owned by keyRange struct.
+ func (st *Stream) produceRanges(ctx context.Context) {
+	 ranges := st.db.Ranges(st.Prefix, 16)
+	 y.AssertTrue(len(ranges) > 0)
+	 y.AssertTrue(ranges[0].left == nil)
+	 y.AssertTrue(ranges[len(ranges)-1].right == nil)
+	 st.db.opt.Infof("Number of ranges found: %d\n", len(ranges))
+ 
+	 // Sort in descending order of size.
+	 sort.Slice(ranges, func(i, j int) bool {
+		 return ranges[i].size > ranges[j].size
+	 })
+	 for i, r := range ranges {
+		 st.rangeCh <- *r
+		 st.db.opt.Infof("Sent range %d for iteration: [%x, %x) of size: %s\n",
+			 i, r.left, r.right, humanize.IBytes(uint64(r.size)))
+	 }
+	 close(st.rangeCh)
+ }
+ 
+ // produceKVs picks up ranges from rangeCh, generates KV lists and sends them to kvChan.
+ func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
+	 st.numProducers.Add(1)
+	 defer st.numProducers.Add(-1)
+ 
+	 var txn *Txn
+	 if st.readTs > 0 {
+		 txn = st.db.NewTransactionAt(st.readTs, false)
+	 } else {
+		 txn = st.db.NewTransaction(false)
+	 }
+	 defer txn.Discard()
+ 
+	 // produceKVs is running iterate serially. So, we can define the outList here.
+	 outList := z.NewBuffer(2*batchSize, "Stream.ProduceKVs")
+	 defer func() {
+		 // The outList variable changes. So, we need to evaluate the variable in the defer. DO NOT
+		 // call `defer outList.Release()`.
+		 _ = outList.Release()
+	 }()
+ 
+	 iterate := func(kr keyRange) error {
+		 iterOpts := DefaultIteratorOptions
+		 iterOpts.AllVersions = true
+		 iterOpts.Prefix = st.Prefix
+		 iterOpts.PrefetchValues = false
+		 iterOpts.SinceTs = st.SinceTs
+		 itr := txn.NewIterator(iterOpts)
+		 itr.ThreadId = threadId
+		 defer itr.Close()
+ 
+		 itr.Alloc = z.NewAllocator(1<<20, "Stream.Iterate")
+		 defer itr.Alloc.Release()
+ 
+		 // This unique stream id is used to identify all the keys from this iteration.
+		 streamId := st.nextStreamId.Add(1)
+		 var scanned int
+ 
+		 sendIt := func() error {
+			 select {
+			 case st.kvChan <- outList:
+				 outList = z.NewBuffer(2*batchSize, "Stream.ProduceKVs")
+				 st.scanned.Add(uint64(itr.scanned - scanned))
+				 scanned = itr.scanned
+			 case <-ctx.Done():
+				 return ctx.Err()
+			 }
+			 return nil
+		 }
+ 
+		 var prevKey []byte
+		 for itr.Seek(kr.left); itr.Valid(); {
+			 // it.Valid would only return true for keys with the provided Prefix in iterOpts.
+			 item := itr.Item()
+			 if bytes.Equal(item.Key(), prevKey) {
+				 itr.Next()
+				 continue
+			 }
+			 prevKey = append(prevKey[:0], item.Key()...)
+ 
+			 // Check if we reached the end of the key range.
+			 if len(kr.right) > 0 && bytes.Compare(item.Key(), kr.right) >= 0 {
+				 break
+			 }
+ 
+			 // Check if we should pick this key.
+			 if st.ChooseKey != nil && !st.ChooseKey(item) {
+				 continue
+			 }
+ 
+			 // Now convert to key value.
+			 itr.Alloc.Reset()
+			 list, err := st.KeyToList(item.KeyCopy(nil), itr)
+			 if err != nil {
+				 st.db.opt.Warningf("While reading key: %x, got error: %v", item.Key(), err)
+				 continue
+			 }
+			 if list == nil || len(list.Kv) == 0 {
+				 continue
+			 }
+			 for _, kv := range list.Kv {
+				 kv.StreamId = streamId
+				 KVToBuffer(kv, outList)
+				 if outList.LenNoPadding() < batchSize {
+					 continue
+				 }
+				 if err := sendIt(); err != nil {
+					 return err
+				 }
+			 }
+		 }
+		 // Mark the stream as done.
+		 if st.doneMarkers {
+			 kv := &pb.KV{
+				 StreamId:   streamId,
+				 StreamDone: true,
+			 }
+			 KVToBuffer(kv, outList)
+		 }
+		 return sendIt()
+	 }
+ 
+	 for {
+		 select {
+		 case kr, ok := <-st.rangeCh:
+			 if !ok {
+				 // Done with the keys.
+				 return nil
+			 }
+			 if err := iterate(kr); err != nil {
+				 return err
+			 }
+		 case <-ctx.Done():
+			 return ctx.Err()
+		 }
+	 }
+ }
+ 
+ func (st *Stream) streamKVs(ctx context.Context) error {
+	 onDiskSize, uncompressedSize := st.db.EstimateSize(st.Prefix)
+	 // Manish has seen uncompressed size to be in 20% error margin.
+	 uncompressedSize = uint64(float64(uncompressedSize) * 1.2)
+	 st.db.opt.Infof("%s Streaming about %s of uncompressed data (%s on disk)\n",
+		 st.LogPrefix, humanize.IBytes(uncompressedSize), humanize.IBytes(onDiskSize))
+ 
+	 tickerDur := 5 * time.Second
+	 var bytesSent uint64
+	 t := time.NewTicker(tickerDur)
+	 defer t.Stop()
+	 now := time.Now()
+ 
+	 sendBatch := func(batch *z.Buffer) error {
+		 defer func() { _ = batch.Release() }()
+		 sz := uint64(batch.LenNoPadding())
+		 if sz == 0 {
+			 return nil
+		 }
+		 bytesSent += sz
+		 // st.db.opt.Infof("%s Sending batch of size: %s.\n", st.LogPrefix, humanize.IBytes(sz))
+		 if err := st.Send(batch); err != nil {
+			 st.db.opt.Warningf("Error while sending: %v\n", err)
+			 return err
+		 }
+		 return nil
+	 }
+ 
+	 slurp := func(batch *z.Buffer) error {
+	 loop:
+		 for {
+			 // Send the batch immediately if it already exceeds the maximum allowed size.
+			 // If the size of the batch exceeds maxStreamSize, break from the loop to
+			 // avoid creating a batch that is so big that certain limits are reached.
+			 if batch.LenNoPadding() > int(st.MaxSize) {
+				 break loop
+			 }
+			 select {
+			 case kvs, ok := <-st.kvChan:
+				 if !ok {
+					 break loop
+				 }
+				 y.AssertTrue(kvs != nil)
+				 y.Check2(batch.Write(kvs.Bytes()))
+				 y.Check(kvs.Release())
+ 
+			 default:
+				 break loop
+			 }
+		 }
+		 return sendBatch(batch)
+	 } // end of slurp.
+ 
+	 writeRate := y.NewRateMonitor(20)
+	 scanRate := y.NewRateMonitor(20)
+ outer:
+	 for {
+		 var batch *z.Buffer
+		 select {
+		 case <-ctx.Done():
+			 return ctx.Err()
+ 
+		 case <-t.C:
+			 // Instead of calculating speed over the entire lifetime, we average the speed over
+			 // ticker duration.
+			 writeRate.Capture(bytesSent)
+			 scanned := st.scanned.Load()
+			 scanRate.Capture(scanned)
+			 numProducers := st.numProducers.Load()
+ 
+			 st.db.opt.Infof("%s [%s] Scan (%d): ~%s/%s at %s/sec. Sent: %s at %s/sec."+
+				 " jemalloc: %s\n",
+				 st.LogPrefix, y.FixedDuration(time.Since(now)), numProducers,
+				 y.IBytesToString(scanned, 1), humanize.IBytes(uncompressedSize),
+				 humanize.IBytes(scanRate.Rate()),
+				 y.IBytesToString(bytesSent, 1), humanize.IBytes(writeRate.Rate()),
+				 humanize.IBytes(uint64(z.NumAllocBytes())))
+ 
+		 case kvs, ok := <-st.kvChan:
+			 if !ok {
+				 break outer
+			 }
+			 y.AssertTrue(kvs != nil)
+			 batch = kvs
+ 
+			 // Otherwise, slurp more keys into this batch.
+			 if err := slurp(batch); err != nil {
+				 return err
+			 }
+		 }
+	 }
+ 
+	 st.db.opt.Infof("%s Sent data of size %s\n", st.LogPrefix, humanize.IBytes(bytesSent))
+	 return nil
+ }
+ 
+ // Orchestrate runs Stream. It picks up ranges from the SSTables, then runs NumGo number of
+ // goroutines to iterate over these ranges and batch up KVs in lists. It concurrently runs a single
+ // goroutine to pick these lists, batch them up further and send to Output.Send. Orchestrate also
+ // spits logs out to Infof, using provided LogPrefix. Note that all calls to Output.Send
+ // are serial. In case any of these steps encounter an error, Orchestrate would stop execution and
+ // return that error. Orchestrate can be called multiple times, but in serial order.
+ func (st *Stream) Orchestrate(ctx context.Context) error {
+	 ctx, cancel := context.WithCancel(ctx)
+	 defer cancel()
+	 st.rangeCh = make(chan keyRange, 3) // Contains keys for posting lists.
+ 
+	 // kvChan should only have a small capacity to ensure that we don't buffer up too much data if
+	 // sending is slow. Page size is set to 4MB, which is used to lazily cap the size of each
+	 // KVList. To get 128MB buffer, we can set the channel size to 32.
+	 st.kvChan = make(chan *z.Buffer, 32)
+ 
+	 if st.KeyToList == nil {
+		 st.KeyToList = st.ToList
+	 }
+ 
+	 // Picks up ranges from Badger, and sends them to rangeCh.
+	 go st.produceRanges(ctx)
+ 
+	 errCh := make(chan error, st.NumGo) // Stores error by consumeKeys.
+	 var wg sync.WaitGroup
+	 for i := 0; i < st.NumGo; i++ {
+		 wg.Add(1)
+ 
+		 go func(threadId int) {
+			 defer wg.Done()
+			 // Picks up ranges from rangeCh, generates KV lists, and sends them to kvChan.
+			 if err := st.produceKVs(ctx, threadId); err != nil {
+				 select {
+				 case errCh <- err:
+				 default:
+				 }
+			 }
+		 }(i)
+	 }
+ 
+	 // Pick up key-values from kvChan and send to stream.
+	 kvErr := make(chan error, 1)
+	 go func() {
+		 // Picks up KV lists from kvChan, and sends them to Output.
+		 err := st.streamKVs(ctx)
+		 if err != nil {
+			 cancel() // Stop all the go routines.
+		 }
+		 kvErr <- err
+	 }()
+	 wg.Wait()        // Wait for produceKVs to be over.
+	 close(st.kvChan) // Now we can close kvChan.
+	 defer func() {
+		 // If due to some error, we have buffers left in kvChan, we should release them.
+		 for buf := range st.kvChan {
+			 _ = buf.Release()
+		 }
+	 }()
+ 
+	 select {
+	 case err := <-errCh: // Check error from produceKVs.
+		 return err
+	 default:
+	 }
+ 
+	 // Wait for key streaming to be over.
+	 err := <-kvErr
+	 return err
+ }
+ 
+ func (db *DB) newStream() *Stream {
+	 return &Stream{
+		 db:        db,
+		 NumGo:     db.opt.NumGoroutines,
+		 LogPrefix: "Badger.Stream",
+		 MaxSize:   maxStreamSize,
+	 }
+ }
+ 
+ // NewStream creates a new Stream.
+ func (db *DB) NewStream() *Stream {
+	 if db.opt.managedTxns {
+		 panic("This API can not be called in managed mode.")
+	 }
+	 return db.newStream()
+ }
+ 
+ // NewStreamAt creates a new Stream at a particular timestamp. Should only be used with managed DB.
+ func (db *DB) NewStreamAt(readTs uint64) *Stream {
+	 if !db.opt.managedTxns {
+		 panic("This API can only be called in managed mode.")
+	 }
+	 stream := db.newStream()
+	 stream.readTs = readTs
+	 return stream
+ }
+ 
+ func BufferToKVList(buf *z.Buffer) (*pb.KVList, error) {
+	 var list pb.KVList
+	 err := buf.SliceIterate(func(s []byte) error {
+		 kv := new(pb.KV)
+		 if err := kv.Unmarshal(s); err != nil {
+			 return err
+		 }
+		 list.Kv = append(list.Kv, kv)
+		 return nil
+	 })
+	 return &list, err
+ }
+ 
+ func KVToBuffer(kv *pb.KV, buf *z.Buffer) {
+	 out := buf.SliceAllocate(kv.Size())
+	 y.Check2(kv.MarshalToSizedBuffer(out))
+ }
+ 

--- a/stream_test.go
+++ b/stream_test.go
@@ -14,313 +14,376 @@
  * limitations under the License.
  */
 
-package badger
+ package badger
 
-import (
-	"context"
-	"fmt"
-	"math"
-	"os"
-	"strconv"
-	"strings"
-	"testing"
-
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/require"
-
-	bpb "github.com/dgraph-io/badger/v4/pb"
-	"github.com/dgraph-io/badger/v4/y"
-	"github.com/dgraph-io/ristretto/z"
-)
-
-func keyWithPrefix(prefix string, k int) []byte {
-	return []byte(fmt.Sprintf("%s-%d", prefix, k))
-}
-
-func keyToInt(k []byte) (string, int) {
-	splits := strings.Split(string(k), "-")
-	key, err := strconv.Atoi(splits[1])
-	y.Check(err)
-	return splits[0], key
-}
-
-func value(k int) []byte {
-	return []byte(fmt.Sprintf("%08d", k))
-}
-
-type collector struct {
-	kv []*bpb.KV
-}
-
-func (c *collector) Send(buf *z.Buffer) error {
-	list, err := BufferToKVList(buf)
-	if err != nil {
-		return err
-	}
-	for _, kv := range list.Kv {
-		if kv.StreamDone == true {
-			return nil
-		}
-		cp := proto.Clone(kv).(*bpb.KV)
-		c.kv = append(c.kv, cp)
-	}
-	return err
-}
-
-var ctxb = context.Background()
-
-func TestStream(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	require.NoError(t, err)
-	defer removeDir(dir)
-
-	db, err := OpenManaged(DefaultOptions(dir))
-	require.NoError(t, err)
-
-	var count int
-	for _, prefix := range []string{"p0", "p1", "p2"} {
-		txn := db.NewTransactionAt(math.MaxUint64, true)
-		for i := 1; i <= 100; i++ {
-			require.NoError(t, txn.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
-			count++
-		}
-		require.NoError(t, txn.CommitAt(5, nil))
-	}
-
-	stream := db.NewStreamAt(math.MaxUint64)
-	stream.LogPrefix = "Testing"
-	c := &collector{}
-	stream.Send = c.Send
-
-	// Test case 1. Retrieve everything.
-	err = stream.Orchestrate(ctxb)
-	require.NoError(t, err)
-	require.Equal(t, 300, len(c.kv), "Expected 300. Got: %d", len(c.kv))
-
-	m := make(map[string]int)
-	for _, kv := range c.kv {
-		prefix, ki := keyToInt(kv.Key)
-		expected := value(ki)
-		require.Equal(t, expected, kv.Value)
-		m[prefix]++
-	}
-	require.Equal(t, 3, len(m))
-	for pred, count := range m {
-		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
-	}
-
-	// Test case 2. Retrieve only 1 predicate.
-	stream.Prefix = []byte("p1")
-	c.kv = c.kv[:0]
-	err = stream.Orchestrate(ctxb)
-	require.NoError(t, err)
-	require.Equal(t, 100, len(c.kv), "Expected 100. Got: %d", len(c.kv))
-
-	m = make(map[string]int)
-	for _, kv := range c.kv {
-		prefix, ki := keyToInt(kv.Key)
-		expected := value(ki)
-		require.Equal(t, expected, kv.Value)
-		m[prefix]++
-	}
-	require.Equal(t, 1, len(m))
-	for pred, count := range m {
-		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
-	}
-
-	// Test case 3. Retrieve select keys within the predicate.
-	c.kv = c.kv[:0]
-	stream.ChooseKey = func(item *Item) bool {
-		_, k := keyToInt(item.Key())
-		return k%2 == 0
-	}
-	err = stream.Orchestrate(ctxb)
-	require.NoError(t, err)
-	require.Equal(t, 50, len(c.kv), "Expected 50. Got: %d", len(c.kv))
-
-	m = make(map[string]int)
-	for _, kv := range c.kv {
-		prefix, ki := keyToInt(kv.Key)
-		expected := value(ki)
-		require.Equal(t, expected, kv.Value)
-		m[prefix]++
-	}
-	require.Equal(t, 1, len(m))
-	for pred, count := range m {
-		require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
-	}
-
-	// Test case 4. Retrieve select keys from all predicates.
-	c.kv = c.kv[:0]
-	stream.Prefix = []byte{}
-	err = stream.Orchestrate(ctxb)
-	require.NoError(t, err)
-	require.Equal(t, 150, len(c.kv), "Expected 150. Got: %d", len(c.kv))
-
-	m = make(map[string]int)
-	for _, kv := range c.kv {
-		prefix, ki := keyToInt(kv.Key)
-		expected := value(ki)
-		require.Equal(t, expected, kv.Value)
-		m[prefix]++
-	}
-	require.Equal(t, 3, len(m))
-	for pred, count := range m {
-		require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
-	}
-	require.NoError(t, db.Close())
-}
-
-func TestStreamWithThreadId(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	require.NoError(t, err)
-	defer removeDir(dir)
-
-	db, err := OpenManaged(DefaultOptions(dir))
-	require.NoError(t, err)
-
-	var count int
-	for _, prefix := range []string{"p0", "p1", "p2"} {
-		txn := db.NewTransactionAt(math.MaxUint64, true)
-		for i := 1; i <= 100; i++ {
-			require.NoError(t, txn.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
-			count++
-		}
-		require.NoError(t, txn.CommitAt(5, nil))
-	}
-
-	stream := db.NewStreamAt(math.MaxUint64)
-	stream.LogPrefix = "Testing"
-	stream.KeyToList = func(key []byte, itr *Iterator) (
-		*bpb.KVList, error) {
-		require.Less(t, itr.ThreadId, stream.NumGo)
-		return stream.ToList(key, itr)
-	}
-	c := &collector{}
-	stream.Send = c.Send
-
-	err = stream.Orchestrate(ctxb)
-	require.NoError(t, err)
-	require.Equal(t, 300, len(c.kv), "Expected 300. Got: %d", len(c.kv))
-
-	m := make(map[string]int)
-	for _, kv := range c.kv {
-		prefix, ki := keyToInt(kv.Key)
-		expected := value(ki)
-		require.Equal(t, expected, kv.Value)
-		m[prefix]++
-	}
-	require.Equal(t, 3, len(m))
-	for pred, count := range m {
-		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
-	}
-	require.NoError(t, db.Close())
-}
-
-func TestBigStream(t *testing.T) {
-	if !*manual {
-		t.Skip("Skipping test meant to be run manually.")
-		return
-	}
-	// Set the maxStreamSize to 1MB for the duration of the test so that the it can use a smaller
-	// dataset than it would otherwise need.
-	originalMaxStreamSize := maxStreamSize
-	maxStreamSize = 1 << 20
-	defer func() {
-		maxStreamSize = originalMaxStreamSize
-	}()
-
-	testSize := int(1e6)
-	dir, err := os.MkdirTemp("", "badger-big-test")
-	require.NoError(t, err)
-	defer removeDir(dir)
-
-	db, err := OpenManaged(DefaultOptions(dir))
-	require.NoError(t, err)
-
-	var count int
-	wb := db.NewWriteBatchAt(5)
-	for _, prefix := range []string{"p0", "p1", "p2"} {
-		for i := 1; i <= testSize; i++ {
-			require.NoError(t, wb.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
-			count++
-		}
-	}
-	require.NoError(t, wb.Flush())
-
-	stream := db.NewStreamAt(math.MaxUint64)
-	stream.LogPrefix = "Testing"
-	c := &collector{}
-	stream.Send = c.Send
-
-	// Test case 1. Retrieve everything.
-	err = stream.Orchestrate(ctxb)
-	require.NoError(t, err)
-	require.Equal(t, 3*testSize, len(c.kv), "Expected 30000. Got: %d", len(c.kv))
-
-	m := make(map[string]int)
-	for _, kv := range c.kv {
-		prefix, ki := keyToInt(kv.Key)
-		expected := value(ki)
-		require.Equal(t, expected, kv.Value)
-		m[prefix]++
-	}
-	require.Equal(t, 3, len(m))
-	for pred, count := range m {
-		require.Equal(t, testSize, count, "Count mismatch for pred: %s", pred)
-	}
-	require.NoError(t, db.Close())
-}
-
-// There was a bug in the stream writer code which would cause allocators to be
-// freed up twice if the default keyToList was not used. This test verifies that issue.
-func TestStreamCustomKeyToList(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badger-test")
-	require.NoError(t, err)
-	defer removeDir(dir)
-
-	db, err := OpenManaged(DefaultOptions(dir))
-	require.NoError(t, err)
-
-	var count int
-	for _, key := range []string{"p0", "p1", "p2"} {
-		for i := 1; i <= 100; i++ {
-			txn := db.NewTransactionAt(math.MaxUint64, true)
-			require.NoError(t, txn.SetEntry(NewEntry([]byte(key), value(i))))
-			count++
-			require.NoError(t, txn.CommitAt(uint64(i), nil))
-		}
-	}
-
-	stream := db.NewStreamAt(math.MaxUint64)
-	stream.LogPrefix = "Testing"
-	stream.KeyToList = func(key []byte, itr *Iterator) (*bpb.KVList, error) {
-		item := itr.Item()
-		val, err := item.ValueCopy(nil)
-		if err != nil {
-			return nil, err
-		}
-		kv := &bpb.KV{
-			Key:   y.Copy(item.Key()),
-			Value: val,
-		}
-		return &bpb.KVList{
-			Kv: []*bpb.KV{kv},
-		}, nil
-	}
-	res := map[string]struct{}{"p0": {}, "p1": {}, "p2": {}}
-	stream.Send = func(buf *z.Buffer) error {
-		list, err := BufferToKVList(buf)
-		require.NoError(t, err)
-		for _, kv := range list.Kv {
-			key := string(kv.Key)
-			if _, ok := res[key]; !ok {
-				panic(fmt.Sprintf("%s key not found", key))
-			}
-			delete(res, key)
-		}
-		return nil
-	}
-	require.NoError(t, stream.Orchestrate(ctxb))
-	require.Zero(t, len(res))
-}
+ import (
+	 "context"
+	 "fmt"
+	 "github.com/stretchr/testify/assert"
+	 "math"
+	 "os"
+	 "strconv"
+	 "strings"
+	 "testing"
+ 
+	 "github.com/golang/protobuf/proto"
+	 "github.com/stretchr/testify/require"
+ 
+	 bpb "github.com/dgraph-io/badger/v4/pb"
+	 "github.com/dgraph-io/badger/v4/y"
+	 "github.com/dgraph-io/ristretto/z"
+ )
+ 
+ func keyWithPrefix(prefix string, k int) []byte {
+	 return []byte(fmt.Sprintf("%s-%d", prefix, k))
+ }
+ 
+ func keyToInt(k []byte) (string, int) {
+	 splits := strings.Split(string(k), "-")
+	 key, err := strconv.Atoi(splits[1])
+	 y.Check(err)
+	 return splits[0], key
+ }
+ 
+ func value(k int) []byte {
+	 return []byte(fmt.Sprintf("%08d", k))
+ }
+ 
+ type collector struct {
+	 kv []*bpb.KV
+ }
+ 
+ func (c *collector) Send(buf *z.Buffer) error {
+	 list, err := BufferToKVList(buf)
+	 if err != nil {
+		 return err
+	 }
+	 for _, kv := range list.Kv {
+		 if kv.StreamDone == true {
+			 return nil
+		 }
+		 cp := proto.Clone(kv).(*bpb.KV)
+		 c.kv = append(c.kv, cp)
+	 }
+	 return err
+ }
+ 
+ var ctxb = context.Background()
+ 
+ func TestStreamMaxSize(t *testing.T) {
+	 if !*manual {
+		 t.Skip("Skipping test meant to be run manually.")
+		 return
+	 }
+	 // Set the maxStreamSize to 1MB for the duration of the test so that the it can use a smaller
+	 // dataset than it would otherwise need.
+	 originalMaxStreamSize := maxStreamSize
+	 maxStreamSize = 1 << 20
+	 defer func() {
+		 maxStreamSize = originalMaxStreamSize
+	 }()
+ 
+	 testSize := int(1e6)
+	 dir, err := os.MkdirTemp("", "badger-big-test")
+	 require.NoError(t, err)
+	 defer removeDir(dir)
+ 
+	 db, err := OpenManaged(DefaultOptions(dir))
+	 require.NoError(t, err)
+ 
+	 var count int
+	 wb := db.NewWriteBatchAt(5)
+	 for _, prefix := range []string{"p0", "p1", "p2"} {
+		 for i := 1; i <= testSize; i++ {
+			 require.NoError(t, wb.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
+			 count++
+		 }
+	 }
+	 require.NoError(t, wb.Flush())
+ 
+	 stream := db.NewStreamAt(math.MaxUint64)
+	 stream.LogPrefix = "Testing"
+	 c := &collector{}
+	 stream.Send = c.Send
+ 
+	 // default value
+	 assert.Equal(t, stream.MaxSize, maxStreamSize)
+ 
+	 // reset maxsize
+	 stream.MaxSize = 1024 * 1024 * 50
+ 
+	 // Test case 1. Retrieve everything.
+	 err = stream.Orchestrate(ctxb)
+	 require.NoError(t, err)
+	 require.Equal(t, 3*testSize, len(c.kv), "Expected 30000. Got: %d", len(c.kv))
+ 
+	 m := make(map[string]int)
+	 for _, kv := range c.kv {
+		 prefix, ki := keyToInt(kv.Key)
+		 expected := value(ki)
+		 require.Equal(t, expected, kv.Value)
+		 m[prefix]++
+	 }
+	 require.Equal(t, 3, len(m))
+	 for pred, count := range m {
+		 require.Equal(t, testSize, count, "Count mismatch for pred: %s", pred)
+	 }
+	 require.NoError(t, db.Close())
+ }
+ 
+ func TestStream(t *testing.T) {
+	 dir, err := os.MkdirTemp("", "badger-test")
+	 require.NoError(t, err)
+	 defer removeDir(dir)
+ 
+	 db, err := OpenManaged(DefaultOptions(dir))
+	 require.NoError(t, err)
+ 
+	 var count int
+	 for _, prefix := range []string{"p0", "p1", "p2"} {
+		 txn := db.NewTransactionAt(math.MaxUint64, true)
+		 for i := 1; i <= 100; i++ {
+			 require.NoError(t, txn.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
+			 count++
+		 }
+		 require.NoError(t, txn.CommitAt(5, nil))
+	 }
+ 
+	 stream := db.NewStreamAt(math.MaxUint64)
+	 stream.LogPrefix = "Testing"
+	 c := &collector{}
+	 stream.Send = c.Send
+ 
+	 // Test case 1. Retrieve everything.
+	 err = stream.Orchestrate(ctxb)
+	 require.NoError(t, err)
+	 require.Equal(t, 300, len(c.kv), "Expected 300. Got: %d", len(c.kv))
+ 
+	 m := make(map[string]int)
+	 for _, kv := range c.kv {
+		 prefix, ki := keyToInt(kv.Key)
+		 expected := value(ki)
+		 require.Equal(t, expected, kv.Value)
+		 m[prefix]++
+	 }
+	 require.Equal(t, 3, len(m))
+	 for pred, count := range m {
+		 require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
+	 }
+ 
+	 // Test case 2. Retrieve only 1 predicate.
+	 stream.Prefix = []byte("p1")
+	 c.kv = c.kv[:0]
+	 err = stream.Orchestrate(ctxb)
+	 require.NoError(t, err)
+	 require.Equal(t, 100, len(c.kv), "Expected 100. Got: %d", len(c.kv))
+ 
+	 m = make(map[string]int)
+	 for _, kv := range c.kv {
+		 prefix, ki := keyToInt(kv.Key)
+		 expected := value(ki)
+		 require.Equal(t, expected, kv.Value)
+		 m[prefix]++
+	 }
+	 require.Equal(t, 1, len(m))
+	 for pred, count := range m {
+		 require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
+	 }
+ 
+	 // Test case 3. Retrieve select keys within the predicate.
+	 c.kv = c.kv[:0]
+	 stream.ChooseKey = func(item *Item) bool {
+		 _, k := keyToInt(item.Key())
+		 return k%2 == 0
+	 }
+	 err = stream.Orchestrate(ctxb)
+	 require.NoError(t, err)
+	 require.Equal(t, 50, len(c.kv), "Expected 50. Got: %d", len(c.kv))
+ 
+	 m = make(map[string]int)
+	 for _, kv := range c.kv {
+		 prefix, ki := keyToInt(kv.Key)
+		 expected := value(ki)
+		 require.Equal(t, expected, kv.Value)
+		 m[prefix]++
+	 }
+	 require.Equal(t, 1, len(m))
+	 for pred, count := range m {
+		 require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
+	 }
+ 
+	 // Test case 4. Retrieve select keys from all predicates.
+	 c.kv = c.kv[:0]
+	 stream.Prefix = []byte{}
+	 err = stream.Orchestrate(ctxb)
+	 require.NoError(t, err)
+	 require.Equal(t, 150, len(c.kv), "Expected 150. Got: %d", len(c.kv))
+ 
+	 m = make(map[string]int)
+	 for _, kv := range c.kv {
+		 prefix, ki := keyToInt(kv.Key)
+		 expected := value(ki)
+		 require.Equal(t, expected, kv.Value)
+		 m[prefix]++
+	 }
+	 require.Equal(t, 3, len(m))
+	 for pred, count := range m {
+		 require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
+	 }
+	 require.NoError(t, db.Close())
+ }
+ 
+ func TestStreamWithThreadId(t *testing.T) {
+	 dir, err := os.MkdirTemp("", "badger-test")
+	 require.NoError(t, err)
+	 defer removeDir(dir)
+ 
+	 db, err := OpenManaged(DefaultOptions(dir))
+	 require.NoError(t, err)
+ 
+	 var count int
+	 for _, prefix := range []string{"p0", "p1", "p2"} {
+		 txn := db.NewTransactionAt(math.MaxUint64, true)
+		 for i := 1; i <= 100; i++ {
+			 require.NoError(t, txn.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
+			 count++
+		 }
+		 require.NoError(t, txn.CommitAt(5, nil))
+	 }
+ 
+	 stream := db.NewStreamAt(math.MaxUint64)
+	 stream.LogPrefix = "Testing"
+	 stream.KeyToList = func(key []byte, itr *Iterator) (
+		 *bpb.KVList, error) {
+		 require.Less(t, itr.ThreadId, stream.NumGo)
+		 return stream.ToList(key, itr)
+	 }
+	 c := &collector{}
+	 stream.Send = c.Send
+ 
+	 err = stream.Orchestrate(ctxb)
+	 require.NoError(t, err)
+	 require.Equal(t, 300, len(c.kv), "Expected 300. Got: %d", len(c.kv))
+ 
+	 m := make(map[string]int)
+	 for _, kv := range c.kv {
+		 prefix, ki := keyToInt(kv.Key)
+		 expected := value(ki)
+		 require.Equal(t, expected, kv.Value)
+		 m[prefix]++
+	 }
+	 require.Equal(t, 3, len(m))
+	 for pred, count := range m {
+		 require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
+	 }
+	 require.NoError(t, db.Close())
+ }
+ 
+ func TestBigStream(t *testing.T) {
+	 if !*manual {
+		 t.Skip("Skipping test meant to be run manually.")
+		 return
+	 }
+	 // Set the maxStreamSize to 1MB for the duration of the test so that the it can use a smaller
+	 // dataset than it would otherwise need.
+	 originalMaxStreamSize := maxStreamSize
+	 maxStreamSize = 1 << 20
+	 defer func() {
+		 maxStreamSize = originalMaxStreamSize
+	 }()
+ 
+	 testSize := int(1e6)
+	 dir, err := os.MkdirTemp("", "badger-big-test")
+	 require.NoError(t, err)
+	 defer removeDir(dir)
+ 
+	 db, err := OpenManaged(DefaultOptions(dir))
+	 require.NoError(t, err)
+ 
+	 var count int
+	 wb := db.NewWriteBatchAt(5)
+	 for _, prefix := range []string{"p0", "p1", "p2"} {
+		 for i := 1; i <= testSize; i++ {
+			 require.NoError(t, wb.SetEntry(NewEntry(keyWithPrefix(prefix, i), value(i))))
+			 count++
+		 }
+	 }
+	 require.NoError(t, wb.Flush())
+ 
+	 stream := db.NewStreamAt(math.MaxUint64)
+	 stream.LogPrefix = "Testing"
+	 c := &collector{}
+	 stream.Send = c.Send
+ 
+	 // Test case 1. Retrieve everything.
+	 err = stream.Orchestrate(ctxb)
+	 require.NoError(t, err)
+	 require.Equal(t, 3*testSize, len(c.kv), "Expected 30000. Got: %d", len(c.kv))
+ 
+	 m := make(map[string]int)
+	 for _, kv := range c.kv {
+		 prefix, ki := keyToInt(kv.Key)
+		 expected := value(ki)
+		 require.Equal(t, expected, kv.Value)
+		 m[prefix]++
+	 }
+	 require.Equal(t, 3, len(m))
+	 for pred, count := range m {
+		 require.Equal(t, testSize, count, "Count mismatch for pred: %s", pred)
+	 }
+	 require.NoError(t, db.Close())
+ }
+ 
+ // There was a bug in the stream writer code which would cause allocators to be
+ // freed up twice if the default keyToList was not used. This test verifies that issue.
+ func TestStreamCustomKeyToList(t *testing.T) {
+	 dir, err := os.MkdirTemp("", "badger-test")
+	 require.NoError(t, err)
+	 defer removeDir(dir)
+ 
+	 db, err := OpenManaged(DefaultOptions(dir))
+	 require.NoError(t, err)
+ 
+	 var count int
+	 for _, key := range []string{"p0", "p1", "p2"} {
+		 for i := 1; i <= 100; i++ {
+			 txn := db.NewTransactionAt(math.MaxUint64, true)
+			 require.NoError(t, txn.SetEntry(NewEntry([]byte(key), value(i))))
+			 count++
+			 require.NoError(t, txn.CommitAt(uint64(i), nil))
+		 }
+	 }
+ 
+	 stream := db.NewStreamAt(math.MaxUint64)
+	 stream.LogPrefix = "Testing"
+	 stream.KeyToList = func(key []byte, itr *Iterator) (*bpb.KVList, error) {
+		 item := itr.Item()
+		 val, err := item.ValueCopy(nil)
+		 if err != nil {
+			 return nil, err
+		 }
+		 kv := &bpb.KV{
+			 Key:   y.Copy(item.Key()),
+			 Value: val,
+		 }
+		 return &bpb.KVList{
+			 Kv: []*bpb.KV{kv},
+		 }, nil
+	 }
+	 res := map[string]struct{}{"p0": {}, "p1": {}, "p2": {}}
+	 stream.Send = func(buf *z.Buffer) error {
+		 list, err := BufferToKVList(buf)
+		 require.NoError(t, err)
+		 for _, kv := range list.Kv {
+			 key := string(kv.Key)
+			 if _, ok := res[key]; !ok {
+				 panic(fmt.Sprintf("%s key not found", key))
+			 }
+			 delete(res, key)
+		 }
+		 return nil
+	 }
+	 require.NoError(t, stream.Orchestrate(ctxb))
+	 require.Zero(t, len(res))
+ }
+ 


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
I'm trying to read the data using badger and use grpc for node sync, but I can't change the max cut size of stream because it's restricted hardcode
```go
// maxStreamSize is the maximum allowed size of a stream batch. This is a soft limit
// as a single list that is still over the limit will have to be sent as is since it
// cannot be split further. This limit prevents the framework from creating batches
// so big that sending them causes issues (e.g running into the max size gRPC limit).
var maxStreamSize = uint64(100 << 20) // 100MB
```
## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
Add a property to Stream to allow custom slice size
```go
type Stream struct {
	// Prefix to only iterate over certain range of keys. If set to nil (default), Stream would
	// iterate over the entire DB.
	Prefix []byte

	// Number of goroutines to use for iterating over key ranges. Defaults to 8.
	NumGo int

	// Badger would produce log entries in Infof to indicate the progress of Stream. LogPrefix can
	// be used to help differentiate them from other activities. Default is "Badger.Stream".
	LogPrefix string

	// ChooseKey is invoked each time a new key is encountered. Note that this is not called
	// on every version of the value, only the first encountered version (i.e. the highest version
	// of the value a key has). ChooseKey can be left nil to select all keys.
	//
	// Note: Calls to ChooseKey are concurrent.
	ChooseKey func(item *Item) bool

	// MaxSize is the maximum allowed size of a stream batch
	MaxSize uint64
}
```