### PR TITLE
fix: correct the comment on value size in skl.node

### DIFF
--- a/skl/skl.go
+++ b/skl/skl.go
@@ -42,7 +42,7 @@ type node struct {
 	// Multiple parts of the value are encoded as a single uint64 so that it
 	// can be atomically loaded and stored:
 	//   value offset: uint32 (bits 0-31)
-	//   value size  : uint16 (bits 32-63)
+	//   value size  : uint32 (bits 32-63)
 	value atomic.Uint64
 
 	// A byte slice is 24 bytes. We are trying to save space here.


### PR DESCRIPTION
**Description**

Correct an incorrect comment on the value size in skl.node.

Background: the PR https://github.com/dgraph-io/badger/pull/880 changed the value size from uint16 to uint32, but the did not update the comment.

**Checklist**

- [X] Code compiles correctly and linting passes locally
- [X] Tests added for new functionality, or regression tests for bug fixes added as applicable

