### PR TITLE
fix: prevent data race between sendToWriteCh and DB close (#2249)

### DIFF
--- a/db.go
+++ b/db.go
@@ -115,6 +115,7 @@ type DB struct {
 	blockWrites atomic.Int32
 	isClosed    atomic.Uint32
 
+	writeChInFlight atomic.Int32
 	// gcActive is set while a vlog GC rewrite (scan + write-back) is in flight,
 	// and gcDiscardTs records the DB's max version captured at its start. While
 	// active, last-level compaction clamps its discard threshold to gcDiscardTs
@@ -581,6 +582,10 @@ func (db *DB) close() (err error) {
 	// Stop writes next.
 	db.closers.writes.SignalAndWait()
 
+	// Drain pending requests and wait for in-flight senders to resolve
+	// before closing writeCh, so no goroutine sends on a closed channel.
+	db.drainWriteCh()
+
 	// Don't accept any more write.
 	close(db.writeCh)
 
@@ -914,7 +919,12 @@ func (db *DB) writeRequests(reqs []*request) error {
 }
 
 func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
+	// Increment the in-flight counter so close() knows a sender is inside this
+	// function and will not close writeCh until we bail out or succeed.
+	db.writeChInFlight.Add(1)
+
 	if db.blockWrites.Load() == 1 {
+		db.writeChInFlight.Add(-1)
 		return nil, ErrBlockedWrites
 	}
 	var count, size int64
@@ -924,6 +934,7 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 	}
 	y.NumBytesWrittenUserAdd(db.opt.MetricsEnabled, size)
 	if count >= db.opt.maxBatchCount || size >= db.opt.maxBatchSize {
+		db.writeChInFlight.Add(-1)
 		return nil, ErrTxnTooBig
 	}
 
@@ -933,11 +944,44 @@ func (db *DB) sendToWriteCh(entries []*Entry) (*request, error) {
 	req.reset()
 	req.Entries = entries
 	req.Wg.Add(1)
-	req.IncrRef()     // for db write
-	db.writeCh <- req // Handled in doWrites.
-	y.NumPutsAdd(db.opt.MetricsEnabled, int64(len(entries)))
+	req.IncrRef() // for db write
 
+	// Use select to avoid sending on writeCh after the writes closer has been
+	// signaled. If close() has initiated shutdown, HasBeenClosed() fires and we
+	// bail out cleanly instead of sending on a channel that is about to be closed
+	// (which would panic).
+	select {
+	case db.writeCh <- req:
+		// Successfully sent - doWrites will handle it.
+	case <-db.closers.writes.HasBeenClosed():
+		// Shutdown in progress - do not send. Release the request back to the
+		// pool and return an error so the caller can clean up (e.g. roll back
+		// the transaction).
+		req.DecrRef()
+		db.writeChInFlight.Add(-1)
+		return nil, ErrBlockedWrites
+	}
+
+	y.NumPutsAdd(db.opt.MetricsEnabled, int64(len(entries)))
+	db.writeChInFlight.Add(-1)
 	return req, nil
+}
+
+// drainWriteCh drains and rejects all pending requests from writeCh with
+// ErrBlockedWrites. It also waits for in-flight senders to resolve before
+// returning, so close() can safely close writeCh afterwards.
+func (db *DB) drainWriteCh() {
+	for {
+		select {
+		case req := <-db.writeCh:
+			req.Err = ErrBlockedWrites
+			req.Wg.Done()
+		default:
+			if db.writeChInFlight.Load() == 0 {
+				return
+			}
+		}
+	}
 }
 
 func (db *DB) doWrites(lc *z.Closer) {

--- a/db_test.go
+++ b/db_test.go
@@ -2735,3 +2735,34 @@ func TestCloseDBWhileReading(t *testing.T) {
 	require.NoError(t, db.Close())
 	wg.Wait()
 }
+
+// TestRaceSendToWriteChOnClose ensures that concurrent Commit calls do not
+// race with DB.Close. Before the fix, a sender could pass the blockWrites
+// check in sendToWriteCh while close() simultaneously closed writeCh,
+// causing a "send on closed channel" panic or a data race.
+func TestRaceSendToWriteChOnClose(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		dir := t.TempDir()
+		db, err := Open(DefaultOptions(dir))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				if err := db.Update(func(txn *Txn) error {
+					return txn.Set([]byte("key"), []byte("val"))
+				}); err != nil {
+					return // ErrBlockedWrites or DB closed
+				}
+			}
+		}()
+
+		time.Sleep(time.Microsecond)
+		db.Close()
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
**Description**

Fixes: https://github.com/dgraph-io/badger/issues/2249

Fix a data race between sendToWriteCh and db.Close(). A sender goroutine could pass the blockWrites check in sendToWriteCh while close() simultaneously closed writeCh, causing a "send on closed channel" panic.

Three changes:
- sendToWriteCh now uses a select over both writeCh <- req and HasBeenClosed() so senders bail cleanly with ErrBlockedWrites during shutdown, instead of sending on a channel that may have been closed.
- An atomic "writeChInFlight" counter tracks goroutines inside sendToWriteCh so close() knows when no sender remains.
- A new drainWriteCh() method drains and rejects any orphaned requests from the channel buffer after doWrites exits, ensuring no caller hangs on req.Wait().

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable