### PR TITLE
fix(in-memory): resolve orphaned skiplist arena leak on Close

### DIFF
--- a/db.go
+++ b/db.go
@@ -625,6 +625,9 @@ func (db *DB) close() (err error) {
 	db.threshold.close()
 
 	if db.opt.InMemory {
+		for _, mem := range db.imm{
+			mem.DecrRef()
+		}
 		return
 	}
 

--- a/issue_2205_test.go
+++ b/issue_2205_test.go
@@ -1,0 +1,34 @@
+package badger
+
+import (
+	"testing"
+)
+
+func TestIssue2205_MemoryLeak(t *testing.T) {
+	// Loop 1000 times to force the leak to accumulate
+	for i := 0; i < 1000; i++ {
+		// Initialize an in-memory database configuration
+		opt := DefaultOptions("").WithInMemory(true)
+		opt.Logger = nil // Turn off logging so our terminal doesn't get spammed
+
+		db, err := Open(opt)
+		if err != nil {
+			t.Fatalf("Failed to open DB on iteration %d: %v", i, err)
+		}
+
+		// Perform a single write transaction
+		err = db.Update(func(txn *Txn) error {
+			return txn.Set([]byte("leak-test"), []byte("value"))
+		})
+		if err != nil {
+			t.Fatalf("Failed to write on iteration %d: %v", i, err)
+		}
+
+		// Close the database. This is where the bug lives!
+		// It is supposed to clean up everything, but it's leaving something behind.
+		err = db.Close()
+		if err != nil {
+			t.Fatalf("Failed to close DB on iteration %d: %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
**Description**

Fixes #2205.

**Root Cause:**
When Badger is configured with `opt.InMemory = true`, the `db.close()` function triggers an early return. This prevents the cleanup logic from iterating over the immutable memtables slice (`db.imm`). Because `mmap` allocations bypass Go's GC, failing to explicitly call `DecrRef()` on these memtables leaves the `skl.Arena` allocations orphaned in memory indefinitely.

**The Fix:**
Added an explicit iteration over `db.imm` to decrement reference counts on all immutable memtables prior to the early return in the in-memory shutdown sequence. 

**Verification:**
Included `issue_2205_test.go` to aggressively cycle in-memory database instantiation. 
* **Before:** `pprof` `inuse_space` showed ~83GB of retained `skl.newArena` allocations across 1000 iterations.
* **After:** Retained arenas dropped to 0 bytes. 

All tests in `./test.sh` pass locally.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable


<img width="1920" height="1000" alt="ppof1" src="https://github.com/user-attachments/assets/b8bfc9b6-09b6-487e-abda-d22a2cefa8b8" />
<img width="1920" height="1004" alt="ppof2" src="https://github.com/user-attachments/assets/46a85775-71be-4e64-b460-8fe9cea09d93" />
