### PR TITLE
fix: fix an issue where the compactor causes previously deleted data to reappear

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -385,10 +385,26 @@ func (s *levelsController) levelTargets() targets {
 	for i := len(s.levels) - 1; i > 0; i-- {
 		ltarget := adjust(dbSize)
 		t.targetSz[i] = ltarget
-		if t.baseLevel == 0 && ltarget <= s.kv.opt.BaseLevelSize {
-			t.baseLevel = i
-		}
 		dbSize /= int64(s.kv.opt.LevelSizeMultiplier)
+	}
+
+	// Bring the base level down to the last empty level.
+	t.baseLevel = 1
+	for i := 1; i < len(s.levels)-1; i++ {
+		if s.levels[i].getTotalSize() > 0 {
+			break
+		}
+		t.baseLevel = i
+	}
+
+	// If the base level is empty and the next level size is less than the
+	// target size and less than base level size, pick the next level as the base level.
+	b := t.baseLevel
+	lvl := s.levels
+	baseLevelIsEmpty := lvl[b].getTotalSize() == 0
+	baseLevelIsNotLastLevel := b < len(lvl)-1
+	if baseLevelIsNotLastLevel && baseLevelIsEmpty && lvl[b+1].getTotalSize() < t.targetSz[b+1] && lvl[b+1].getTotalSize() < s.kv.opt.BaseLevelSize {
+		t.baseLevel++
 	}
 
 	tsz := s.kv.opt.BaseTableSize
@@ -407,30 +423,9 @@ func (s *levelsController) levelTargets() targets {
 		}
 	}
 
-	// Bring the base level down to the last empty level.
-	for i := t.baseLevel + 1; i < len(s.levels)-1; i++ {
-		if s.levels[i].getTotalSize() > 0 {
-			break
-		}
-		t.baseLevel = i
-	}
-
-	// If the base level is empty and the next level size is less than the
-	// target size, pick the next level as the base level.
-	b := t.baseLevel
-	lvl := s.levels
-	if b < len(lvl)-1 && lvl[b].getTotalSize() == 0 && lvl[b+1].getTotalSize() < t.targetSz[b+1] {
-		t.baseLevel++
-	}
-
-	// The base level must never be L0. For a very large LSM tree the size loop
-	// above can fail to assign a base level: it only sets baseLevel where
-	// adjust(dbSize) <= BaseLevelSize, and the smallest level it checks (L1)
-	// has dbSize = lastLevelSize / LevelSizeMultiplier^(MaxLevels-2). Once the
-	// last level exceeds that (~1TB with defaults), baseLevel stays 0, and a
-	// non-empty L1 prevents the "bring down" loop from fixing it. Clamp to L1
-	// (the topmost real level) so we never try to compact L0 into itself, which
-	// would otherwise panic in fillTablesL0ToLbase.
+	// The base level must never be L0. The base-level scan above starts at L1, so
+	// baseLevel is already >= 1; this is a defensive guard (added in #2296) against
+	// ever compacting L0 into itself, which would panic in fillTablesL0ToLbase.
 	if t.baseLevel == 0 {
 		t.baseLevel = 1
 	}
@@ -1444,6 +1439,15 @@ func (s *levelsController) runCompactDef(id, l int, cd compactDef) (err error) {
 	if len(cd.t.fileSz) == 0 {
 		return errors.New("Filesizes cannot be zero. Targets are not set")
 	}
+
+	if cd.thisLevel.level == 0 {
+		for i := cd.nextLevel.level - 1; i > 0; i-- {
+			if s.levels[i].getTotalSize() > 0 {
+				return fmt.Errorf("there is a non-empty level %d above base level %d", i, cd.nextLevel.level)
+			}
+		}
+	}
+
 	timeStart := time.Now()
 
 	thisLevel := cd.thisLevel

--- a/levels_test.go
+++ b/levels_test.go
@@ -6,6 +6,7 @@
 package badger
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"math/rand"
@@ -1502,4 +1503,113 @@ func TestLevelTargets(t *testing.T) {
 			require.Equal(t, opt.MaxLevels-3, target.baseLevel)
 		})
 	})
+}
+
+// TestDeletedKeyReappears is an end-to-end regression test for the compaction
+// routing fix in PR #2278. Data is written through real transactions; the
+// compaction steps call runCompactDef directly because doCompact's
+// fillMaxLevelTables skips small/recent tables in a short test. levelTargets()'s
+// baseLevel selection is unit-tested in TestLevelTargets; this test checks the
+// user-visible outcome — a deleted key stays deleted.
+func TestDeletedKeyReappears(t *testing.T) {
+	dir, err := os.MkdirTemp("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	const (
+		baseLevelSz = 16 << 10 // 16 KB
+		baseTableSz = 8 << 10  // 8 KB
+	)
+
+	openDB := func(compactOnClose bool) *DB {
+		opt := getTestOptions(dir).
+			WithNumCompactors(0).
+			WithBaseLevelSize(baseLevelSz).
+			WithBaseTableSize(baseTableSz).
+			WithCompression(options.None). // disable compression so SST sizes are predictable
+			WithValueThreshold(1 << 20)    // keep all values inline — no vlog
+		opt.managedTxns = true
+		opt = opt.WithCompactL0OnClose(compactOnClose)
+		db, err := Open(opt)
+		require.NoError(t, err)
+		return db
+	}
+
+	padVal := bytes.Repeat([]byte("p"), 20<<10) // 20 KB → SST ≈ 25 KB > baseLevelSz
+	fooVal := bytes.Repeat([]byte("f"), 2<<10)  // 2 KB  → SST ≈  7 KB < baseLevelSz
+
+	// Write an expired pad entry; its SST exceeds baseLevelSz, so after close L6
+	// is large enough that levelTargets() returns baseLevel=5 on reopen.
+	db := openDB(true)
+	padEntry := NewEntry([]byte("pad"), padVal)
+	padEntry.ExpiresAt = 1 // already expired
+	txn := db.NewTransactionAt(0, true)
+	require.NoError(t, txn.SetEntry(padEntry))
+	require.NoError(t, txn.CommitAt(10, nil))
+	require.NoError(t, db.Close()) // memtable → L0 → L6
+
+	// Write foo@v20; it lands in L5 because baseLevel is now 5.
+	db = openDB(true)
+	require.Equal(t, 5, db.lc.levelTargets().baseLevel)
+	txn2 := db.NewTransactionAt(0, true)
+	require.NoError(t, txn2.SetEntry(NewEntry([]byte("foo"), fooVal)))
+	require.NoError(t, txn2.CommitAt(20, nil))
+	require.NoError(t, db.Close()) // memtable → L0 → L5
+
+	// Drop the expired pad from L6 (Lmax-to-Lmax compaction, discardTs=15),
+	// leaving L6 empty and foo@v20 untouched in L5.
+	db = openDB(false)
+	db.SetDiscardTs(15)
+	targets := db.lc.levelTargets()
+	cdef6a := compactDef{
+		thisLevel: db.lc.levels[6],
+		nextLevel: db.lc.levels[6],
+		top:       db.lc.levels[6].tables,
+		bot:       nil,
+		t:         targets,
+	}
+	require.NoError(t, db.lc.runCompactDef(-1, 6, cdef6a))
+	require.Zero(t, db.lc.levels[6].getTotalSize())
+	require.NoError(t, db.Close())
+
+	// Delete foo@v21; CompactL0OnClose routes the tombstone to the computed
+	// baseLevel (L5, alongside foo@v20).
+	db = openDB(true)
+	txn3 := db.NewTransactionAt(0, true)
+	require.NoError(t, txn3.Delete([]byte("foo")))
+	require.NoError(t, txn3.CommitAt(21, nil))
+	require.NoError(t, db.Close())
+
+	db = openDB(false)
+	db.SetDiscardTs(25)
+	targets2 := db.lc.levelTargets()
+
+	// Drop the tombstone from L6 if it landed there; skipped when L6 is empty.
+	if len(db.lc.levels[6].tables) > 0 {
+		cdef6b := compactDef{
+			thisLevel: db.lc.levels[6],
+			nextLevel: db.lc.levels[6],
+			top:       db.lc.levels[6].tables,
+			bot:       nil,
+			t:         targets2,
+		}
+		require.NoError(t, db.lc.runCompactDef(-1, 6, cdef6b))
+	}
+
+	// Compact L5 → L6.
+	cdef5 := compactDef{
+		thisLevel: db.lc.levels[5],
+		nextLevel: db.lc.levels[6],
+		top:       db.lc.levels[5].tables,
+		bot:       db.lc.levels[6].tables,
+		t:         targets2,
+	}
+	require.NoError(t, db.lc.runCompactDef(-1, 5, cdef5))
+
+	err = db.View(func(txn *Txn) error {
+		_, err := txn.Get([]byte("foo"))
+		return err
+	})
+	require.Equal(t, ErrKeyNotFound, err, "deleted foo must not reappear after compaction")
+	require.NoError(t, db.Close())
 }

--- a/levels_test.go
+++ b/levels_test.go
@@ -1357,3 +1357,149 @@ func TestBaseLevelZeroBySize(t *testing.T) {
 		})
 	}
 }
+
+func TestLevelTargets(t *testing.T) {
+	// Disable compactions and keep single version of each key.
+	opt := DefaultOptions("").WithNumCompactors(0).WithNumVersionsToKeep(1)
+	opt.managedTxns = true
+
+	t.Run("level 0 to level 6 when level 5 is not empty", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+
+			createAndOpen(db, data, 0)
+
+			createAndOpen(db, data, opt.MaxLevels-2)
+			createAndOpen(db, data, opt.MaxLevels-1)
+
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize * 2
+			db.lc.levels[opt.MaxLevels-2].totalSize = opt.BaseLevelSize / 4
+
+			cdef := compactDef{
+				thisLevel: db.lc.levels[0],
+				nextLevel: db.lc.levels[opt.MaxLevels-1],
+				top:       db.lc.levels[0].tables,
+				bot:       db.lc.levels[opt.MaxLevels-1].tables,
+				t:         db.lc.levelTargets(),
+			}
+			cdef.t.baseLevel = opt.MaxLevels - 1
+			err := db.lc.runCompactDef(-1, 0, cdef)
+			require.Error(t, err)
+			expectedErr := fmt.Sprintf(
+				"there is a non-empty level %d above base level %d",
+				opt.MaxLevels-2, opt.MaxLevels-1)
+			require.Contains(t, err.Error(), expectedErr)
+		})
+	})
+
+	t.Run("level 0 to level 5 while size of level 6 is less than BaseLevelSize", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+
+			createAndOpen(db, data, opt.MaxLevels-2)
+			createAndOpen(db, data, opt.MaxLevels-1)
+
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize / 2
+			db.lc.levels[opt.MaxLevels-2].totalSize = opt.BaseLevelSize / 4
+
+			target := db.lc.levelTargets()
+			require.Equal(t, opt.MaxLevels-2, target.baseLevel)
+		})
+	})
+
+	t.Run("level 0 to level 4 while size of level 5 and 6 is less than BaseLevelSize", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+
+			createAndOpen(db, data, opt.MaxLevels-3)
+			createAndOpen(db, data, opt.MaxLevels-2)
+			createAndOpen(db, data, opt.MaxLevels-1)
+
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize / 2
+			db.lc.levels[opt.MaxLevels-2].totalSize = opt.BaseLevelSize / 2
+			db.lc.levels[opt.MaxLevels-3].totalSize = opt.BaseLevelSize / 4
+
+			target := db.lc.levelTargets()
+			require.Equal(t, opt.MaxLevels-3, target.baseLevel)
+		})
+	})
+
+	t.Run("all level have data", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+
+			for i := 1; i < opt.MaxLevels; i++ {
+				createAndOpen(db, data, i)
+				db.lc.levels[i].totalSize = opt.BaseLevelSize / 2
+			}
+
+			target := db.lc.levelTargets()
+			require.Equal(t, 1, target.baseLevel)
+		})
+	})
+
+	t.Run("level 1 is larger than BaseLevelSize", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+
+			for i := 1; i < opt.MaxLevels; i++ {
+				createAndOpen(db, data, i)
+				db.lc.levels[i].totalSize = opt.BaseLevelSize * 2
+			}
+
+			target := db.lc.levelTargets()
+			require.Equal(t, 1, target.baseLevel)
+		})
+	})
+
+	t.Run("level 5 is larger than BaseLevelSize", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+
+			createAndOpen(db, data, opt.MaxLevels-2)
+			createAndOpen(db, data, opt.MaxLevels-1)
+
+			db.lc.levels[opt.MaxLevels-2].totalSize = opt.BaseLevelSize * 2
+			// Set level 6 large enough so that targetSz[5] > level 5 size (satisfying old
+			// bump condition), but level 5 itself exceeds BaseLevelSize so the new guard
+			// prevents the bump.
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize * int64(opt.LevelSizeMultiplier*2+1)
+
+			target := db.lc.levelTargets()
+			require.Equal(t, opt.MaxLevels-3, target.baseLevel)
+		})
+	})
+
+	t.Run("only level 0 has data", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+
+			// All levels below are empty; base level should be the last level.
+			target := db.lc.levelTargets()
+			require.Equal(t, opt.MaxLevels-1, target.baseLevel)
+		})
+	})
+
+	t.Run("level size exactly at BaseLevelSize boundary", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+
+			createAndOpen(db, data, opt.MaxLevels-2)
+			createAndOpen(db, data, opt.MaxLevels-1)
+
+			// Level 5 size exactly equals BaseLevelSize; should NOT bump past it.
+			db.lc.levels[opt.MaxLevels-2].totalSize = opt.BaseLevelSize
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize * 2
+
+			target := db.lc.levelTargets()
+			require.Equal(t, opt.MaxLevels-3, target.baseLevel)
+		})
+	})
+}


### PR DESCRIPTION
**Description**

During Level 0 compaction, the engine may skip intermediate levels and compact Level 0 tables directly to the bottommost level. This can leave stale data in the skipped intermediate levels. As a result, previously deleted keys may reappear from the user's perspective after compaction completes.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable


