### PR TITLE
bugfix(cli): don't require --dir for completion commands

### DIFF
--- a/badger/cmd/root.go
+++ b/badger/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -41,8 +40,10 @@ func init() {
 }
 
 func validateRootCmdArgs(cmd *cobra.Command, args []string) error {
-	if strings.HasPrefix(cmd.Use, "help ") { // No need to validate if it is help
-		return nil
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "help" || c.Name() == "completion" {
+			return nil
+		}
 	}
 	if sstDir == "" {
 		return errors.New("--dir not specified")

--- a/badger/cmd/root_test.go
+++ b/badger/cmd/root_test.go
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletionWithoutDir(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			oldSstDir := sstDir
+			defer func() { sstDir = oldSstDir }()
+			sstDir = ""
+
+			RootCmd.SetOut(new(bytes.Buffer))
+			RootCmd.SetArgs([]string{"completion", shell})
+
+			err := RootCmd.Execute()
+			require.NoError(t, err, "completion %s should not require --dir", shell)
+		})
+	}
+}
+
+func TestInfoWithoutDirFails(t *testing.T) {
+	oldSstDir := sstDir
+	defer func() { sstDir = oldSstDir }()
+	sstDir = ""
+
+	RootCmd.SetArgs([]string{"info"})
+	err := RootCmd.Execute()
+	require.Error(t, err, "info without --dir should fail")
+	require.Contains(t, err.Error(), "--dir not specified")
+}

--- a/badger/main.go
+++ b/badger/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
+	"os"
 	"runtime"
 
 	"github.com/dustin/go-humanize"
@@ -19,6 +20,11 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "completion" {
+		cmd.Execute()
+		return
+	}
+
 	go func() {
 		for i := 8080; i < 9080; i++ {
 			fmt.Printf("Listening for /debug HTTP requests at port: %d\n", i)


### PR DESCRIPTION
Fixes #2315.

badger completion bash was failing with --dir not specified because PersistentPreRunE validated flags for all subcommands, including completion. Even with --dir passed, debug output (HTTP server, jemalloc stats) leaked into stdout, breaking shell sourcing.

Skip flag validation and diagnostic output for completion commands. Adds tests for both the fix and the existing --dir enforcement.

