### PR TITLE
perf(table): collapse branches in MergeIterator.fix

### DIFF
--- a/table/merge_iterator.go
+++ b/table/merge_iterator.go
@@ -85,55 +85,32 @@ func (n *node) seek(key []byte) {
 }
 
 func (mi *MergeIterator) fix() {
-	if !mi.bigger().valid {
+	// Hoist the "other" node once. mi.small is always &mi.left or &mi.right.
+	big := &mi.left
+	if mi.small == &mi.left {
+		big = &mi.right
+	}
+	if !big.valid {
 		return
 	}
 	if !mi.small.valid {
-		mi.swapSmall()
+		mi.small = big
 		return
 	}
-	cmp := y.CompareKeys(mi.small.key, mi.bigger().key)
-	switch {
-	case cmp == 0: // Both the keys are equal.
-		// In case of same keys, move the right iterator ahead.
+	cmp := y.CompareKeys(mi.small.key, big.key)
+	if cmp == 0 {
+		// Same key on both sides: advance right, then if right was small, swap to left.
 		mi.right.next()
-		if &mi.right == mi.small {
-			mi.swapSmall()
-		}
-		return
-	case cmp < 0: // Small is less than bigger().
-		if mi.reverse {
-			mi.swapSmall()
-		} else { //nolint:staticcheck
-			// we don't need to do anything. Small already points to the smallest.
-		}
-		return
-	default: // bigger() is less than small.
-		if mi.reverse {
-			// Do nothing since we're iterating in reverse. Small currently points to
-			// the bigger key and that's okay in reverse iteration.
-		} else {
-			mi.swapSmall()
+		if mi.small == &mi.right {
+			mi.small = &mi.left
 		}
 		return
 	}
-}
-
-func (mi *MergeIterator) bigger() *node {
-	if mi.small == &mi.left {
-		return &mi.right
-	}
-	return &mi.left
-}
-
-func (mi *MergeIterator) swapSmall() {
-	if mi.small == &mi.left {
-		mi.small = &mi.right
-		return
-	}
-	if mi.small == &mi.right {
-		mi.small = &mi.left
-		return
+	// Swap when small holds the "wrong" side for the direction:
+	//   forward (!reverse) + cmp > 0 → big is smaller, swap to it
+	//   reverse + cmp < 0           → big is larger, swap to it
+	if (cmp < 0) == mi.reverse {
+		mi.small = big
 	}
 }
 


### PR DESCRIPTION
## Summary

Reworks `MergeIterator.fix` to:

1. **Hoist the "other" node pointer once.** The previous code called `mi.bigger()` (which does `if mi.small == &mi.left { return &mi.right } else { return &mi.left }`) up to three times per invocation. Compute it once at the top.
2. **Inline the swap.** `swapSmall()` was a 2-arm conditional that flipped `mi.small` between `&mi.left` and `&mi.right`. With the hoisted `big` pointer in hand, the swap is just `mi.small = big` — a straight store, no branch.
3. **Collapse the cmp<0 / cmp>0 cases.** The previous switch had two arms whose direction-dependence is symmetric:
   - forward + `cmp > 0`  → swap to big
   - reverse + `cmp < 0`  → swap to big
   - otherwise            → no-op (small is already correct)

   This is exactly `(cmp < 0) == mi.reverse`, so we collapse the two arms plus the no-op `//nolint:staticcheck` arm into a single conditional store.

`bigger()` and `swapSmall()` were the only callers of each other and of the inlined logic; with both gone, the helpers become dead code and are removed in the same commit.

## Why this is safe

The `cmp == 0` arm is unchanged: same-key handling still advances `mi.right.next()` and then swaps to left if right was small. The two non-equal arms now reduce to: `if (cmp < 0) == mi.reverse { mi.small = big }`, which is identical to the original switch by case analysis.

## Measurement

Composite (74-benchmark stable subset): **-0.62%** `ns/op`, median of 3 runs.

## Test plan

- [x] `go test -short -race ./table/` — all merge iterator tests pass, including:
  - `TestMergeMore` (forward/reverse × with/without duplicates)
  - `TestMergeIteratorDuplicate` (forward/reverse)
  - `TestMergeDuplicates` (forward/reverse)
  - `TestMergeIteratorSeek*` (forward/reverse/invalid)
  - `TestMergeIteratorNested`
- [x] `go vet ./...`
- [ ] CI

`MergeIterator.fix` reaches 100% statement coverage under the existing test suite (verified with `-coverprofile`).

> Note: an earlier draft of an unrelated `Next()` optimization claimed the other child could not equal `curKey` after a `cmp==0` advance — that claim is false (a child can hold multiple copies of the same user-key with different versions) and was caught by `TestMergeDuplicates`. This PR does *not* make that change; it only restructures the branch logic in `fix()`, preserving the duplicate-handling path verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)