### PR TITLE
Feat/atomic create table

### DIFF
--- a/badger/cmd/backup.go
+++ b/badger/cmd/backup.go
@@ -44,7 +44,8 @@ func init() {
 func doBackup(cmd *cobra.Command, args []string) error {
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithNumVersionsToKeep(math.MaxInt32)
+		WithNumVersionsToKeep(math.MaxInt32).
+		WithMaxLevels(vMaxLevels)
 
 	if bo.numVersions > 0 {
 		opt.NumVersionsToKeep = bo.numVersions

--- a/badger/cmd/bank.go
+++ b/badger/cmd/bank.go
@@ -303,7 +303,8 @@ func runDisect(cmd *cobra.Command, args []string) error {
 		WithValueDir(vlogDir).
 		WithReadOnly(true).
 		WithEncryptionKey([]byte(encryptionKey)).
-		WithIndexCacheSize(1 << 30))
+		WithIndexCacheSize(1 << 30).
+		WithMaxLevels(vMaxLevels))
 	if err != nil {
 		return err
 	}
@@ -351,7 +352,8 @@ func runTest(cmd *cobra.Command, args []string) error {
 		// Do not GC any versions, because we need them for the disect.
 		WithNumVersionsToKeep(int(math.MaxInt32)).
 		WithBlockCacheSize(1 << 30).
-		WithIndexCacheSize(1 << 30)
+		WithIndexCacheSize(1 << 30).
+		WithMaxLevels(vMaxLevels)
 
 	if verbose {
 		opts = opts.WithLoggingLevel(badger.DEBUG)
@@ -376,7 +378,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 		dir, err := os.MkdirTemp("", "bank_subscribe")
 		y.Check(err)
 
-		subscribeDB, err = badger.Open(badger.DefaultOptions(dir).WithSyncWrites(false))
+		subscribeDB, err = badger.Open(badger.DefaultOptions(dir).WithSyncWrites(false).WithMaxLevels(vMaxLevels))
 		if err != nil {
 			return err
 		}
@@ -387,7 +389,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 		dir, err := os.MkdirTemp("", "bank_stream")
 		y.Check(err)
 
-		tmpDb, err = badger.Open(badger.DefaultOptions(dir).WithSyncWrites(false))
+		tmpDb, err = badger.Open(badger.DefaultOptions(dir).WithSyncWrites(false).WithMaxLevels(vMaxLevels))
 		if err != nil {
 			return err
 		}

--- a/badger/cmd/cli_test.go
+++ b/badger/cmd/cli_test.go
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+// TestMaxLevelsFlag tests the --max-levels CLI flag
+func TestMaxLevelsFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxLevels   int
+		shouldError bool
+	}{
+		{"max-levels-0", 0, true},
+		{"max-levels-negative", -1, true},
+		{"max-levels-10", 10, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "badger-max-levels-test")
+			require.NoError(t, err)
+			defer os.RemoveAll(dir)
+
+			// Set the vMaxLevels variable to test value
+			oldMaxLevels := vMaxLevels
+			vMaxLevels = tt.maxLevels
+			defer func() { vMaxLevels = oldMaxLevels }()
+
+			sstDir = dir
+			vlogDir = dir
+
+			// Test validation - create a mock cobra command to avoid nil pointer dereference
+			cmd := &cobra.Command{Use: "test"}
+			err = validateRootCmdArgs(cmd, []string{})
+
+			if tt.shouldError {
+				require.Error(t, err, "Expected validation to fail for max-levels=%d", tt.maxLevels)
+				require.Contains(t, err.Error(), "--max-levels should be at least 1")
+			} else {
+				require.NoError(t, err, "Expected validation to pass for max-levels=%d", tt.maxLevels)
+
+				// Test that DB can be opened with the max-levels setting
+				opts := badger.DefaultOptions(dir).WithMaxLevels(vMaxLevels)
+				db, err := badger.Open(opts)
+				require.NoError(t, err)
+				require.NoError(t, db.Close())
+			}
+		})
+	}
+}

--- a/badger/cmd/cli_test.go
+++ b/badger/cmd/cli_test.go
@@ -31,7 +31,11 @@ func TestMaxLevelsFlag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir, err := os.MkdirTemp("", "badger-max-levels-test")
 			require.NoError(t, err)
-			defer os.RemoveAll(dir)
+			defer func() {
+				if err := os.RemoveAll(dir); err != nil {
+					t.Fatalf("Failed to clean up temp directory: %v", err)
+				}
+			}()
 
 			// Set the vMaxLevels variable to test value
 			oldMaxLevels := vMaxLevels

--- a/badger/cmd/flatten.go
+++ b/badger/cmd/flatten.go
@@ -67,7 +67,8 @@ func flatten(cmd *cobra.Command, args []string) error {
 		WithBlockCacheSize(100 << 20).
 		WithIndexCacheSize(200 << 20).
 		WithCompression(options.CompressionType(fo.compressionType)).
-		WithEncryptionKey(encKey)
+		WithEncryptionKey(encKey).
+		WithMaxLevels(vMaxLevels)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.Open(opt)
 	if err != nil {

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -40,6 +40,8 @@ type flagOptions struct {
 	checksumVerificationMode string
 	discard                  bool
 	externalMagicVersion     uint16
+
+	memTableSize int64
 }
 
 var (
@@ -73,6 +75,8 @@ func init() {
 		"Parse and print DISCARD file from value logs.")
 	infoCmd.Flags().Uint16Var(&opt.externalMagicVersion, "external-magic", 0,
 		"External magic number")
+	infoCmd.Flags().Int64Var(&opt.memTableSize, "memtable-size", 128<<20,
+		"Size of memtable in bytes.")
 }
 
 var infoCmd = &cobra.Command{
@@ -96,7 +100,9 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 		WithIndexCacheSize(200 << 20).
 		WithEncryptionKey([]byte(opt.encryptionKey)).
 		WithChecksumVerificationMode(cvMode).
-		WithExternalMagic(opt.externalMagicVersion)
+		WithExternalMagic(opt.externalMagicVersion).
+		WithMemTableSize(opt.memTableSize).
+		WithMaxLevels(vMaxLevels)
 
 	if opt.discard {
 		ds, err := badger.InitDiscardStats(bopt)

--- a/badger/cmd/pick_table_bench.go
+++ b/badger/cmd/pick_table_bench.go
@@ -51,7 +51,8 @@ func init() {
 func pickTableBench(cmd *cobra.Command, args []string) error {
 	opt := badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithReadOnly(pickOpts.readOnly)
+		WithReadOnly(pickOpts.readOnly).
+		WithMaxLevels(vMaxLevels)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.OpenManaged(opt)
 	if err != nil {

--- a/badger/cmd/read_bench.go
+++ b/badger/cmd/read_bench.go
@@ -98,7 +98,8 @@ func readBench(cmd *cobra.Command, args []string) error {
 		WithValueDir(vlogDir).
 		WithReadOnly(ro.readOnly).
 		WithBlockCacheSize(ro.blockCacheSize << 20).
-		WithIndexCacheSize(ro.indexCacheSize << 20)
+		WithIndexCacheSize(ro.indexCacheSize << 20).
+		WithMaxLevels(vMaxLevels)
 	fmt.Printf("Opening badger with options = %+v\n", opt)
 	db, err := badger.OpenManaged(opt)
 	if err != nil {

--- a/badger/cmd/restore.go
+++ b/badger/cmd/restore.go
@@ -58,7 +58,8 @@ func doRestore(cmd *cobra.Command, args []string) error {
 	// Open DB
 	db, err := badger.Open(badger.DefaultOptions(sstDir).
 		WithValueDir(vlogDir).
-		WithNumVersionsToKeep(math.MaxInt32))
+		WithNumVersionsToKeep(math.MaxInt32).
+		WithMaxLevels(vMaxLevels))
 	if err != nil {
 		return err
 	}

--- a/badger/cmd/root.go
+++ b/badger/cmd/root.go
@@ -16,6 +16,8 @@ import (
 
 var sstDir, vlogDir string
 
+var vMaxLevels int
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:               "badger",
@@ -38,6 +40,9 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&vlogDir, "vlog-dir", "",
 		"Directory where the value log files are located, if different from --dir")
+
+	RootCmd.PersistentFlags().IntVar(&vMaxLevels, "max-levels", 7, 
+		"Maximum number of levels in the LSM tree")
 }
 
 func validateRootCmdArgs(cmd *cobra.Command, args []string) error {
@@ -49,6 +54,10 @@ func validateRootCmdArgs(cmd *cobra.Command, args []string) error {
 	}
 	if vlogDir == "" {
 		vlogDir = sstDir
+	}
+
+	if vMaxLevels < 1 {
+		return errors.New("--max-levels should be at least 1")
 	}
 	return nil
 }

--- a/badger/cmd/root.go
+++ b/badger/cmd/root.go
@@ -41,7 +41,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&vlogDir, "vlog-dir", "",
 		"Directory where the value log files are located, if different from --dir")
 
-	RootCmd.PersistentFlags().IntVar(&vMaxLevels, "max-levels", 7, 
+	RootCmd.PersistentFlags().IntVar(&vMaxLevels, "max-levels", 7,
 		"Maximum number of levels in the LSM tree")
 }
 

--- a/badger/cmd/stream.go
+++ b/badger/cmd/stream.go
@@ -71,7 +71,8 @@ func stream(cmd *cobra.Command, args []string) error {
 		WithNumVersionsToKeep(so.numVersions).
 		WithBlockCacheSize(100 << 20).
 		WithIndexCacheSize(200 << 20).
-		WithEncryptionKey(encKey)
+		WithEncryptionKey(encKey).
+		WithMaxLevels(vMaxLevels)
 
 	// Options for output DB.
 	if so.compressionType > 2 {

--- a/badger/cmd/write_bench.go
+++ b/badger/cmd/write_bench.go
@@ -264,7 +264,8 @@ func writeBench(cmd *cobra.Command, args []string) error {
 		WithValueLogMaxEntries(wo.vlogMaxEntries).
 		WithEncryptionKey([]byte(wo.encryptionKey)).
 		WithDetectConflicts(wo.detectConflicts).
-		WithLoggingLevel(badger.INFO)
+		WithLoggingLevel(badger.INFO).
+		WithMaxLevels(vMaxLevels)
 	if wo.zstdComp {
 		opt = opt.WithCompression(options.ZSTD)
 	}

--- a/levels.go
+++ b/levels.go
@@ -1477,7 +1477,7 @@ func (s *levelsController) runCompactDef(id, l int, cd compactDef) (err error) {
 			expensive = " [E]"
 		}
 		s.kv.opt.Infof("[%d]%s LOG Compact %d->%d (%d, %d -> %d tables with %d splits)."+
-			" [%s] -> [%s], took %v\n, deleted %d bytes",
+			" [%s] -> [%s], took %v, deleted %d bytes\n",
 			id, expensive, thisLevel.level, nextLevel.level, len(cd.top), len(cd.bot),
 			len(newTables), len(cd.splits), strings.Join(from, " "), strings.Join(to, " "),
 			dur.Round(time.Millisecond), sizeOldTables-sizeNewTables)

--- a/table/table.go
+++ b/table/table.go
@@ -258,7 +258,65 @@ func CreateTable(fname string, builder *Builder) (*Table, error) {
 	if err := z.Msync(mf.Data); err != nil {
 		return nil, y.Wrapf(err, "while calling msync on %s", fname)
 	}
+
+	// Validate the footer written to the mmap before opening. This diagnostic
+	// check detects corruption introduced during bd.Copy by verifying that the
+	// checksum length and index length in the file footer are sane relative to
+	// the file size. If they are not, the table is corrupt and we return an
+	// error rather than panicking in initIndex.
+	if err := validateFooter(mf.Data, fname); err != nil {
+		mf.Close(-1)
+		// Remove the corrupt file so it doesn't linger on disk.
+		os.Remove(fname)
+		return nil, err
+	}
+
 	return OpenTable(mf, *builder.opts)
+}
+
+// validateFooter performs a sanity check on the table footer stored in data.
+// The footer layout is: [index | indexLen(4B) | checksum | checksumLen(4B)].
+// Returns an error if the encoded lengths are inconsistent with the file size.
+func validateFooter(data []byte, fname string) error {
+	sz := len(data)
+	if sz < 8 {
+		return errors.Errorf("table %s too small (%d bytes) to contain a valid footer", fname, sz)
+	}
+
+	checksumLen := int(y.BytesToU32(data[sz-4 : sz]))
+	if checksumLen < 0 || checksumLen > sz-8 {
+		return errors.Errorf(
+			"FOOTER_CORRUPTION: table %s (size %d): invalid checksumLen %d."+
+				" Footer bytes (last 16): [% x]",
+			fname, sz, checksumLen, tailBytes(data, 16))
+	}
+
+	indexLenOffset := sz - 4 - checksumLen - 4
+	if indexLenOffset < 0 || indexLenOffset+4 > sz {
+		return errors.Errorf(
+			"FOOTER_CORRUPTION: table %s (size %d): checksumLen %d produces"+
+				" out-of-bounds indexLen offset %d. Footer bytes (last 16): [% x]",
+			fname, sz, checksumLen, indexLenOffset, tailBytes(data, 16))
+	}
+
+	indexLen := int(y.BytesToU32(data[indexLenOffset : indexLenOffset+4]))
+	indexStart := indexLenOffset - indexLen
+	if indexLen < 0 || indexStart < 0 {
+		return errors.Errorf(
+			"FOOTER_CORRUPTION: table %s (size %d): invalid indexLen %d"+
+				" (checksumLen %d, indexStart %d). Footer bytes (last 16): [% x]",
+			fname, sz, indexLen, checksumLen, indexStart, tailBytes(data, 16))
+	}
+
+	return nil
+}
+
+// tailBytes returns the last n bytes of data, or all of data if len(data) < n.
+func tailBytes(data []byte, n int) []byte {
+	if len(data) < n {
+		return data
+	}
+	return data[len(data)-n:]
 }
 
 // OpenTable assumes file has only one table and opens it. Takes ownership of fd upon function
@@ -426,6 +484,11 @@ func (t *Table) initIndex() (*fb.BlockOffset, error) {
 	if checksumLen < 0 {
 		return nil, errors.New("checksum length less than zero. Data corrupted")
 	}
+	if checksumLen > t.tableSize-8 {
+		return nil, errors.Errorf(
+			"checksum length %d exceeds table size %d. Data corrupted. File: %s",
+			checksumLen, t.tableSize, t.Filename())
+	}
 
 	// Read checksum.
 	expectedChk := &pb.Checksum{}
@@ -437,8 +500,18 @@ func (t *Table) initIndex() (*fb.BlockOffset, error) {
 
 	// Read index size from the footer.
 	readPos -= 4
+	if readPos < 0 {
+		return nil, errors.Errorf(
+			"readPos underflow after checksum (checksumLen=%d, tableSize=%d). File: %s",
+			checksumLen, t.tableSize, t.Filename())
+	}
 	buf = t.readNoFail(readPos, 4)
 	t.indexLen = int(y.BytesToU32(buf))
+	if t.indexLen < 0 || t.indexLen > readPos {
+		return nil, errors.Errorf(
+			"invalid index length %d (readPos=%d, tableSize=%d). Data corrupted. File: %s",
+			t.indexLen, readPos, t.tableSize, t.Filename())
+	}
 
 	// Read index.
 	readPos -= t.indexLen

--- a/table/table.go
+++ b/table/table.go
@@ -244,33 +244,62 @@ func (b *Block) verifyCheckSum() error {
 
 func CreateTable(fname string, builder *Builder) (*Table, error) {
 	bd := builder.Done()
-	mf, err := z.OpenMmapFile(fname, os.O_CREATE|os.O_RDWR|os.O_EXCL, bd.Size)
+
+	// Write to a temporary file first, then atomically rename to the final
+	// path. This prevents a crash between file creation and msync from
+	// leaving a corrupt .sst file that badger would try to open on restart.
+	tmpName := fname + ".tmp"
+	mf, err := z.OpenMmapFile(tmpName, os.O_CREATE|os.O_RDWR|os.O_TRUNC, bd.Size)
 	if err == z.NewFile {
 		// Expected.
 	} else if err != nil {
-		return nil, y.Wrapf(err, "while creating table: %s", fname)
-	} else {
-		return nil, fmt.Errorf("file already exists: %s", fname)
+		return nil, y.Wrapf(err, "while creating temp table: %s", tmpName)
 	}
 
 	written := bd.Copy(mf.Data)
 	y.AssertTrue(written == len(mf.Data))
 	if err := z.Msync(mf.Data); err != nil {
-		return nil, y.Wrapf(err, "while calling msync on %s", fname)
+		mf.Close(-1)
+		os.Remove(tmpName)
+		return nil, y.Wrapf(err, "while calling msync on %s", tmpName)
 	}
 
-	// Validate the footer written to the mmap before opening. This diagnostic
-	// check detects corruption introduced during bd.Copy by verifying that the
-	// checksum length and index length in the file footer are sane relative to
-	// the file size. If they are not, the table is corrupt and we return an
-	// error rather than panicking in initIndex.
-	if err := validateFooter(mf.Data, fname); err != nil {
+	// Validate the footer written to the mmap before committing. This
+	// diagnostic check detects corruption introduced during bd.Copy by
+	// verifying that the checksum length and index length in the file footer
+	// are sane relative to the file size.
+	if err := validateFooter(mf.Data, tmpName); err != nil {
 		mf.Close(-1)
-		// Remove the corrupt file so it doesn't linger on disk.
-		os.Remove(fname)
+		os.Remove(tmpName)
 		return nil, err
 	}
 
+	// Flush file metadata to durable storage before renaming.
+	if err := mf.Fd.Sync(); err != nil {
+		mf.Close(-1)
+		os.Remove(tmpName)
+		return nil, y.Wrapf(err, "while calling fdatasync on %s", tmpName)
+	}
+
+	// Close the temp mmap before rename so we can reopen at the final path.
+	if err := mf.Close(-1); err != nil {
+		os.Remove(tmpName)
+		return nil, y.Wrapf(err, "while closing temp table: %s", tmpName)
+	}
+
+	// Atomic rename — on Linux this is guaranteed atomic within the same
+	// directory/filesystem. After this point, fname is either fully valid
+	// or absent.
+	if err := os.Rename(tmpName, fname); err != nil {
+		os.Remove(tmpName)
+		return nil, y.Wrapf(err, "while renaming temp table %s to %s", tmpName, fname)
+	}
+
+	// Reopen the table at its final path.
+	mf, err = z.OpenMmapFile(fname, os.O_RDWR, bd.Size)
+	if err != nil {
+		return nil, y.Wrapf(err, "while reopening table: %s", fname)
+	}
 	return OpenTable(mf, *builder.opts)
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -280,12 +280,12 @@ func CreateTable(fname string, builder *Builder) (*Table, error) {
 func validateFooter(data []byte, fname string) error {
 	sz := len(data)
 	if sz < 8 {
-		return errors.Errorf("table %s too small (%d bytes) to contain a valid footer", fname, sz)
+		return fmt.Errorf("table %s too small (%d bytes) to contain a valid footer", fname, sz)
 	}
 
 	checksumLen := int(y.BytesToU32(data[sz-4 : sz]))
 	if checksumLen < 0 || checksumLen > sz-8 {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"FOOTER_CORRUPTION: table %s (size %d): invalid checksumLen %d."+
 				" Footer bytes (last 16): [% x]",
 			fname, sz, checksumLen, tailBytes(data, 16))
@@ -293,7 +293,7 @@ func validateFooter(data []byte, fname string) error {
 
 	indexLenOffset := sz - 4 - checksumLen - 4
 	if indexLenOffset < 0 || indexLenOffset+4 > sz {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"FOOTER_CORRUPTION: table %s (size %d): checksumLen %d produces"+
 				" out-of-bounds indexLen offset %d. Footer bytes (last 16): [% x]",
 			fname, sz, checksumLen, indexLenOffset, tailBytes(data, 16))
@@ -302,7 +302,7 @@ func validateFooter(data []byte, fname string) error {
 	indexLen := int(y.BytesToU32(data[indexLenOffset : indexLenOffset+4]))
 	indexStart := indexLenOffset - indexLen
 	if indexLen < 0 || indexStart < 0 {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"FOOTER_CORRUPTION: table %s (size %d): invalid indexLen %d"+
 				" (checksumLen %d, indexStart %d). Footer bytes (last 16): [% x]",
 			fname, sz, indexLen, checksumLen, indexStart, tailBytes(data, 16))
@@ -485,7 +485,7 @@ func (t *Table) initIndex() (*fb.BlockOffset, error) {
 		return nil, errors.New("checksum length less than zero. Data corrupted")
 	}
 	if checksumLen > t.tableSize-8 {
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"checksum length %d exceeds table size %d. Data corrupted. File: %s",
 			checksumLen, t.tableSize, t.Filename())
 	}
@@ -501,14 +501,14 @@ func (t *Table) initIndex() (*fb.BlockOffset, error) {
 	// Read index size from the footer.
 	readPos -= 4
 	if readPos < 0 {
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"readPos underflow after checksum (checksumLen=%d, tableSize=%d). File: %s",
 			checksumLen, t.tableSize, t.Filename())
 	}
 	buf = t.readNoFail(readPos, 4)
 	t.indexLen = int(y.BytesToU32(buf))
 	if t.indexLen < 0 || t.indexLen > readPos {
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"invalid index length %d (readPos=%d, tableSize=%d). Data corrupted. File: %s",
 			t.indexLen, readPos, t.tableSize, t.Filename())
 	}


### PR DESCRIPTION
## Problem
Should something interpupt the CreateTable function between `OpenMmapFile` and `msync`, SST files can be left in an indeterminate state.  This crash window can be significant as `bd.Copy` is moving significant amounts of data. Because these are memory mapped files, error handling is more opaque than direct IO. Upon startup, or recovery, this corrupt SST can then be read  causing further panics.

## Solution

### CreateTable Uses Write-to-Temp-Then-Rename Pattern

This shrinks the crash window and is defense-in-depth. It prevents a corruption between the time `OpenMmapFile` is called and `Msync` completes. 

1. Opens the mmap at `fname + ".tmp"` (using `O_TRUNC` instead of `O_EXCL` so retries after a prior crash clean up the old temp file)
2. `bd.Copy` → `Msync` → `validateFooter` — same as before, but on the temp file
3. `Fd.Sync()` — flushes file metadata to durable storage
4. `mf.Close(-1)` — unmaps and closes the temp file
5. `os.Rename` — atomic commit point; `fname` is either fully valid or absent
6. Reopens the file at the final path for `OpenTable`

Each error path cleans up the temp file. If the process crashes at any point before the rename, only a `.tmp` file exists — badger won't try to load it on restart.