### PR TITLE
docs: update CONTRIBUTING (TOC, code style, license header, master→main)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,21 @@
 # Contribution Guide
 
-- [Before you get started](#before-you-get-started)
-  - [Code of Conduct](#code-of-conduct)
-- [Your First Contribution](#your-first-contribution)
-  - [Find a good first topic](#find-a-good-first-topic)
-- [Setting up your development environment](#setting-up-your-development-environment)
-  - [Fork the project](#fork-the-project)
-  - [Clone the project](#clone-the-project)
-  - [New branch for a new code](#new-branch-for-a-new-code)
-  - [Test](#test)
-  - [Commit and push](#commit-and-push)
-  - [Create a Pull Request](#create-a-pull-request)
-  - [Sign the CLA](#sign-the-cla)
-  - [Get a code review](#get-a-code-review)
+- [Contribution Guide](#contribution-guide)
+  - [Before you get started](#before-you-get-started)
+    - [Code of Conduct](#code-of-conduct)
+  - [Your First Contribution](#your-first-contribution)
+    - [Code style](#code-style)
+    - [License Header](#license-header)
+    - [Find a good first topic](#find-a-good-first-topic)
+  - [Setting up your development environment](#setting-up-your-development-environment)
+    - [Fork the project](#fork-the-project)
+    - [Clone the project](#clone-the-project)
+    - [New branch for a new code](#new-branch-for-a-new-code)
+    - [Test](#test)
+    - [Commit and push](#commit-and-push)
+    - [Create a Pull Request](#create-a-pull-request)
+    - [Sign the CLA](#sign-the-cla)
+    - [Get a code review](#get-a-code-review)
 
 ## Before you get started
 
@@ -21,6 +24,30 @@
 Please make sure to read and observe our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Your First Contribution
+
+### Code style
+
+- We follow [Go Code Review](https://github.com/golang/go/wiki/CodeReviewComments)
+- At a minimum, use `go fmt` to format your code before committing. Ideally you should use `trunk`
+  as our CI will run `trunk` on your code
+- If you see _any code_ which clearly violates the style guide, please fix it and send a pull
+  request. No need to ask for permission
+- Avoid unnecessary vertical spaces. Use your judgment or follow the code review comments
+- Wrap your code and comments to 120 characters, unless doing so makes the code less legible
+
+### License Header
+
+Every new source file must begin with a license header.
+
+Most of Dgraph, Badger, and the Dgraph clients (dgo, dgraph-js, pydgraph and dgraph4j) are licensed
+under the Apache 2.0 license:
+
+```sh
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+```
 
 ### Find a good first topic
 
@@ -48,21 +75,21 @@ git clone https://github.com/$GITHUB_USER/badger
 cd badger
 git remote add upstream git@github.com:dgraph-io/badger.git
 
-# Never push to the upstream master
+# Never push to the upstream main
 git remote set-url --push upstream no_push
 ```
 
 ### New branch for a new code
 
-Get your local master up to date:
+Get your local main up to date:
 
 ```sh
 git fetch upstream
-git checkout master
-git rebase upstream/master
+git checkout main
+git rebase upstream/main
 ```
 
-Create a new branch from the master:
+Create a new branch from the main:
 
 ```sh
 git checkout -b my_new_feature


### PR DESCRIPTION
## Description

Updates `CONTRIBUTING.md`:

- Regenerated the table of contents so it includes the top-level heading and nests the subsections correctly.
- Added a **Code style** section: `go fmt`/`trunk`, 120-char wrapping, and a pointer to the Go Code Review guide.
- Added a **License Header** section with the SPDX Apache-2.0 header new source files should carry.
- Replaced stale `master` references with `main` to match the default branch.

No code changes.
