### PR TITLE
fix: Handle and ignore ERROR_USER_MAPPED_FILE during WAL truncation

### DIFF
--- a/memtable.go
+++ b/memtable.go
@@ -209,7 +209,14 @@ func (mt *memTable) UpdateSkipList() error {
 	if endOff < mt.wal.size.Load() && mt.opt.ReadOnly {
 		return y.Wrapf(ErrTruncateNeeded, "end offset: %d < size: %d", endOff, mt.wal.size.Load())
 	}
-	return mt.wal.Truncate(int64(endOff))
+	if err := mt.wal.Truncate(int64(endOff)); err != nil {
+		if isUserMappedFileError(err) {
+			mt.opt.Warningf("Skipping WAL truncation for %s: %v", mt.wal.Fd.Name(), err)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // IncrRef increases the refcount

--- a/memtable.go
+++ b/memtable.go
@@ -210,6 +210,10 @@ func (mt *memTable) UpdateSkipList() error {
 		return y.Wrapf(ErrTruncateNeeded, "end offset: %d < size: %d", endOff, mt.wal.size.Load())
 	}
 	if err := mt.wal.Truncate(int64(endOff)); err != nil {
+		// On Windows, truncation fails if another process has the file memory-mapped
+		// (ERROR_USER_MAPPED_FILE). Since the WAL data has already been successfully
+		// replayed into the skiplist, we can safely skip the truncation. The file
+		// will be truncated the next time it is opened without contention.
 		if isUserMappedFileError(err) {
 			mt.opt.Warningf("Skipping WAL truncation for %s: %v", mt.wal.Fd.Name(), err)
 			return nil
@@ -272,12 +276,21 @@ type logFile struct {
 }
 
 func (lf *logFile) Truncate(end int64) error {
-	if fi, err := lf.Fd.Stat(); err != nil {
+	fi, err := lf.Fd.Stat()
+	if err != nil {
 		return fmt.Errorf("while file.stat on file: %s, error: %v\n", lf.Fd.Name(), err)
-	} else if fi.Size() == end {
+	}
+	if fi.Size() == end {
 		return nil
 	}
 	y.AssertTrue(!lf.opt.ReadOnly)
+	// On Windows, MmapFile.Truncate does Munmap→Truncate→Mmap. If the file
+	// truncation fails (e.g. another process has it memory-mapped), the mmap
+	// is left in a broken state. Probe with Fd.Truncate first to fail fast
+	// without disturbing the existing memory mapping.
+	if err := probeFileTruncate(lf.Fd, end); err != nil {
+		return fmt.Errorf("while truncate file: %s, error: %v", lf.Fd.Name(), err)
+	}
 	lf.size.Store(uint32(end))
 	return lf.MmapFile.Truncate(end)
 }

--- a/memtable_other.go
+++ b/memtable_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package badger
+
+func isUserMappedFileError(_ error) bool {
+	return false
+}

--- a/memtable_other.go
+++ b/memtable_other.go
@@ -3,6 +3,12 @@
 
 package badger
 
+import "os"
+
 func isUserMappedFileError(_ error) bool {
 	return false
+}
+
+func probeFileTruncate(_ *os.File, _ int64) error {
+	return nil
 }

--- a/memtable_windows.go
+++ b/memtable_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+// +build windows
+
+package badger
+
+import (
+	"errors"
+	"syscall"
+)
+
+const errnoUserMappedFile = syscall.Errno(1224)
+
+func isUserMappedFileError(err error) bool {
+	return errors.Is(err, errnoUserMappedFile)
+}

--- a/memtable_windows.go
+++ b/memtable_windows.go
@@ -5,11 +5,26 @@ package badger
 
 import (
 	"errors"
+	"os"
+	"strings"
 	"syscall"
 )
 
 const errnoUserMappedFile = syscall.Errno(1224)
 
 func isUserMappedFileError(err error) bool {
-	return errors.Is(err, errnoUserMappedFile)
+	if errors.Is(err, errnoUserMappedFile) {
+		return true
+	}
+	// Fall back to string matching because some dependencies (e.g. ristretto)
+	// wrap errors with fmt.Errorf using %v instead of %w, losing the error chain.
+	return strings.Contains(err.Error(), errnoUserMappedFile.Error())
+}
+
+// probeFileTruncate attempts to truncate the file to detect whether the OS
+// will allow it. On Windows, this fails with ERROR_USER_MAPPED_FILE when
+// another process has the file memory-mapped. By probing before Munmap we
+// avoid leaving the mmap in a broken state.
+func probeFileTruncate(fd *os.File, size int64) error {
+	return fd.Truncate(size)
 }

--- a/memtable_windows_test.go
+++ b/memtable_windows_test.go
@@ -1,0 +1,112 @@
+//go:build windows
+// +build windows
+
+package badger
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mmapFile memory-maps a file on Windows, simulating another process holding
+// the file open. Returns a cleanup function that releases the mapping.
+func mmapFile(t *testing.T, path string) func() {
+	t.Helper()
+	fd, err := os.OpenFile(path, os.O_RDWR, 0666)
+	require.NoError(t, err)
+
+	fi, err := fd.Stat()
+	require.NoError(t, err)
+
+	size := fi.Size()
+	if size == 0 {
+		fd.Close()
+		t.Fatalf("file %s is empty, cannot mmap", path)
+	}
+
+	sizeLo := uint32(size)
+	sizeHi := uint32(size >> 32)
+	h, err := syscall.CreateFileMapping(syscall.Handle(fd.Fd()), nil,
+		syscall.PAGE_READWRITE, sizeHi, sizeLo, nil)
+	require.NoError(t, err)
+
+	addr, err := syscall.MapViewOfFile(h, syscall.FILE_MAP_WRITE, 0, 0, uintptr(size))
+	require.NoError(t, err)
+	syscall.CloseHandle(h)
+
+	return func() {
+		syscall.UnmapViewOfFile(addr)
+		fd.Close()
+	}
+}
+
+// TestOpenWithBypassLockGuardWindows verifies that Open succeeds when another
+// process holds memory-mapped files in the same directory. This is the common
+// scenario when multiple CLI processes share a cache directory with
+// WithBypassLockGuard(true).
+//
+// Without the fix, Open fails with ERROR_USER_MAPPED_FILE (1224) because
+// WAL/vlog truncation cannot operate on files mapped by another process.
+func TestOpenWithBypassLockGuardWindows(t *testing.T) {
+	dir, err := os.MkdirTemp("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	opt := getTestOptions(dir).WithBypassLockGuard(true)
+
+	// Open and write data to create .mem and .vlog files, then close cleanly.
+	db, err := Open(opt)
+	require.NoError(t, err)
+
+	err = db.Update(func(txn *Txn) error {
+		return txn.Set([]byte("key1"), []byte("val1"))
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Find .mem and .vlog files and hold them open via mmap, simulating
+	// another process that has the DB open.
+	var cleanups []func()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		name := e.Name()
+		if filepath.Ext(name) == ".mem" || filepath.Ext(name) == ".vlog" {
+			cleanup := mmapFile(t, filepath.Join(dir, name))
+			cleanups = append(cleanups, cleanup)
+			fmt.Printf("Holding mmap on %s\n", name)
+		}
+	}
+	require.NotEmpty(t, cleanups, "expected .mem or .vlog files to mmap")
+
+	// Re-open the DB while the files are externally memory-mapped.
+	// Without the fix, this fails with ERROR_USER_MAPPED_FILE.
+	db, err = Open(opt)
+	require.NoError(t, err, "Open should succeed even when files are externally mmap'd")
+
+	// Verify we can still read the data.
+	err = db.View(func(txn *Txn) error {
+		item, err := txn.Get([]byte("key1"))
+		if err != nil {
+			return err
+		}
+		val, err := item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, []byte("val1"), val)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Release external mmaps first, then close the DB.
+	for _, cleanup := range cleanups {
+		cleanup()
+	}
+	require.NoError(t, db.Close())
+}

--- a/value.go
+++ b/value.go
@@ -603,6 +603,14 @@ func (vlog *valueLog) open(db *DB) error {
 		return y.Wrapf(err, "while iterating over: %s", last.path)
 	}
 	if err := last.Truncate(int64(lastOff)); err != nil {
+		// On Windows, truncation fails with ERROR_USER_MAPPED_FILE when another
+		// process has the file memory-mapped. Since probeFileTruncate prevents
+		// Munmap from running, the existing mmap remains valid. We skip creating
+		// a new vlog file and continue writing to the current one.
+		if isUserMappedFileError(err) {
+			vlog.opt.Warningf("Skipping vlog truncation for %s: %v", last.path, err)
+			return nil
+		}
 		return y.Wrapf(err, "while truncating last value log file: %s", last.path)
 	}
 
@@ -628,7 +636,12 @@ func (vlog *valueLog) Close() error {
 			offset = int64(vlog.woffset())
 		}
 		if terr := lf.Close(offset); terr != nil && err == nil {
-			err = terr
+			// On Windows, Close may fail to truncate if another process has the
+			// file memory-mapped. The data is already synced, so this is safe to
+			// ignore; the file will be truncated on next open.
+			if !isUserMappedFileError(terr) {
+				err = terr
+			}
 		}
 	}
 	if vlog.discardStats != nil {


### PR DESCRIPTION
**Description**

On Windows, truncation fails if another process has the file memory-mapped
(ERROR_USER_MAPPED_FILE). Since the WAL data has already been successfully replayed into the skiplist, we can safely skip the truncation. The file will be truncated the next time it is opened without contention.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable