### PR TITLE
fix: Prevent NPE on sync with inmemory DB

### DIFF
--- a/db.go
+++ b/db.go
@@ -671,6 +671,11 @@ const (
 // Sync syncs database content to disk. This function provides
 // more control to user to sync data whenever required.
 func (db *DB) Sync() error {
+	if db.opt.InMemory {
+		// InMemory mode does not use WAL/vlog files, so Sync is a no-op.
+		return nil
+	}
+
 	/**
 	Make an attempt to sync both the logs, the active memtable's WAL and the vLog (1847).
 	Cases:

--- a/db_test.go
+++ b/db_test.go
@@ -2161,6 +2161,19 @@ func TestSyncForReadingTheEntriesThatWereSynced(t *testing.T) {
 	}
 }
 
+func TestSyncInMemoryNoError(t *testing.T) {
+	opt := getTestOptions("")
+	opt.InMemory = true
+
+	runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+		err := db.Update(func(txn *Txn) error {
+			return txn.Set([]byte("key"), []byte("value"))
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.Sync())
+	})
+}
+
 func TestForceFlushMemtable(t *testing.T) {
 	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err, "temp dir for badger could not be created")


### PR DESCRIPTION
**Description**

When `Sync` is called on a in memory DB, a null pointer exception happens when storing the wals.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
