### PR TITLE
chore: configure renovate to leave go version as declared

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>hypermodeinc/renovate-config"],
-  "rangeStrategy": "widen"
+  "rangeStrategy": "widen",
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "enabled": false
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 ![Badger mascot](images/diggy-shadow.png)
 
 BadgerDB is an embeddable, persistent and fast key-value (KV) database written in pure Go. It is the
-underlying database for [Dgraph](https://github.com/hypermodeinc/dgraph), a fast, distributed graph database. It's meant
-to be a performant alternative to non-Go-based key-value stores like RocksDB.
+underlying database for [Dgraph](https://github.com/hypermodeinc/dgraph), a fast, distributed graph
+database. It's meant to be a performant alternative to non-Go-based key-value stores like RocksDB.
 
 ## Project Status
 
@@ -25,6 +25,9 @@ Jaeger Tracing, UsenetExpress, and many more.
 The list of projects using Badger can be found [here](#projects-using-badger).
 
 Please consult the [Changelog] for more detailed information on releases.
+
+Note: Badger is built with go 1.23 and we refrain from bumping this version to minimize downstream
+effects of those using Badger in applications built with older versions of Go.
 
 [Changelog]: https://github.com/hypermodeinc/badger/blob/main/CHANGELOG.md
 
@@ -51,7 +54,7 @@ Please consult the [Changelog] for more detailed information on releases.
 
 ### Installing
 
-To start using Badger, install Go 1.21 or above. Badger v3 and above needs go modules. From your
+To start using Badger, install Go 1.23 or above. Badger v3 and above needs go modules. From your
 project, run the following command
 
 ```sh
@@ -244,8 +247,8 @@ Below is a list of known projects that use Badger:
 - [MightyMap](https://github.com/thisisdevelopment/mightymap) - Mightymap: Conveys both robustness
   and high capability, fitting for a powerful concurrent map.
 - [FlowG](https://github.com/link-society/flowg) - A low-code log processing facility
-- [Bluefin](https://github.com/blinklabs-io/bluefin) - Bluefin is a TUNA Proof of Work miner for
-  the Fortuna smart contract on the Cardano blockchain
+- [Bluefin](https://github.com/blinklabs-io/bluefin) - Bluefin is a TUNA Proof of Work miner for the
+  Fortuna smart contract on the Cardano blockchain
 - [cDNSd](https://github.com/blinklabs-io/cdnsd) - A Cardano blockchain backed DNS server daemon
 - [Dingo](https://github.com/blinklabs-io/dingo) - A Cardano blockchain data node
 
@@ -258,6 +261,6 @@ If you're interested in contributing to Badger see [CONTRIBUTING](./CONTRIBUTING
 ## Contact
 
 - Please use [Github issues](https://github.com/hypermodeinc/badger/issues) for filing bugs.
-- Please use [discuss.hypermode.com](https://discuss.hypermode.com) for questions, discussions, and feature
-  requests.
+- Please use [discuss.hypermode.com](https://discuss.hypermode.com) for questions, discussions, and
+  feature requests.
 - Follow us on Twitter [@hypermodeinc](https://twitter.com/hypermodeinc).


### PR DESCRIPTION
**Description**

This PR prevents the renovate bot from bumping the go version we aim to support, which is 1.23 for now.
