### PR TITLE
chore(ci): restrict Dgraph test to core packages only

### DIFF
--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -64,7 +64,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          cd t; ./t
+          cd t; ./t --pkg=edgraph,posting,worker,query
           # clean up docker containers after test execution
           ./t -r
           # sleep


### PR DESCRIPTION
**Description**

This PR restricts the Dgraph CI workflow to only check core Dgraph packages. The intent of this CI workflow is to immediately identify badger@main compatibility issues with the main branch of Dgraph. Running the entire Dgraph test suite is overkill -- this should immediately find any badger incompatibilities with Dgraph.