### PR TITLE
perf(db): eliminate closure allocation in getMemTables cleanup

### DIFF
--- a/db.go
+++ b/db.go
@@ -745,8 +745,14 @@ func (db *DB) Sync() error {
 	return y.CombineErrors(memtableSyncError, vLogSyncError)
 }
 
-// getMemtables returns the current memtables and get references.
-func (db *DB) getMemTables() ([]*memTable, func()) {
+// getMemTables returns the active set of memtables (mutable + immutables)
+// with their refcounts already incremented. Callers MUST release the
+// references by calling decrMemTables(tables) — typically via defer.
+//
+// The two-method shape (instead of returning a cleanup closure) avoids the
+// per-call closure allocation that the previous API forced on every iterator
+// construction and stream-writer setup.
+func (db *DB) getMemTables() []*memTable {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
@@ -765,10 +771,16 @@ func (db *DB) getMemTables() ([]*memTable, func()) {
 		tables = append(tables, db.imm[last-i])
 		db.imm[last-i].IncrRef()
 	}
-	return tables, func() {
-		for _, tbl := range tables {
-			tbl.DecrRef()
-		}
+	return tables
+}
+
+// decrMemTables releases the refcounts taken by getMemTables. Pair with
+// `defer decrMemTables(tables)` after a getMemTables call. Free function
+// (no receiver) so the deferred call record doesn't have to capture a
+// *DB pointer alongside the slice header.
+func decrMemTables(tables []*memTable) {
+	for _, tbl := range tables {
+		tbl.DecrRef()
 	}
 }
 
@@ -790,8 +802,8 @@ func (db *DB) get(key []byte) (y.ValueStruct, error) {
 	if db.IsClosed() {
 		return y.ValueStruct{}, ErrDBClosed
 	}
-	tables, decr := db.getMemTables() // Lock should be released.
-	defer decr()
+	tables := db.getMemTables() // Lock should be released.
+	defer decrMemTables(tables)
 
 	var maxVs y.ValueStruct
 	version := y.ParseTs(key)

--- a/iterator.go
+++ b/iterator.go
@@ -470,8 +470,8 @@ func (txn *Txn) NewIterator(opt IteratorOptions) *Iterator {
 	txn.numIterators.Add(1)
 
 	// TODO: If Prefix is set, only pick those memtables which have keys with the prefix.
-	tables, decr := txn.db.getMemTables()
-	defer decr()
+	tables := txn.db.getMemTables()
+	defer decrMemTables(tables)
 	txn.db.vlog.incrIteratorCount()
 	var iters []y.Iterator
 	if itr := txn.newPendingWritesIterator(opt.Reverse); itr != nil {

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -93,8 +93,8 @@ func (sw *StreamWriter) PrepareIncremental() error {
 	}
 	sw.done = func() { once.Do(done) }
 
-	mts, decr := sw.db.getMemTables()
-	defer decr()
+	mts := sw.db.getMemTables()
+	defer decrMemTables(mts)
 	for _, m := range mts {
 		if !m.sl.Empty() {
 			return fmt.Errorf("Unable to do incremental writes because MemTable has data")


### PR DESCRIPTION
## Summary

`getMemTables` previously returned `(tables, cleanupFunc)` where `cleanupFunc` was a closure capturing the `tables` slice. That closure escaped to the heap on every call — one extra allocation per iterator construction in the rollup path.

Split into:

```go
func (db *DB) getMemTables() []*memTable
func decrMemTables([]*memTable)
```

Callers do `defer decrMemTables(tables)` after the `getMemTables` call. The slice is fully populated before the defer evaluates its argument, so the captured slice header points to the correct backing array; no behavioral change.

`decrMemTables` is a free function (no receiver) so the deferred call record doesn't pay for a `*DB` pointer alongside the slice header.

## Benchmark — BenchmarkRollupKeyIterator

| | B/op | allocs/op |
| --- | --- | --- |
| before | 801 | 14 |
| after  | 769 | 13 |

## Test plan

- [x] `go test ./...` passes
- [x] All three callers (`db.get`, `txn.NewIterator`, `stream_writer`) verified to release refs via defer

🤖 Generated with [Claude Code](https://claude.com/claude-code)