### PR TITLE
Allow IteratorOptions/DefaultIteratorOptions to use builder methods just like Options/DefaultOptions

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -384,9 +384,7 @@ method. Iteration happens in byte-wise lexicographical sorting order.
 
 ```go
 err := db.View(func(txn *badger.Txn) error {
-  opts := badger.DefaultIteratorOptions
-  opts.PrefetchSize = 10
-  it := txn.NewIterator(opts)
+  it := txn.NewIterator(badger.DefaultIteratorOptions.WithPrefetchSize(10))
   defer it.Close()
   for it.Rewind(); it.Valid(); it.Next() {
     item := it.Item()
@@ -526,9 +524,7 @@ reads for selected keys during an iteration, by calling `item.Value()` only when
 
 ```go
 err := db.View(func(txn *badger.Txn) error {
-  opts := badger.DefaultIteratorOptions
-  opts.PrefetchValues = false
-  it := txn.NewIterator(opts)
+  it := txn.NewIterator(badger.DefaultIteratorOptions.WithPrefetchValues(false))
   defer it.Close()
   for it.Rewind(); it.Valid(); it.Next() {
     item := it.Item()

--- a/iterator.go
+++ b/iterator.go
@@ -320,6 +320,48 @@ type IteratorOptions struct {
 	SinceTs     uint64 // Only read data that has version > SinceTs.
 }
 
+// WithPrefetchSize returns a new IteratorOptions value with PrefetchSize set to the given value.
+func (opt IteratorOptions) WithPrefetchSize(size int) IteratorOptions {
+	opt.PrefetchSize = size
+	return opt
+}
+
+// WithPrefetchValues returns a new IteratorOptions value with PrefetchValues set to the given value.
+func (opt IteratorOptions) WithPrefetchValues(prefetch bool) IteratorOptions {
+	opt.PrefetchValues = prefetch
+	return opt
+}
+
+// WithReverse returns a new IteratorOptions value with Reverse set to the given value.
+func (opt IteratorOptions) WithReverse(reverse bool) IteratorOptions {
+	opt.Reverse = reverse
+	return opt
+}
+
+// WithAllVersions returns a new IteratorOptions value with AllVersions set to the given value.
+func (opt IteratorOptions) WithAllVersions(all bool) IteratorOptions {
+	opt.AllVersions = all
+	return opt
+}
+
+// WithInternalAccess returns a new IteratorOptions value with InternalAccess set to the given value.
+func (opt IteratorOptions) WithInternalAccess(access bool) IteratorOptions {
+	opt.InternalAccess = access
+	return opt
+}
+
+// WithPrefix returns a new IteratorOptions value with Prefix set to the given prefix.
+func (opt IteratorOptions) WithPrefix(prefix []byte) IteratorOptions {
+	opt.Prefix = prefix
+	return opt
+}
+
+// WithSinceTs returns a new IteratorOptions value with SinceTs set to the given value.
+func (opt IteratorOptions) WithSinceTs(ts uint64) IteratorOptions {
+	opt.SinceTs = ts
+	return opt
+}
+
 func (opt *IteratorOptions) compareToPrefix(key []byte) int {
 	// We should compare key without timestamp. For example key - a[TS] might be > "aa" prefix.
 	key = y.ParseKey(key)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -114,6 +114,25 @@ func TestPickSortTables(t *testing.T) {
 	require.Equal(t, y.ParseKey(filtered[0].Biggest()), []byte("abc"))
 }
 
+func TestIteratorOptionsBuilderMethods(t *testing.T) {
+	opt := DefaultIteratorOptions.
+		WithPrefetchSize(0).
+		WithPrefetchValues(false).
+		WithReverse(true).
+		WithAllVersions(true).
+		WithInternalAccess(true).
+		WithPrefix([]byte("prefix")).
+		WithSinceTs(123)
+
+	require.Equal(t, 0, opt.PrefetchSize)
+	require.False(t, opt.PrefetchValues)
+	require.True(t, opt.Reverse)
+	require.True(t, opt.AllVersions)
+	require.True(t, opt.InternalAccess)
+	require.Equal(t, []byte("prefix"), opt.Prefix)
+	require.Equal(t, uint64(123), opt.SinceTs)
+}
+
 func TestIterateSinceTs(t *testing.T) {
 	bkey := func(i int) []byte {
 		return []byte(fmt.Sprintf("%04d", i))


### PR DESCRIPTION


**Description**

Should close #2224, add builder methods to IteratorOptions : 
- Maintain consistency with Options/DefaultOptions
- Avoid errors when using IteratorOptions (described here #2224)

**Example Usage**

```go
iterator := txn.NewIterator(badger.DefaultIteratorOptions.WithPrefix([]byte("some.prefix.")))
```

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
