### PR TITLE
feat(cmd): add max-levels and memtable-size configuration options

### DIFF
--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -44,6 +44,7 @@ func init() {
 func doBackup(cmd *cobra.Command, args []string) error {
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
+		WithMaxLevels(vMaxLevels).
 		WithNumVersionsToKeep(math.MaxInt32)
 
 	if bo.numVersions > 0 {

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -40,6 +40,9 @@ type flagOptions struct {
 	checksumVerificationMode string
 	discard                  bool
 	externalMagicVersion     uint16
+
+	maxLevels int
+	memTableSize int64
 }
 
 var (
@@ -73,6 +76,10 @@ func init() {
 		"Parse and print DISCARD file from value logs.")
 	infoCmd.Flags().Uint16Var(&opt.externalMagicVersion, "external-magic", 0,
 		"External magic number")
+	infoCmd.Flags().IntVar(&opt.maxLevels, "max-levels", 7,
+		"Maximum number of levels in the LSM tree")
+	infoCmd.Flags().Int64Var(&opt.memTableSize, "memtable-size", 128<<20,
+		"Size of memtable in bytes.")
 }
 
 var infoCmd = &cobra.Command{
@@ -92,6 +99,8 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 	bopt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
 		WithReadOnly(opt.readOnly).
+		WithMaxLevels(opt.maxLevels).
+		WithMemTableSize(opt.memTableSize).
 		WithBlockCacheSize(100 << 20).
 		WithIndexCacheSize(200 << 20).
 		WithEncryptionKey([]byte(opt.encryptionKey)).

--- a/badger/cmd/root.go
+++ b/badger/cmd/root.go
@@ -16,6 +16,8 @@ import (
 
 var sstDir, vlogDir string
 
+var vMaxLevels int
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:               "badger",
@@ -38,6 +40,9 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&vlogDir, "vlog-dir", "",
 		"Directory where the value log files are located, if different from --dir")
+
+	RootCmd.PersistentFlags().IntVar(&vMaxLevels, "max-levels", 7, 
+		"Maximum number of levels in the LSM tree")
 }
 
 func validateRootCmdArgs(cmd *cobra.Command, args []string) error {
@@ -49,6 +54,10 @@ func validateRootCmdArgs(cmd *cobra.Command, args []string) error {
 	}
 	if vlogDir == "" {
 		vlogDir = sstDir
+	}
+
+	if vMaxLevels < 1 {
+		return errors.New("--max-levels should be at least 1")
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

Add support for configuring the maximum number of levels in the LSM tree and the size of the memtable through command-line flags. The max-levels flag is now available as a persistent flag for the root command and as a specific flag for the info command, while the memtable-size flag is available for the info command.

Validation has been added to ensure the max-levels value is at least 1.

**Checklist**

- [ ] Code compiles correctly and linting passes locally
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
