### PR TITLE
fix(compaction): clamp baseLevel to >=1 to prevent L0->L0 panic on la…

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -422,6 +422,18 @@ func (s *levelsController) levelTargets() targets {
 	if b < len(lvl)-1 && lvl[b].getTotalSize() == 0 && lvl[b+1].getTotalSize() < t.targetSz[b+1] {
 		t.baseLevel++
 	}
+
+	// The base level must never be L0. For a very large LSM tree the size loop
+	// above can fail to assign a base level: it only sets baseLevel where
+	// adjust(dbSize) <= BaseLevelSize, and the smallest level it checks (L1)
+	// has dbSize = lastLevelSize / LevelSizeMultiplier^(MaxLevels-2). Once the
+	// last level exceeds that (~1TB with defaults), baseLevel stays 0, and a
+	// non-empty L1 prevents the "bring down" loop from fixing it. Clamp to L1
+	// (the topmost real level) so we never try to compact L0 into itself, which
+	// would otherwise panic in fillTablesL0ToLbase.
+	if t.baseLevel == 0 {
+		t.baseLevel = 1
+	}
 	return t
 }
 

--- a/levels_test.go
+++ b/levels_test.go
@@ -1322,7 +1322,10 @@ func TestBaseLevelZeroBySize(t *testing.T) {
 
 	for _, tc := range sizes {
 		t.Run(tc.name, func(t *testing.T) {
-			runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+			// Disable background compactors so they don't race with the manual
+			// size mutation and doCompact call below.
+			opt := DefaultOptions("").WithNumCompactors(0)
+			runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
 				setSize := func(level int, sz int64) {
 					lh := db.lc.levels[level]
 					lh.Lock()
@@ -1330,9 +1333,10 @@ func TestBaseLevelZeroBySize(t *testing.T) {
 					lh.Unlock()
 				}
 
-				setSize(6, tc.lmax) // last level (Lmax)
-				setSize(1, 1*GB)    // L1 non-empty: would block the "bring base level down" loop
-				setSize(0, 1*GB)    // L0 non-empty: would block the final empty-L0 adjustment
+				lmaxLevel := db.opt.MaxLevels - 1 // last level (Lmax), not hard-coded
+				setSize(lmaxLevel, tc.lmax)
+				setSize(1, 1*GB) // L1 non-empty: would block the "bring base level down" loop
+				setSize(0, 1*GB) // L0 non-empty: would block the final empty-L0 adjustment
 
 				tt := db.lc.levelTargets()
 

--- a/levels_test.go
+++ b/levels_test.go
@@ -1290,3 +1290,66 @@ func TestStaleDataCleanup(t *testing.T) {
 
 	})
 }
+
+func TestBaseLevelZeroBySize(t *testing.T) {
+	const GB = int64(1) << 30
+	const TB = int64(1) << 40
+
+	// didPanic reports whether f panicked, and with what value.
+	didPanic := func(f func()) (panicked bool, val any) {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked, val = true, r
+			}
+		}()
+		f()
+		return
+	}
+
+	// Regression test for the "Base level can't be zero." panic.
+	// Before the fix, the last two cases produced baseLevel==0 and panicked.
+	// After the fix, levelTargets() clamps baseLevel>=1, so no size panics.
+	sizes := []struct {
+		name string
+		lmax int64
+	}{
+		{"10GB", 10 * GB},
+		{"100GB", 100 * GB},
+		{"500GB", 500 * GB},
+		{"1TB", 1 * TB},
+		{"2TB", 2 * TB},
+	}
+
+	for _, tc := range sizes {
+		t.Run(tc.name, func(t *testing.T) {
+			runBadgerTest(t, nil, func(t *testing.T, db *DB) {
+				setSize := func(level int, sz int64) {
+					lh := db.lc.levels[level]
+					lh.Lock()
+					lh.totalSize = sz
+					lh.Unlock()
+				}
+
+				setSize(6, tc.lmax) // last level (Lmax)
+				setSize(1, 1*GB)    // L1 non-empty: would block the "bring base level down" loop
+				setSize(0, 1*GB)    // L0 non-empty: would block the final empty-L0 adjustment
+
+				tt := db.lc.levelTargets()
+
+				panicked, val := didPanic(func() {
+					_ = db.lc.doCompact(0, compactionPriority{level: 0, t: tt})
+				})
+
+				t.Logf("Lmax=%s: baseLevel=%d, panicked=%v (%v)  [BaseLevelSize=%d, MaxLevels=%d]",
+					tc.name, tt.baseLevel, panicked, val, db.opt.BaseLevelSize, db.opt.MaxLevels)
+
+				// Post-fix invariant: base level is never L0, and an L0
+				// compaction never hits the "Base level can't be zero." panic.
+				require.NotEqual(t, 0, tt.baseLevel,
+					"baseLevel must never be 0 (Lmax=%s)", tc.name)
+				require.False(t, panicked,
+					"L0 compaction must not panic (Lmax=%s); got %v", tc.name, val)
+			})
+		})
+	}
+}


### PR DESCRIPTION
…rge LSM trees

When the last level (Lmax) grows past BaseLevelSize × LevelSizeMultiplier^(MaxLevels-2) (~1.05 TB with default options) and L1 is non-empty, levelTargets() fails to assign a base level and returns baseLevel == 0. The next L0 compaction then tries to compact L0 into itself and hits the safety assertion in fillTablesL0ToLbase, crashing the compactor.

**Fix** - Clamp baseLevel to a minimum of 1 in levelTargets(). This is a no-op for normal-sized databases (the size loop already picks a valid level) and only engages for very large trees, where L1 is the correct base level turning the crash into a normal L0→L1 compaction.

fixes #2214 
