### PR TITLE
fix: prevent nil deref when reading in-memory tables

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -553,7 +553,7 @@ func (t *Table) block(idx int, useCache bool) (*Block, error) {
 	if blk.data, err = t.read(blk.offset, int(ko.Len())); err != nil {
 		return nil, y.Wrapf(err,
 			"failed to read from file: %s at offset: %d, len: %d",
-			t.Fd.Name(), blk.offset, ko.Len())
+			t.Filename(), blk.offset, ko.Len())
 	}
 
 	if t.shouldDecrypt() {
@@ -568,7 +568,7 @@ func (t *Table) block(idx int, useCache bool) (*Block, error) {
 	if err = t.decompress(blk); err != nil {
 		return nil, y.Wrapf(err,
 			"failed to decode compressed data in file: %s at offset: %d, len: %d",
-			t.Fd.Name(), blk.offset, ko.Len())
+			t.Filename(), blk.offset, ko.Len())
 	}
 
 	// Read meta data related to block.
@@ -659,7 +659,12 @@ func (t *Table) Smallest() []byte { return t.smallest }
 func (t *Table) Biggest() []byte { return t.biggest }
 
 // Filename is NOT the file name.  Just kidding, it is.
-func (t *Table) Filename() string { return t.Fd.Name() }
+func (t *Table) Filename() string {
+	if t.Fd == nil {
+		return IDToFilename(t.id)
+	}
+	return t.Fd.Name()
+}
 
 // ID is the table's ID number (used to make the file name).
 func (t *Table) ID() uint64 { return t.id }

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dgraph-io/badger/v4/options"
 	"github.com/dgraph-io/badger/v4/y"
 	"github.com/dgraph-io/ristretto/v2"
+	"github.com/dgraph-io/ristretto/v2/z"
 )
 
 func key(prefix string, i int) string {
@@ -895,4 +896,40 @@ func TestMaxVersion(t *testing.T) {
 	table, err := CreateTable(filename, b)
 	require.NoError(t, err)
 	require.Equal(t, N, int(table.MaxVersion()))
+}
+
+func TestInMemoryTableBlockErrorNoPanic(t *testing.T) {
+	opts := getTestTableOptions()
+	src := buildTestTable(t, "key", 500, opts)
+
+	data := make([]byte, len(src.Data))
+	copy(data, src.Data)
+	srcID := src.ID()
+	require.NoError(t, src.DecrRef())
+
+	tbl, err := OpenInMemoryTable(data, srcID, &opts)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, tbl.DecrRef()) }()
+
+	corruptEnd := tbl.indexStart
+	if corruptEnd > 256 {
+		corruptEnd = 256
+	}
+	for i := 0; i < corruptEnd; i++ {
+		data[i] = 0xFF
+	}
+
+	require.NotPanics(t, func() {
+		_, err = tbl.block(0, false)
+	})
+	require.Error(t, err)
+}
+
+func TestInMemoryTableFilename(t *testing.T) {
+	tbl := &Table{
+		MmapFile: &z.MmapFile{Data: []byte{}, Fd: nil},
+		id:       777,
+		opt:      &Options{},
+	}
+	require.Equal(t, IDToFilename(777), tbl.Filename())
 }


### PR DESCRIPTION
## Description

Fixes #2105.

Hi, when Badger is running in in-memory mode (Options.InMemory = true), SSTables exist entirely in memory and don't have an underlying file. There were two error paths in (*Table).block that accessed the table's filename directly to produce a more descriptive error. Since in-memory tables don't have a file handle, those paths could dereference a nil pointer and panic.

This shows up whenever a block read fails on an in-memory table. A few real situations that trigger it:

- **Bad RAM / bit flips** -- in-memory tables have no checksums, so a single flipped bit in a compressed block makes decompression fail. The reporter was running on an ARMv7 with 1GB of RAM, which makes this kind of corruption much more likely.
- **Interrupted memtable flush** -- if a flush into an in-memory L0 table is cut short by an OOM or signal, the table bytes end up half-written. The next read of that table hits the panic instead of returning a clean error.
- **Compression mismatch** -- building a table with one compression algorithm (say, zstd) and reading it back with a different one causes decompression to fail, which takes the same panicking path.

The fix keeps things minimal. `Filename()` now returns a stable, convention-matching name derived from the table ID when there's no file handle, and the two direct filename lookups in `block()` go through `Filename()` as well. On-disk tables are completely unaffected.

Added two tests:

- `TestInMemoryTableBlockErrorNoPanic` -- corrupts a compressed in-memory table and asserts `block()` returns an error instead of panicking. Reproduces the exact panic from the issue on `main` before the fix.
- `TestInMemoryTableFilename` -- verifies the synthesized name returned for an in-memory table.

## Checklist

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
