### PR TITLE
fix(info): print Total BloomFilter Size with totalBloomFilter instead of totalIndex

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -305,7 +305,7 @@ func tableInfo(dir, valueDir string, db *badger.DB) {
 	}
 	fmt.Println()
 	fmt.Printf("Total Index Size: %s\n", hbytes(int64(totalIndex)))
-	fmt.Printf("Total BloomFilter Size: %s\n", hbytes(int64(totalIndex)))
+	fmt.Printf("Total BloomFilter Size: %s\n", hbytes(int64(totalBloomFilter)))
 	fmt.Printf("Mean Compression Ratio: %.2f\n", totalCompressionRatio/float64(len(tables)))
 	fmt.Println()
 }


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

print Total BloomFilter Size with totalBloomFilter instead of totalIndex
Fixes #2144

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->

print Total BloomFilter Size with totalBloomFilter instead of totalIndex