### PR TITLE
fix(cd): upload build artifacts to GitHub Release

### DIFF
--- a/.github/workflows/cd-badger.yml
+++ b/.github/workflows/cd-badger.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   badger-build-amd64:
@@ -95,3 +95,25 @@ jobs:
           path: |
             badger/badger-checksum-linux-arm64.sha256
             badger/badger-linux-arm64.tar.gz
+
+  upload-to-release:
+    runs-on: ubuntu-latest
+    needs: [badger-build-amd64, badger-build-arm64]
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: List downloaded artifacts
+        run: ls -alR artifacts/
+      - name: Upload assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.inputs.releasetag }}" \
+            artifacts/badger-linux-amd64.tar.gz \
+            artifacts/badger-checksum-linux-amd64.sha256 \
+            artifacts/badger-linux-arm64.tar.gz \
+            artifacts/badger-checksum-linux-arm64.sha256 \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -1,6 +1,7 @@
 name: ci-badger-bank-tests
 
 on:
+  workflow_dispatch: # allows manual trigger from GitHub
   pull_request:
     paths-ignore:
       - "**.md"

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -1,6 +1,7 @@
 name: ci-badger-tests
 
 on:
+  workflow_dispatch: # allows manual trigger from GitHub
   pull_request:
     paths-ignore:
       - "**.md"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -22,7 +22,7 @@ lint:
         - pb/*.pb.go
   enabled:
     - golangci-lint2@2.4.0
-    - trivy@0.64.1
+    - trivy@0.69.3
     - renovate@41.76.0
     - actionlint@1.7.7
     - checkov@3.2.461

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [4.9.1] - 2026-02-04
+
+**Fixed**
+
+- fix(aix): add aix directory synchronization support (#2115)
+- fix: correct the comment on value size in skl.node (#2250)
+
+**Tests**
+
+- test: add checksum tests for package y (#2246)
+
+**Chores**
+
+- chore(ci): update arm runner label (#2248)
+
+**Full Changelog**: https://github.com/dgraph-io/badger/compare/v4.9.0...v4.9.1
+
 ## [4.9.0] - 2025-12-15
 
 **Fixed**

--- a/contrib/RELEASE.md
+++ b/contrib/RELEASE.md
@@ -5,7 +5,7 @@ This document outlines the steps needed to build and push a new release of Badge
 1. Have a team member "at-the-ready" with github `writer` access (you'll need them to approve PRs).
 1. Create a new branch (prepare-for-release-vXX.X.X, for instance).
 1. Update dependencies in `go.mod` for Ristretto, if required.
-1. Update the CHANGELOG.md. Sonnet 4.5 does a great job of doing this. Example prompt:
+1. Update the CHANGELOG.md. Opus 4.5 does a great job of doing this. Example prompt:
    `I'm releasing vXX.X.X off the main branch, add a new entry for this release. Conform to the`
    `"Keep a Changelog" format, use past entries as a formatting guide. Run the trunk linter.`
 1. Validate the version does not have storage incompatibilities with the previous version. If so,
@@ -34,7 +34,7 @@ This document outlines the steps needed to build and push a new release of Badge
 1. Splash the "go index" cache to ensure that the latest release is available to the public with:
 
    ```sh
-   go list -m github.com/dgraph-io/badger@vX.X.X
+   go list -m github.com/dgraph-io/badger/v4@vX.X.X
    ```
 
 1. If needed, create a new announcement thread in the


### PR DESCRIPTION
## Summary
- The `cd-badger` workflow was building binaries and uploading them as ephemeral workflow artifacts via `actions/upload-artifact`, but never attaching them to the actual GitHub Release — causing empty release pages (e.g. v4.9.1)
- Adds an `upload-to-release` job that downloads build artifacts and uploads them to the release via `gh release upload`
- Upgrades `permissions.contents` from `read` to `write` to allow release asset uploads

## Test plan
- [ ] Merge and re-run the `cd-badger` workflow with `releasetag: v4.9.1`
- [ ] Verify the four assets (amd64/arm64 tarballs + checksums) appear on the [v4.9.1 release page](https://github.com/dgraph-io/badger/releases/tag/v4.9.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)