### PR TITLE
feat(table): optional prefix bloom filters for prefix-scan pruning

### DIFF
--- a/fb/TableIndex.go
+++ b/fb/TableIndex.go
@@ -140,8 +140,51 @@ func (rcv *TableIndex) MutateStaleDataSize(n uint32) bool {
 	return rcv._tab.MutateUint32Slot(16, n)
 }
 
+// BloomPrefixFilter is an optional bloom filter built over the first
+// BloomPrefixLength bytes of each user key. It is stored in an appended
+// flatbuffer field (vtable slot 7) so that tables written without it (or by
+// older code) decode to a nil slice here.
+func (rcv *TableIndex) BloomPrefixFilter(j int) byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.GetByte(a + flatbuffers.UOffsetT(j*1))
+	}
+	return 0
+}
+
+func (rcv *TableIndex) BloomPrefixFilterLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+func (rcv *TableIndex) BloomPrefixFilterBytes() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+// BloomPrefixLength is the number of leading user-key bytes hashed into
+// BloomPrefixFilter. Zero means prefix blooms are disabled for this table.
+func (rcv *TableIndex) BloomPrefixLength() uint32 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
+	if o != 0 {
+		return rcv._tab.GetUint32(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *TableIndex) MutateBloomPrefixLength(n uint32) bool {
+	return rcv._tab.MutateUint32Slot(20, n)
+}
+
 func TableIndexStart(builder *flatbuffers.Builder) {
-	builder.StartObject(7)
+	builder.StartObject(9)
 }
 func TableIndexAddOffsets(builder *flatbuffers.Builder, offsets flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(offsets), 0)
@@ -169,6 +212,15 @@ func TableIndexAddOnDiskSize(builder *flatbuffers.Builder, onDiskSize uint32) {
 }
 func TableIndexAddStaleDataSize(builder *flatbuffers.Builder, staleDataSize uint32) {
 	builder.PrependUint32Slot(6, staleDataSize, 0)
+}
+func TableIndexAddBloomPrefixFilter(builder *flatbuffers.Builder, bloomPrefixFilter flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(7, flatbuffers.UOffsetT(bloomPrefixFilter), 0)
+}
+func TableIndexStartBloomPrefixFilterVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(1, numElems, 1)
+}
+func TableIndexAddBloomPrefixLength(builder *flatbuffers.Builder, bloomPrefixLength uint32) {
+	builder.PrependUint32Slot(8, bloomPrefixLength, 0)
 }
 func TableIndexEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/fb/flatbuffer.fbs
+++ b/fb/flatbuffer.fbs
@@ -13,6 +13,12 @@ table TableIndex {
   uncompressed_size:uint32;
   on_disk_size:uint32;
   stale_data_size:uint32;
+  // Optional prefix bloom filter, built over the first prefix_length bytes of
+  // each user key. Empty/absent when prefix blooms are disabled. Appended at the
+  // end for forward/backward compatibility: old readers ignore these fields, and
+  // new readers see the default (nil/0) when reading tables written without them.
+  bloom_prefix_filter:[ubyte];
+  bloom_prefix_length:uint32;
 }
 
 table BlockOffset {

--- a/iterator.go
+++ b/iterator.go
@@ -348,6 +348,12 @@ func (opt *IteratorOptions) pickTable(t table.TableInterface) bool {
 	if opt.prefixIsKey && t.DoesNotHave(y.Hash(opt.Prefix)) {
 		return false
 	}
+	// Prefix bloom: for a true prefix scan (not a single-key lookup), consult
+	// the optional prefix bloom filter. It is a no-op for tables built without
+	// the WithBloomPrefixLength option (DoesNotHavePrefix returns false).
+	if !opt.prefixIsKey && t.DoesNotHavePrefix(opt.Prefix) {
+		return false
+	}
 	return true
 }
 
@@ -388,8 +394,17 @@ func (opt *IteratorOptions) pickTables(all []*table.Table) []*table.Table {
 		eIdx := sort.Search(len(filtered), func(i int) bool {
 			return opt.compareToPrefix(filtered[i].Smallest()) > 0
 		})
-		out := make([]*table.Table, len(filtered[:eIdx]))
-		copy(out, filtered[:eIdx])
+		candidates := filtered[:eIdx]
+		// Prune candidates whose prefix bloom proves the scan prefix is absent.
+		// Tables without a prefix bloom (DoesNotHavePrefix == false) are kept,
+		// preserving the original key-range behaviour.
+		out := make([]*table.Table, 0, len(candidates))
+		for _, t := range candidates {
+			if t.DoesNotHavePrefix(opt.Prefix) {
+				continue
+			}
+			out = append(out, t)
+		}
 		return filterTables(out)
 	}
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -24,12 +24,23 @@ import (
 
 type tableMock struct {
 	left, right []byte
+	// absentPrefixes, when set, makes DoesNotHavePrefix return true for any of
+	// the listed prefixes, simulating a table whose prefix bloom prunes them.
+	absentPrefixes [][]byte
 }
 
 func (tm *tableMock) Smallest() []byte             { return tm.left }
 func (tm *tableMock) Biggest() []byte              { return tm.right }
 func (tm *tableMock) DoesNotHave(hash uint32) bool { return false }
 func (tm *tableMock) MaxVersion() uint64           { return math.MaxUint64 }
+func (tm *tableMock) DoesNotHavePrefix(prefix []byte) bool {
+	for _, p := range tm.absentPrefixes {
+		if bytes.Equal(p, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestPickTables(t *testing.T) {
 	opt := DefaultIteratorOptions
@@ -60,6 +71,40 @@ func TestPickTables(t *testing.T) {
 	outside("abd", "a", "ab")
 	outside("abd", "ab", "abc")
 	outside("abd", "ab", "abc123")
+}
+
+// TestPickTablePrefixBloom verifies that a prefix scan (not a single-key
+// lookup) consults the prefix bloom: a table whose prefix bloom says the scan
+// prefix is absent is skipped, even though its key range overlaps the prefix.
+func TestPickTablePrefixBloom(t *testing.T) {
+	opt := DefaultIteratorOptions
+	opt.prefixIsKey = false
+	opt.Prefix = []byte("abc")
+
+	// Key range [ab, ad] overlaps prefix "abc", so range pruning keeps it.
+	inRange := func() *tableMock {
+		return &tableMock{left: y.KeyWithTs([]byte("ab"), 1), right: y.KeyWithTs([]byte("ad"), 1)}
+	}
+
+	// Without a pruning prefix bloom, the overlapping table is picked.
+	require.True(t, opt.pickTable(inRange()))
+
+	// With the prefix bloom reporting "abc" absent, the table is skipped.
+	tm := inRange()
+	tm.absentPrefixes = [][]byte{[]byte("abc")}
+	require.False(t, opt.pickTable(tm))
+
+	// A different (present) prefix is not pruned.
+	tm2 := inRange()
+	tm2.absentPrefixes = [][]byte{[]byte("xyz")}
+	require.True(t, opt.pickTable(tm2))
+
+	// For a single-key lookup (prefixIsKey), the prefix bloom path is NOT used;
+	// the full-key bloom (DoesNotHave) governs instead, so the table is kept.
+	opt.prefixIsKey = true
+	tm3 := inRange()
+	tm3.absentPrefixes = [][]byte{[]byte("abc")}
+	require.True(t, opt.pickTable(tm3))
 }
 
 func TestPickSortTables(t *testing.T) {
@@ -112,6 +157,76 @@ func TestPickSortTables(t *testing.T) {
 	filtered = opt.pickTables(tables)
 	require.Equal(t, y.ParseKey(filtered[0].Smallest()), []byte("a"))
 	require.Equal(t, y.ParseKey(filtered[0].Biggest()), []byte("abc"))
+}
+
+// TestPickTablesPrefixBloomReal builds real SSTables with a prefix bloom and
+// verifies that opt.pickTables prunes the table that does not contain the scan
+// prefix, while keeping the one that does. It also confirms a table built with
+// the prefix bloom disabled (old format) is never pruned.
+func TestPickTablesPrefixBloomReal(t *testing.T) {
+	buildPrefixed := func(prefix string, prefixLen int) *table.Table {
+		opts := table.Options{
+			ChkMode:            options.OnTableAndBlockRead,
+			BloomFalsePositive: 0.01,
+			BlockSize:          4 * 1024,
+			BloomPrefixLength:  prefixLen,
+		}
+		var kvs [][]string
+		for i := 0; i < 200; i++ {
+			kvs = append(kvs, []string{fmt.Sprintf("%s%04d", prefix, i), "v"})
+		}
+		tbl := buildTable(t, kvs, opts)
+		return tbl
+	}
+
+	// Two non-overlapping key ranges, each with a 5-byte prefix bloom.
+	tblA := buildPrefixed("aaaaa", 5) // keys aaaaa0000..aaaaa0199
+	tblC := buildPrefixed("ccccc", 5) // keys ccccc0000..ccccc0199
+	defer func() { require.NoError(t, tblA.DecrRef()) }()
+	defer func() { require.NoError(t, tblC.DecrRef()) }()
+
+	tables := []*table.Table{tblA, tblC}
+
+	opt := DefaultIteratorOptions
+	opt.prefixIsKey = false
+
+	// Scan for prefix "ccccc": tblA's range [aaaaa..aaaaa] sorts before it and
+	// is excluded by range search; tblC is kept. (Range pruning alone suffices
+	// here, so also test a same-range case below.)
+	opt.Prefix = []byte("ccccc")
+	filtered := opt.pickTables(tables)
+	require.Equal(t, 1, len(filtered))
+	require.Equal(t, []byte("ccccc"), y.ParseKey(filtered[0].Smallest())[:5])
+
+	// Now make the ranges overlap so range pruning cannot help: build a table
+	// whose key range spans the scan prefix but which does NOT contain it, and
+	// rely on the prefix bloom to prune it.
+	opts := table.Options{
+		ChkMode:            options.OnTableAndBlockRead,
+		BloomFalsePositive: 0.01,
+		BlockSize:          4 * 1024,
+		BloomPrefixLength:  3,
+	}
+	// Keys "aaa..." and "zzz...": range [aaa, zzz] straddles prefix "mmm",
+	// but no key has prefix "mmm".
+	var kvs [][]string
+	for i := 0; i < 100; i++ {
+		kvs = append(kvs, []string{fmt.Sprintf("aaa%04d", i), "v"})
+		kvs = append(kvs, []string{fmt.Sprintf("zzz%04d", i), "v"})
+	}
+	straddle := buildTable(t, kvs, opts)
+	defer func() { require.NoError(t, straddle.DecrRef()) }()
+
+	opt.Prefix = []byte("mmm")
+	// Range pruning keeps straddle (aaa <= mmm <= zzz), but the prefix bloom
+	// proves "mmm" is absent, so pickTables must drop it.
+	filtered = opt.pickTables([]*table.Table{straddle})
+	require.Equal(t, 0, len(filtered), "prefix bloom should prune straddling table")
+
+	// A present prefix is kept.
+	opt.Prefix = []byte("aaa")
+	filtered = opt.pickTables([]*table.Table{straddle})
+	require.Equal(t, 1, len(filtered))
 }
 
 func TestIterateSinceTs(t *testing.T) {
@@ -412,4 +527,58 @@ func BenchmarkIteratePrefixSingleKey(b *testing.B) {
 			}
 		}
 	})
+}
+
+// TestPrefixBloomEndToEnd opens a DB with WithBloomPrefixLength set, flushes the
+// data to SSTables, and verifies that prefix scans return correct results:
+// present prefixes return all their keys, and an absent prefix returns nothing.
+// This exercises the full build -> persist -> read -> pickTables path.
+func TestPrefixBloomEndToEnd(t *testing.T) {
+	dir, err := os.MkdirTemp("", "badger-pbloom")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	opts := getTestOptions(dir).WithBloomPrefixLength(6)
+	db, err := Open(opts)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	prefixes := []string{"users:", "posts:", "likess"}
+	const perPrefix = 500
+	wb := db.NewWriteBatch()
+	for _, p := range prefixes {
+		for i := 0; i < perPrefix; i++ {
+			k := []byte(fmt.Sprintf("%s%06d", p, i))
+			require.NoError(t, wb.Set(k, []byte("v")))
+		}
+	}
+	require.NoError(t, wb.Flush())
+
+	// Push memtables to SSTables on disk so the table-level prefix bloom is used.
+	require.NoError(t, db.Flatten(2))
+
+	count := func(prefix string) int {
+		n := 0
+		require.NoError(t, db.View(func(txn *Txn) error {
+			io := DefaultIteratorOptions
+			io.Prefix = []byte(prefix)
+			it := txn.NewIterator(io)
+			defer it.Close()
+			for it.Rewind(); it.Valid(); it.Next() {
+				require.True(t, bytes.HasPrefix(it.Item().Key(), []byte(prefix)))
+				n++
+			}
+			return nil
+		}))
+		return n
+	}
+
+	// Present prefixes return all their keys.
+	for _, p := range prefixes {
+		require.Equalf(t, perPrefix, count(p), "prefix %q", p)
+	}
+
+	// Absent prefixes (>= prefix-bloom length) return nothing and are pruned.
+	require.Equal(t, 0, count("absent"))
+	require.Equal(t, 0, count("zzzzzz"))
 }

--- a/options.go
+++ b/options.go
@@ -64,6 +64,7 @@ type Options struct {
 	// read from the block index stored at the end of the table.
 	BlockSize          int
 	BloomFalsePositive float64
+	BloomPrefixLength  int
 	BlockCacheSize     int64
 	IndexCacheSize     int64
 
@@ -187,6 +188,7 @@ func buildTableOptions(db *DB) table.Options {
 		TableSize:            uint64(opt.BaseTableSize),
 		BlockSize:            opt.BlockSize,
 		BloomFalsePositive:   opt.BloomFalsePositive,
+		BloomPrefixLength:    opt.BloomPrefixLength,
 		ChkMode:              opt.ChecksumVerificationMode,
 		Compression:          opt.Compression,
 		ZSTDCompressionLevel: opt.ZSTDCompressionLevel,
@@ -543,6 +545,29 @@ func (opt Options) WithMemTableSize(val int64) Options {
 // Setting this to 0 disables the bloom filter completely.
 func (opt Options) WithBloomFalsePositive(val float64) Options {
 	opt.BloomFalsePositive = val
+	return opt
+}
+
+// WithBloomPrefixLength returns a new Options value with BloomPrefixLength set
+// to the given value.
+//
+// When BloomPrefixLength is greater than 0, each SSTable additionally stores a
+// bloom filter built over the first BloomPrefixLength bytes of every user key.
+// Prefix-bounded iterators (those that set IteratorOptions.Prefix) can then
+// consult this filter to skip whole SSTables that provably contain no key with
+// the scan prefix, instead of relying on key-range pruning alone.
+//
+// The prefix bloom is only effective for scan prefixes at least
+// BloomPrefixLength bytes long; shorter prefixes never prune. Choose a value
+// matching the common length of the prefixes you scan by.
+//
+// This is fully backward compatible: tables written with BloomPrefixLength == 0
+// (the default) behave exactly as before, and tables written with a prefix
+// bloom remain readable by code that ignores it.
+//
+// The default value of BloomPrefixLength is 0 (disabled).
+func (opt Options) WithBloomPrefixLength(val int) Options {
+	opt.BloomPrefixLength = val
 	return opt
 }
 

--- a/table/builder.go
+++ b/table/builder.go
@@ -74,6 +74,7 @@ type Builder struct {
 
 	lenOffsets    uint32
 	keyHashes     []uint32 // Used for building the bloomfilter.
+	prefixHashes  []uint32 // Used for building the optional prefix bloomfilter.
 	opts          *Options
 	maxVersion    uint64
 	onDiskSize    uint32
@@ -207,7 +208,18 @@ func (b *Builder) keyDiff(newKey []byte) []byte {
 }
 
 func (b *Builder) addHelper(key []byte, v y.ValueStruct, vpLen uint32) {
-	b.keyHashes = append(b.keyHashes, y.Hash(y.ParseKey(key)))
+	userKey := y.ParseKey(key)
+	b.keyHashes = append(b.keyHashes, y.Hash(userKey))
+
+	// When prefix blooms are enabled, hash the leading prefix of each user key
+	// into a separate filter so prefix-bounded seeks can prune tables. Keys
+	// shorter than the prefix length are hashed whole.
+	if n := b.opts.BloomPrefixLength; n > 0 {
+		if n > len(userKey) {
+			n = len(userKey)
+		}
+		b.prefixHashes = append(b.prefixHashes, y.Hash(userKey[:n]))
+	}
 
 	if version := y.ParseTs(key); version > b.maxVersion {
 		b.maxVersion = version
@@ -436,7 +448,14 @@ func (b *Builder) Done() buildData {
 		bits := y.BloomBitsPerKey(len(b.keyHashes), b.opts.BloomFalsePositive)
 		f = y.NewFilter(b.keyHashes, bits)
 	}
-	index, dataSize := b.buildIndex(f)
+
+	// Build the optional prefix bloom filter from the per-key prefix hashes.
+	var pf y.Filter
+	if b.opts.BloomPrefixLength > 0 && b.opts.BloomFalsePositive > 0 && len(b.prefixHashes) > 0 {
+		bits := y.BloomBitsPerKey(len(b.prefixHashes), b.opts.BloomFalsePositive)
+		pf = y.NewFilter(b.prefixHashes, bits)
+	}
+	index, dataSize := b.buildIndex(f, pf)
 
 	var err error
 	if b.shouldEncrypt() {
@@ -523,7 +542,7 @@ func (b *Builder) compressData(data []byte) ([]byte, error) {
 	return nil, errors.New("Unsupported compression type")
 }
 
-func (b *Builder) buildIndex(bloom []byte) ([]byte, uint32) {
+func (b *Builder) buildIndex(bloom, prefixBloom []byte) ([]byte, uint32) {
 	builder := fbs.NewBuilder(3 << 20)
 
 	boList, dataSize := b.writeBlockOffsets(builder)
@@ -541,6 +560,12 @@ func (b *Builder) buildIndex(bloom []byte) ([]byte, uint32) {
 	if len(bloom) > 0 {
 		bfoff = builder.CreateByteVector(bloom)
 	}
+	// Write the optional prefix bloom filter. Byte vectors must be created
+	// before the enclosing object is started, so do it here alongside bloom.
+	var pbfoff fbs.UOffsetT
+	if len(prefixBloom) > 0 {
+		pbfoff = builder.CreateByteVector(prefixBloom)
+	}
 	b.onDiskSize += dataSize
 	fb.TableIndexStart(builder)
 	fb.TableIndexAddOffsets(builder, boEnd)
@@ -550,6 +575,10 @@ func (b *Builder) buildIndex(bloom []byte) ([]byte, uint32) {
 	fb.TableIndexAddKeyCount(builder, uint32(len(b.keyHashes)))
 	fb.TableIndexAddOnDiskSize(builder, b.onDiskSize)
 	fb.TableIndexAddStaleDataSize(builder, uint32(b.staleDataSize))
+	if len(prefixBloom) > 0 {
+		fb.TableIndexAddBloomPrefixFilter(builder, pbfoff)
+		fb.TableIndexAddBloomPrefixLength(builder, uint32(b.opts.BloomPrefixLength))
+	}
 	builder.Finish(fb.TableIndexEnd(builder))
 
 	buf := builder.FinishedBytes()

--- a/table/table.go
+++ b/table/table.go
@@ -56,6 +56,11 @@ type Options struct {
 	// BloomFalsePositive is the false positive probabiltiy of bloom filter.
 	BloomFalsePositive float64
 
+	// BloomPrefixLength, when > 0, builds an additional bloom filter over the
+	// first BloomPrefixLength bytes of each user key, enabling prefix-bounded
+	// seeks to skip whole SSTables. 0 (the default) disables it.
+	BloomPrefixLength int
+
 	// BlockSize is the size of each block inside SSTable in bytes.
 	BlockSize int
 
@@ -80,6 +85,7 @@ type TableInterface interface {
 	Smallest() []byte
 	Biggest() []byte
 	DoesNotHave(hash uint32) bool
+	DoesNotHavePrefix(prefix []byte) bool
 	MaxVersion() uint64
 }
 
@@ -98,11 +104,13 @@ type Table struct {
 	smallest, biggest []byte // Smallest and largest keys (with timestamps).
 	id                uint64 // file id, part of filename
 
-	Checksum       []byte
-	CreatedAt      time.Time
-	indexStart     int
-	indexLen       int
-	hasBloomFilter bool
+	Checksum         []byte
+	CreatedAt        time.Time
+	indexStart       int
+	indexLen         int
+	hasBloomFilter   bool
+	hasPrefixBloom   bool
+	prefixBloomLen   int // Number of leading user-key bytes hashed into the prefix bloom.
 
 	IsInmemory bool // Set to true if the table is on level 0 and opened in memory.
 	opt        *Options
@@ -467,6 +475,8 @@ func (t *Table) initIndex() (*fb.BlockOffset, error) {
 	}
 
 	t.hasBloomFilter = len(index.BloomFilterBytes()) > 0
+	t.prefixBloomLen = int(index.BloomPrefixLength())
+	t.hasPrefixBloom = t.prefixBloomLen > 0 && len(index.BloomPrefixFilterBytes()) > 0
 
 	var bo fb.BlockOffset
 	y.AssertTrue(index.Offsets(&bo, 0))
@@ -677,6 +687,38 @@ func (t *Table) DoesNotHave(hash uint32) bool {
 	mayContain := y.Filter(bf).MayContain(hash)
 	if !mayContain {
 		y.NumLSMBloomHitsAdd(t.opt.MetricsEnabled, "DoesNotHave_HIT", 1)
+	}
+	return !mayContain
+}
+
+// PrefixBloomLength returns the number of leading user-key bytes hashed into the
+// prefix bloom filter, or 0 if this table has no prefix bloom.
+func (t *Table) PrefixBloomLength() int { return t.prefixBloomLen }
+
+// DoesNotHavePrefix returns true if and only if the table's prefix bloom filter
+// proves that no key with the given prefix is present. The prefix is hashed
+// using exactly the table's prefix-bloom length (the leading bytes of prefix);
+// callers must only consult it when len(prefix) >= t.PrefixBloomLength(),
+// otherwise it returns false (cannot prune). Tables without a prefix bloom
+// always return false so they are never skipped.
+func (t *Table) DoesNotHavePrefix(prefix []byte) bool {
+	if !t.hasPrefixBloom {
+		return false
+	}
+	// We can only prune when the scan prefix is at least as long as the bytes
+	// that were hashed; otherwise the hash of prefix[:prefixBloomLen] is
+	// undefined for this query.
+	if len(prefix) < t.prefixBloomLen {
+		return false
+	}
+	hash := y.Hash(prefix[:t.prefixBloomLen])
+
+	y.NumLSMBloomHitsAdd(t.opt.MetricsEnabled, "DoesNotHavePrefix_ALL", 1)
+	index := t.fetchIndex()
+	bf := index.BloomPrefixFilterBytes()
+	mayContain := y.Filter(bf).MayContain(hash)
+	if !mayContain {
+		y.NumLSMBloomHitsAdd(t.opt.MetricsEnabled, "DoesNotHavePrefix_HIT", 1)
 	}
 	return !mayContain
 }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -896,3 +896,71 @@ func TestMaxVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, N, int(table.MaxVersion()))
 }
+
+// buildPrefixTable builds a table from the given user-key strings (sorted),
+// with the supplied options applied on top of getTestTableOptions.
+func buildPrefixTable(t *testing.T, keys []string, prefixLen int) *Table {
+	opts := getTestTableOptions()
+	opts.BloomPrefixLength = prefixLen
+	kvs := make([][]string, len(keys))
+	for i, k := range keys {
+		kvs[i] = []string{k, fmt.Sprintf("v%d", i)}
+	}
+	return buildTable(t, kvs, opts)
+}
+
+func TestPrefixBloomBasic(t *testing.T) {
+	// Keys all under prefixes "alpha" and "beta", none under "gamma".
+	var keys []string
+	for i := 0; i < 100; i++ {
+		keys = append(keys, fmt.Sprintf("alpha:%04d", i))
+		keys = append(keys, fmt.Sprintf("beta:%04d", i))
+	}
+	tbl := buildPrefixTable(t, keys, 5) // 5 = len("alpha")/len("beta")
+	defer tbl.DecrRef()
+
+	require.Equal(t, 5, tbl.PrefixBloomLength())
+
+	// Present prefixes must not be pruned.
+	require.False(t, tbl.DoesNotHavePrefix([]byte("alpha")))
+	require.False(t, tbl.DoesNotHavePrefix([]byte("beta:")))
+
+	// An absent prefix of the hashed length should be pruned.
+	require.True(t, tbl.DoesNotHavePrefix([]byte("gamma")))
+
+	// A prefix shorter than the bloom length cannot prune (conservative).
+	require.False(t, tbl.DoesNotHavePrefix([]byte("al")))
+}
+
+func TestPrefixBloomDisabledByDefault(t *testing.T) {
+	// BloomPrefixLength == 0 => no prefix bloom; DoesNotHavePrefix always false.
+	keys := []string{"alpha:1", "alpha:2", "beta:1"}
+	tbl := buildPrefixTable(t, keys, 0)
+	defer tbl.DecrRef()
+
+	require.Equal(t, 0, tbl.PrefixBloomLength())
+	require.False(t, tbl.DoesNotHavePrefix([]byte("gamma")))
+	require.False(t, tbl.DoesNotHavePrefix([]byte("zzzzz")))
+
+	// Full-key bloom is unaffected: an absent key is reported missing.
+	require.True(t, tbl.DoesNotHave(y.Hash([]byte("nope"))))
+	require.False(t, tbl.DoesNotHave(y.Hash([]byte("alpha:1"))))
+}
+
+// TestPrefixBloomOldFormatTable verifies that a table written WITHOUT the
+// prefix-bloom fields (the previous on-disk format) opens fine and reports no
+// prefix bloom, exercising the FlatBuffers backward-compatibility path.
+func TestPrefixBloomOldFormatTable(t *testing.T) {
+	// getTestTableOptions has BloomPrefixLength == 0, so this table is written
+	// with exactly the old format (no appended flatbuffer fields).
+	tbl := buildTestTable(t, "key", 5000, getTestTableOptions())
+	defer tbl.DecrRef()
+
+	require.Equal(t, 0, tbl.PrefixBloomLength())
+	require.False(t, tbl.DoesNotHavePrefix([]byte("key0")))
+	require.False(t, tbl.DoesNotHavePrefix([]byte("absent")))
+
+	// And the full-key bloom still works as before.
+	require.False(t, tbl.DoesNotHave(y.Hash([]byte("key0001"))))
+	require.True(t, tbl.DoesNotHave(y.Hash([]byte("zzzz9999"))))
+}


### PR DESCRIPTION
## Motivation

The per-table bloom filter is built over the full user key and is only consulted for single-key iteration (`prefixIsKey`). A real prefix scan over many distinct keys sharing a prefix gets no bloom benefit — only key-range pruning. Prefix scans are a common access pattern (all keys under a predicate/namespace).

## What changed

New opt-in `WithBloomPrefixLength(n)` (default 0 = disabled). When `n > 0`, each SSTable additionally stores a bloom filter built over the first `n` bytes of every user key. A prefix-bounded scan then consults it (`Table.DoesNotHavePrefix`) in `pickTable`/`pickTables` to skip whole SSTables that provably contain no key with the scan prefix — pruning tables whose key range straddles the prefix where range-pruning alone can't help.

Stored as two appended `TableIndex` flatbuffer fields (`bloom_prefix_filter`, `bloom_prefix_length`).

## Compatibility & correctness

`DoesNotHavePrefix` is conservative: it returns "do not skip" unless the table has a prefix bloom **and** the scan prefix is at least `prefixBloomLength` bytes **and** the bloom proves absence. Keys shorter than `n` are hashed whole (they can't match a longer scan prefix anyway). Tables written without a prefix bloom (old format, or `n == 0`) are never skipped. Default (`BloomPrefixLength == 0`) behavior is byte-for-byte unchanged.

## Testing

`go build`, `go vet`, `go test . ./table/...` green. Tests cover: present prefix returns all matches; absent prefix pruned (incl. a table whose key range straddles the absent prefix); short scan prefix conservatively not pruned; old-format table opens and is never skipped; default-off unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtGkC4K2J2XYwcAKwjhHbM
