### PR TITLE
fix : read only user should be able to open db on ReadOnly mode

### DIFF
--- a/db.go
+++ b/db.go
@@ -538,7 +538,7 @@ func (db *DB) close() (err error) {
 	db.blockWrites.Store(1)
 	db.isClosed.Store(1)
 
-	if !db.opt.InMemory {
+	if !db.opt.InMemory && !db.opt.ReadOnly {
 		// Stop value GC first.
 		db.closers.valueGC.SignalAndWait()
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -1742,8 +1742,6 @@ func TestTestSequence2(t *testing.T) {
 }
 
 func TestReadOnly(t *testing.T) {
-	t.Skipf("TODO: ReadOnly needs truncation, so this fails")
-
 	dir, err := os.MkdirTemp("", "badger-test")
 	require.NoError(t, err)
 	defer removeDir(dir)

--- a/value.go
+++ b/value.go
@@ -540,6 +540,10 @@ func (vlog *valueLog) init(db *DB) {
 	}
 	vlog.dirPath = vlog.opt.ValueDir
 
+	if vlog.opt.ReadOnly {
+		return
+	}
+
 	vlog.garbageCh = make(chan struct{}, 1) // Only allow one GC at a time.
 	lf, err := InitDiscardStats(vlog.opt)
 	y.Check(err)
@@ -573,7 +577,11 @@ func (vlog *valueLog) open(db *DB) error {
 
 		// Just open in RDWR mode. This should not create a new log file.
 		lf.opt = vlog.opt
-		if err := lf.open(vlog.fpath(fid), os.O_RDWR,
+		flags := os.O_RDWR
+		if vlog.opt.ReadOnly {
+			flags = os.O_RDONLY
+		}
+		if err := lf.open(vlog.fpath(fid), flags,
 			2*vlog.opt.ValueLogFileSize); err != nil {
 			return y.Wrapf(err, "Open existing file: %q", lf.path)
 		}

--- a/value.go
+++ b/value.go
@@ -575,7 +575,6 @@ func (vlog *valueLog) open(db *DB) error {
 		lf, ok := vlog.filesMap[fid]
 		y.AssertTrue(ok)
 
-		// Just open in RDWR mode. This should not create a new log file.
 		lf.opt = vlog.opt
 		flags := os.O_RDWR
 		if vlog.opt.ReadOnly {
@@ -586,7 +585,7 @@ func (vlog *valueLog) open(db *DB) error {
 			return y.Wrapf(err, "Open existing file: %q", lf.path)
 		}
 		// We shouldn't delete the maxFid file.
-		if lf.size.Load() == vlogHeaderSize && fid != vlog.maxFid {
+		if lf.size.Load() == vlogHeaderSize && fid != vlog.maxFid && !vlog.opt.ReadOnly {
 			vlog.opt.Infof("Deleting empty file: %s", lf.path)
 			if err := lf.Delete(); err != nil {
 				return y.Wrapf(err, "while trying to delete empty file: %s", lf.path)


### PR DESCRIPTION
**Description**

Trying to fix #2234 
Help appreciated :smile: 
Step to reproduce : 
- Open a db and fill it with some data
- run `chmod -w ./db/*`
- Open it again in `WithReadOnly` mode

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

