### PR TITLE
chore (ci): add stale Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: Close stale issues and PRs
+on:
+  schedule:
+    - cron: 00 02 * * *
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Stale
+    uses: dgraph-io/.github/.github/workflows/stale.yml@main


### PR DESCRIPTION
**Description**

This PR adds a scheduled stale-bot workflow (actions/stale@v9) that automatically marks inactive issues and pull requests as stale and closes them if they stay inactive.

How it works

Runs once a day at 02:00 UTC (cron schedule).
An issue or PR with no activity for 60 days is labeled Stale and a comment is posted.
After being marked stale, there is a 7-day cooling period: commenting (or any activity) removes the label and resets the timer; otherwise the item is closed automatically.


**Comment posted on stale items**

Issues
```
This issue has been stale for 60 days and will be closed automatically in 7 days. Comment to keep it open.
```

Pull requests

```
This PR has been stale for 60 days and will be closed automatically in 7 days. Comment to keep it open.
```