### PR TITLE
chore: prepare for release v4.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [4.9.4] - 2026-07-08
+
+**Fixed**
+
+- fix(db): don't drop acknowledged writes during DropPrefix/DropAll (#2313)
+- fix: fix an issue where the compactor causes previously deleted data to reappear (#2278)
+
+**Docs**
+
+- docs(changelog): backfill 4.9.2, add 4.9.3, fix 4.9.0 compare link (#2311)
+
+**Full Changelog**: https://github.com/dgraph-io/badger/compare/v4.9.3...v4.9.4
+
 ## [4.9.3] - 2026-07-06
 
 **Performance**


### PR DESCRIPTION
## Summary

Prep for the `v4.9.4` patch release. Adds the `CHANGELOG.md` entry covering everything landed on `main` since `v4.9.3`.

## Changes since v4.9.3

**Fixed**

- fix(db): don't drop acknowledged writes during DropPrefix/DropAll (#2313)
- fix: fix an issue where the compactor causes previously deleted data to reappear (#2278)

**Docs**

- docs(changelog): backfill 4.9.2, add 4.9.3, fix 4.9.0 compare link (#2311)

## Notes

- No on-disk format changes, so no export/import step is required on upgrade.
- No dependency bumps (Ristretto stays at `v2.2.0`).
- `trunk check CHANGELOG.md` passes clean.

## After merge

Patch release, so no `release/*` branch. Remaining steps from `contrib/RELEASE.md`:

1. Create the draft GitHub release for `v4.9.4`.
2. Run the `cd-badger` CD workflow to build and publish artifacts.
3. Splash the go index cache: `go list -m github.com/dgraph-io/badger/v4@v4.9.4`.