### PR TITLE
fix(y): shall always return empty slice rather than nil

### DIFF
--- a/y/y.go
+++ b/y/y.go
@@ -106,7 +106,11 @@ func OpenTruncFile(filename string, sync bool) (*os.File, error) {
 
 // SafeCopy does append(a[:0], src...).
 func SafeCopy(a, src []byte) []byte {
-	return append(a[:0], src...)
+	b := append(a[:0], src...)
+	if b == nil {
+		return []byte{}
+	}
+	return b
 }
 
 // Copy copies a byte slice and returns the copied slice.


### PR DESCRIPTION
Fixes #2067

**Description**

Fixes #2067

This PR fixes an issue where Go's `append` returns `nil` when appending an empty slice to a nil slice. 
I added a check in `SafeCopy` to ensure we always return `[]byte{}` in this case, along with a new unit test.
I've also run the test offered in the issue.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

**Instructions**

- The PR title should follow the [Conventional Commits](https://www.conventionalcommits.org/)
  syntax, leading with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- The description should briefly explain what the PR is about. In the case of a bugfix, describe or
  link to the bug.
- In the checklist section, check the boxes in that are applicable, using `[x]` syntax.
  - If not applicable, remove the entire line. Only leave the box unchecked if you intend to come
    back and check the box later.
- Delete the `Instructions` line and everything below it, to indicate you have read and are
  following these instructions. 🙂

Thank you for your contribution to Badger!
