### PR TITLE
Fixed nil dereference.

### DIFF
--- a/stream_writer.go
+++ b/stream_writer.go
@@ -273,11 +273,12 @@ func (sw *StreamWriter) Flush() error {
 	if !sw.db.opt.managedTxns {
 		if sw.db.orc != nil {
 			sw.db.orc.Stop()
+
+			if curMax := sw.db.orc.readTs(); curMax >= sw.maxVersion {
+				sw.maxVersion = curMax
+			}
 		}
 
-		if curMax := sw.db.orc.readTs(); curMax >= sw.maxVersion {
-			sw.maxVersion = curMax
-		}
 
 		sw.db.orc = newOracle(sw.db.opt)
 		sw.db.orc.nextTxnTs = sw.maxVersion


### PR DESCRIPTION
Fixed a critical null pointer dereference vulnerability.

After having been compared to a nil value at stream_writer.go:274, pointer '(**sw.db).orc' is passed as implicit 'this' parameter in call to function 'github.com/dgraph-io/badger/v4.oracle.readTs' at stream_writer.go:278, where it is dereferenced at txn.go:79.