### PR TITLE
ci: keep required checks green on docs-only PRs

### DIFF
--- a/.github/workflows/ci-badger-bank-tests.yml
+++ b/.github/workflows/ci-badger-bank-tests.yml
@@ -3,10 +3,6 @@ name: ci-badger-bank-tests
 on:
   workflow_dispatch: # allows manual trigger from GitHub
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - docs/**
-      - images/**
     branches:
       - main
       - release/v*
@@ -15,21 +11,47 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether any non-doc files changed. badger-bank always runs so it
+  # reports a status on every PR, then short-circuits to success when only docs
+  # changed. This keeps the bank test gate for code PRs while preventing
+  # docs-only PRs from deadlocking on a check that paths filtering would skip.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!images/**'
+
   badger-bank:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: Setup Go
+      - if: needs.changes.outputs.code == 'true'
+        uses: actions/checkout@v5
+      - if: needs.changes.outputs.code == 'true'
+        name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Install Dependencies
+      - if: needs.changes.outputs.code == 'true'
+        name: Install Dependencies
         run: make dependency
-      - name: Install jemalloc
+      - if: needs.changes.outputs.code == 'true'
+        name: Install jemalloc
         run: make jemalloc
-      - name: Install Badger
+      - if: needs.changes.outputs.code == 'true'
+        name: Install Badger
         run: cd badger && go install --race --tags=jemalloc .
-      - name: Run Badger Bank Test
+      - if: needs.changes.outputs.code == 'true'
+        name: Run Badger Bank Test
         run: |
           #!/bin/bash
           mkdir bank && cd bank

--- a/.github/workflows/ci-badger-tests.yml
+++ b/.github/workflows/ci-badger-tests.yml
@@ -3,11 +3,6 @@ name: ci-badger-tests
 on:
   workflow_dispatch: # allows manual trigger from GitHub
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - docs/**
-      - images/**
-      - contrib/**
     branches:
       - main
       - release/v*
@@ -16,7 +11,29 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether any non-doc files changed. The required jobs below always run
+  # so they report a status on every PR, then short-circuit to success when only
+  # docs changed. This keeps the test gate for code PRs while preventing
+  # docs-only PRs from deadlocking on a check that paths filtering would skip.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!images/**'
+              - '!contrib/**'
+
   cross-compile:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,14 +65,19 @@ jobs:
         run: go build ./...
 
   badger-tests:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: Setup Go
+      - if: needs.changes.outputs.code == 'true'
+        uses: actions/checkout@v5
+      - if: needs.changes.outputs.code == 'true'
+        name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Install Dependencies
+      - if: needs.changes.outputs.code == 'true'
+        name: Install Dependencies
         run: make dependency
-      - name: Run Badger Tests
+      - if: needs.changes.outputs.code == 'true'
+        name: Run Badger Tests
         run: make test


### PR DESCRIPTION
## Summary

`badger-tests` and `badger-bank` are required status checks, but both workflows skip docs-only changes via `paths-ignore`. On a docs-only PR the workflows never run, so the required contexts sit at "Expected" forever and the PR can't merge, even for a one-line `CONTRIBUTING.md` edit (see #2300).

## Fix

Drop `paths-ignore` and add a `changes` job (`dorny/paths-filter`) that flags whether any non-doc file changed:

- `badger-tests` / `badger-bank` always run, so they always report a status to the PR rollup. Their expensive steps are gated on `needs.changes.outputs.code == 'true'`, so docs-only PRs short-circuit to green in a few seconds.
- `cross-compile` (not a required check) skips at the job level on docs-only PRs.

Code PRs keep the full test gate as before. Each workflow's original ignore set is preserved: `ci-badger-bank-tests` still tests on `contrib/**` changes, `ci-badger-tests` does not.

## Testing

This PR touches workflow files, so the real `badger-tests` and `badger-bank` jobs run here and must pass. The docs-only short-circuit path is exercised by #2300 once this lands.
