### PR TITLE
fix(compaction): restore size-ratio base level selection, clamped to the first non-empty level

### DIFF
--- a/.github/workflows/ci-badger-lsm-bench.yml
+++ b/.github/workflows/ci-badger-lsm-bench.yml
@@ -1,0 +1,122 @@
+name: ci-badger-lsm-bench
+
+# Bulk-load LSM performance benchmark (issue #2327 regression gate).
+#
+# Builds the same harness (integration/lsmbench) against the PR's base and the
+# PR's head, runs both on this runner, and fails if:
+#   - the head run shows the structural #2327 signature (base level collapsed
+#     to L1/L2 on a >2GB tree, tables stranded in L1/L2 at any checkpoint,
+#     or lifetime L0 stall > 30s), or
+#   - the head wall clock is >25% slower than the base run on the same
+#     hardware (self-baselining: no hardcoded absolute time, so the gate is
+#     meaningful regardless of runner speed).
+#
+# Runs independently of the unit tests and badger-bank; ~2x a single bulk
+# load of ~302M entries (~10GB on disk per run, cleaned between runs).
+
+on:
+  workflow_dispatch: # allows manual trigger from GitHub
+  pull_request:
+    branches:
+      - main
+      - release/v*
+
+permissions:
+  contents: read
+
+env:
+  LSMBENCH_ROWS: 500000 # ~302M entries, ~10GB LSM
+
+jobs:
+  # Detect whether any non-doc files changed, mirroring the other CI
+  # workflows: the job always reports a status, and short-circuits to success
+  # for docs-only PRs.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!images/**'
+
+  lsm-bench:
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - if: needs.changes.outputs.code == 'true'
+        uses: actions/checkout@v5
+      - if: needs.changes.outputs.code == 'true'
+        name: Checkout baseline (PR base)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          path: base-checkout
+      - if: needs.changes.outputs.code == 'true'
+        name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - if: needs.changes.outputs.code == 'true'
+        name: Build harnesses (head + baseline)
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+          # Head: harness compiled against this checkout.
+          go build -o /tmp/lsmbench-head ./integration/lsmbench/
+          # Baseline: same harness source compiled against the base checkout,
+          # via a scratch module so the import resolves to the old tree.
+          mkdir /tmp/base-mod && cp integration/lsmbench/main.go /tmp/base-mod/
+          cd /tmp/base-mod
+          go mod init lsmbench-base
+          go mod edit -require=github.com/dgraph-io/badger/v4@v4.0.0 \
+            -replace=github.com/dgraph-io/badger/v4="$GITHUB_WORKSPACE/base-checkout"
+          go mod tidy
+          go build -o /tmp/lsmbench-base .
+      - if: needs.changes.outputs.code == 'true'
+        name: Run baseline benchmark
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+          # No gates on the baseline run: it only provides the wall-clock
+          # reference, and the base commit may itself carry a known regression.
+          /tmp/lsmbench-base -dir /tmp/bench-base -rows "$LSMBENCH_ROWS" | tee /tmp/base.out
+          rm -rf /tmp/bench-base
+      - if: needs.changes.outputs.code == 'true'
+        name: Run head benchmark (structural gates enforced)
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+          /tmp/lsmbench-head -dir /tmp/bench-head -rows "$LSMBENCH_ROWS" \
+            -min-base 3 -max-stall 30s -max-shallow-occupied 0 | tee /tmp/head.out
+          rm -rf /tmp/bench-head
+      - if: needs.changes.outputs.code == 'true'
+        name: Compare wall clock (head vs baseline)
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+          base_ms=$(grep LSMBENCH_RESULT /tmp/base.out | grep -o 'wall_ms=[0-9]*' | cut -d= -f2)
+          head_ms=$(grep LSMBENCH_RESULT /tmp/head.out | grep -o 'wall_ms=[0-9]*' | cut -d= -f2)
+          limit_ms=$(( base_ms * 125 / 100 ))
+          {
+            echo "### LSM bulk-load benchmark (${LSMBENCH_ROWS} rows)"
+            echo ""
+            echo "| run | result |"
+            echo "|---|---|"
+            echo "| baseline | $(grep LSMBENCH_RESULT /tmp/base.out) |"
+            echo "| head | $(grep LSMBENCH_RESULT /tmp/head.out) |"
+            echo ""
+            echo "Wall clock: head ${head_ms}ms vs baseline ${base_ms}ms (limit: ${limit_ms}ms = 125% of baseline)"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "baseline=${base_ms}ms head=${head_ms}ms limit=${limit_ms}ms"
+          if [ "$head_ms" -gt "$limit_ms" ]; then
+            echo "::error::head wall clock ${head_ms}ms is more than 25% slower than baseline ${base_ms}ms"
+            exit 1
+          fi

--- a/integration/lsmbench/main.go
+++ b/integration/lsmbench/main.go
@@ -1,0 +1,317 @@
+/*
+ * SPDX-FileCopyrightText: © Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// lsmbench is a bulk-load LSM benchmark used to detect compaction
+// performance regressions (issue #2327). It recreates the reproducer from
+// that issue: ~300M small entries written through db.Update in batches of
+// 5000 against default options, keys spread across several top-level
+// prefixes.
+//
+// It intentionally uses only badger's public API so the same harness can be
+// compiled against any badger version (the module's replace directive points
+// at the working tree; CI repoints it at a baseline checkout to compare the
+// two on identical hardware).
+//
+// Beyond wall time, it tracks the structural signature of the #2327
+// regression, which is hardware-independent:
+//
+//   - the base level must not collapse to L1/L2 once the tree is large
+//     (healthy: L3+; broken: pinned at L1 from ~170M entries onward), and
+//   - lifetime L0 write stalls must stay near zero (healthy: 0s; broken:
+//     ~1-2 minutes at this scale).
+//
+// Exit code is non-zero if any enabled gate fails. The final line of output
+// is machine-readable:
+//
+//	LSMBENCH_RESULT wall_ms=... stall_ms=... min_base=... final_base=... lsm_mb=... entries=...
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+type config struct {
+	dir           string
+	rows          int
+	minBase       int           // fail if base level drops below this on a big tree; 0 disables
+	maxStall      time.Duration // fail if lifetime L0 stall exceeds this; 0 disables
+	maxShallowOcc int           // fail if more than this many big-tree checkpoints had tables in L1/L2; -1 disables
+}
+
+type results struct {
+	wall      time.Duration
+	stall     time.Duration
+	minBase   int // lowest base level seen while LSM > bigTreeBytes; -1 if tree never got big
+	finalBase int
+	lsmBytes  int64
+	entries   int
+
+	// Checkpoint-sampled counters, only counted while LSM > bigTreeBytes.
+	// Checkpoints are entry-indexed (every checkpointEvery entries), so these
+	// are comparable across machines of different speeds.
+	bigCheckpoints  int // checkpoints taken on a big tree
+	collapsedCp     int // ... where the base level was L2 or shallower
+	shallowOccCp    int // ... where L1 or L2 held any tables
+	slowCompactures map[string]int
+}
+
+const (
+	numFields       = 300
+	batchSize       = 5000
+	checkpointEvery = 10_000_000
+
+	// The base-level gate only applies once the tree is large enough that the
+	// size-ratio target is deep: at 2GB the level targets are L6=2GB,
+	// L5=200MB, L4=20MB, L3=10MB, so a healthy base level is L3 or deeper.
+	bigTreeBytes = 2 << 30
+)
+
+// stallLogger wraps badger's default logger and records the "Lifetime L0
+// stalled for: <duration>" line that levelsController prints on Close. Log
+// scraping is deliberate: it works on every badger version, old and new,
+// which is what allows baseline-vs-head comparison with one harness.
+type stallLogger struct {
+	badger.Logger
+	mu       sync.Mutex
+	stall    time.Duration
+	compacts map[string]int // slow (>2s) compactions by "src->dst"
+}
+
+var (
+	stallRe = regexp.MustCompile(`Lifetime L0 stalled for: (\S+)`)
+	// Note: badger only logs compactions that took >2s, so these counts are
+	// diagnostics for humans, not a gate — fast hardware can complete even a
+	// pathological 0->1 compaction under the logging threshold.
+	compactRe = regexp.MustCompile(`LOG Compact (\d+)->(\d+)`)
+)
+
+func (l *stallLogger) Infof(format string, args ...any) {
+	line := fmt.Sprintf(format, args...)
+	if m := stallRe.FindStringSubmatch(line); m != nil {
+		if d, err := time.ParseDuration(m[1]); err == nil {
+			l.mu.Lock()
+			l.stall = d
+			l.mu.Unlock()
+		}
+	}
+	if m := compactRe.FindStringSubmatch(line); m != nil {
+		l.mu.Lock()
+		if l.compacts == nil {
+			l.compacts = map[string]int{}
+		}
+		l.compacts[m[1]+"->"+m[2]]++
+		l.mu.Unlock()
+	}
+	l.Logger.Infof(format, args...)
+}
+
+func baseLevel(db *badger.DB) int {
+	for _, li := range db.Levels() {
+		if li.IsBaseLevel {
+			return li.Level
+		}
+	}
+	return -1
+}
+
+func run(cfg config) (results, error) {
+	res := results{minBase: -1}
+
+	opts := badger.DefaultOptions(cfg.dir)
+	logger := &stallLogger{Logger: opts.Logger}
+	opts = opts.WithLogger(logger)
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		return res, fmt.Errorf("open: %w", err)
+	}
+
+	typePrefixes := []string{"type1", "type2", "type3", "type4", "type5"}
+	fieldNames := make([]string, numFields)
+	for f := 0; f < numFields; f++ {
+		fieldNames[f] = fmt.Sprintf("FIELD_%03d", f)
+	}
+
+	rng := rand.New(rand.NewSource(42))
+	value := func() []byte {
+		buf := make([]byte, 0, 24)
+		now := uint64(time.Now().UnixNano())
+		for i := 0; i < 8; i++ {
+			buf = append(buf, byte(now>>(8*i)))
+		}
+		return fmt.Appendf(buf, "%d.%d", rng.Int63n(1_000_000), rng.Int63n(1000))
+	}
+
+	batch := make([]*badger.Entry, 0, batchSize+10)
+	commit := func() error {
+		err := db.Update(func(txn *badger.Txn) error {
+			for _, e := range batch {
+				if err := txn.SetEntry(e); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		batch = batch[:0]
+		return err
+	}
+
+	start := time.Now()
+	total := 0
+
+	checkpoint := func() {
+		lsm, _ := db.Size()
+		levels := db.Levels()
+		base, shallowTables := -1, 0
+		for _, li := range levels {
+			if li.IsBaseLevel {
+				base = li.Level
+			}
+			if li.Level == 1 || li.Level == 2 {
+				shallowTables += li.NumTables
+			}
+		}
+		fmt.Printf("checkpoint entries=%d elapsed=%s lsm_mb=%d base=L%d l1l2_tables=%d\n",
+			total, time.Since(start).Round(time.Second), lsm/(1<<20), base, shallowTables)
+		if lsm > bigTreeBytes {
+			res.bigCheckpoints++
+			if base >= 0 && (res.minBase == -1 || base < res.minBase) {
+				res.minBase = base
+			}
+			if base >= 0 && base <= 2 {
+				res.collapsedCp++
+			}
+			if shallowTables > 0 {
+				res.shallowOccCp++
+			}
+		}
+	}
+
+	for row := 0; row < cfg.rows; row++ {
+		secID := fmt.Sprintf("SEC%08d 12345678", row)
+		prefixes := []string{
+			"unknown_id:" + secID + ":",
+			typePrefixes[row%len(typePrefixes)] + ":" + secID + ":",
+		}
+		for _, prefix := range prefixes {
+			for f := 0; f < numFields; f++ {
+				batch = append(batch, badger.NewEntry([]byte(prefix+fieldNames[f]), value()))
+				total++
+				if len(batch) >= batchSize {
+					if err := commit(); err != nil {
+						return res, fmt.Errorf("commit: %w", err)
+					}
+				}
+				if total%checkpointEvery == 0 {
+					checkpoint()
+				}
+			}
+		}
+		for i := 0; i < 4; i++ {
+			suffix := fmt.Sprintf(":%010d:ID_%s", rng.Int63n(10_000_000_000), typePrefixes[0])
+			batch = append(batch,
+				badger.NewEntry([]byte(typePrefixes[(row+i+1)%len(typePrefixes)]+suffix), []byte(secID)))
+			total++
+			if len(batch) >= batchSize {
+				if err := commit(); err != nil {
+					return res, fmt.Errorf("commit: %w", err)
+				}
+			}
+		}
+	}
+	if len(batch) > 0 {
+		if err := commit(); err != nil {
+			return res, fmt.Errorf("commit: %w", err)
+		}
+	}
+
+	res.wall = time.Since(start)
+	res.entries = total
+	res.lsmBytes, _ = db.Size()
+	res.finalBase = baseLevel(db)
+	if res.lsmBytes > bigTreeBytes && res.finalBase >= 0 &&
+		(res.minBase == -1 || res.finalBase < res.minBase) {
+		res.minBase = res.finalBase
+	}
+
+	// Close prints the lifetime L0 stall line, which stallLogger captures.
+	if err := db.Close(); err != nil {
+		return res, fmt.Errorf("close: %w", err)
+	}
+	logger.mu.Lock()
+	res.stall = logger.stall
+	res.slowCompactures = logger.compacts
+	logger.mu.Unlock()
+
+	return res, nil
+}
+
+// gate applies the enabled gates and returns an error listing every failure.
+func gate(cfg config, res results) error {
+	var failures []string
+	if cfg.minBase > 0 && res.minBase != -1 && res.minBase < cfg.minBase {
+		failures = append(failures, fmt.Sprintf(
+			"base level collapsed: min base on a >2GB tree was L%d, want >= L%d (issue #2327 signature)",
+			res.minBase, cfg.minBase))
+	}
+	if cfg.maxStall > 0 && res.stall > cfg.maxStall {
+		failures = append(failures, fmt.Sprintf(
+			"lifetime L0 stall %s exceeds budget %s (issue #2327 signature)",
+			res.stall, cfg.maxStall))
+	}
+	if cfg.maxShallowOcc >= 0 && res.shallowOccCp > cfg.maxShallowOcc {
+		failures = append(failures, fmt.Sprintf(
+			"tables stranded in L1/L2 at %d of %d big-tree checkpoints, want <= %d "+
+				"(healthy bulk loads never place data in L1/L2)",
+			res.shallowOccCp, res.bigCheckpoints, cfg.maxShallowOcc))
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("%d gate(s) failed:\n  - %s", len(failures), strings.Join(failures, "\n  - "))
+	}
+	return nil
+}
+
+func main() {
+	cfg := config{}
+	flag.StringVar(&cfg.dir, "dir", "", "data directory (required; must be empty)")
+	flag.IntVar(&cfg.rows, "rows", 500_000, "rows to load (~604 entries per row)")
+	flag.IntVar(&cfg.minBase, "min-base", 0, "fail if base level on a >2GB tree drops below this level (0 = disabled)")
+	flag.DurationVar(&cfg.maxStall, "max-stall", 0, "fail if lifetime L0 stall exceeds this (0 = disabled)")
+	flag.IntVar(&cfg.maxShallowOcc, "max-shallow-occupied", -1,
+		"fail if more than this many big-tree checkpoints had tables in L1/L2 (-1 = disabled)")
+	flag.Parse()
+
+	if cfg.dir == "" {
+		log.Fatal("-dir is required")
+	}
+
+	res, err := run(cfg)
+	if err != nil {
+		log.Fatalf("lsmbench: %v", err)
+	}
+
+	fmt.Printf("slow compactions (>2s, by level pair): %v\n", res.slowCompactures)
+	fmt.Printf("LSMBENCH_RESULT wall_ms=%d stall_ms=%d min_base=%d final_base=%d "+
+		"collapsed_cp=%d shallow_occ_cp=%d big_cp=%d lsm_mb=%d entries=%d\n",
+		res.wall.Milliseconds(), res.stall.Milliseconds(), res.minBase, res.finalBase,
+		res.collapsedCp, res.shallowOccCp, res.bigCheckpoints,
+		res.lsmBytes/(1<<20), res.entries)
+
+	if err := gate(cfg, res); err != nil {
+		log.Fatalf("lsmbench: %v", err)
+	}
+	fmt.Println("lsmbench: all enabled gates passed")
+	_ = os.Stdout.Sync()
+}

--- a/integration/lsmbench/main_test.go
+++ b/integration/lsmbench/main_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+/*
+ * SPDX-FileCopyrightText: © Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestBulkLoadNoBaseLevelCollapse is the integration-test entry point for the
+// #2327 regression benchmark. It is excluded from normal unit-test runs by
+// the "integration" build tag; run it explicitly with:
+//
+//	go test -v -tags=integration -timeout 60m ./integration/lsmbench/
+//
+// The full run writes ~302M entries (~10GB on disk) and takes ~4 minutes on a
+// 12-core workstation, longer on CI runners. Knobs:
+//
+//	BADGER_LSMBENCH_ROWS        rows to load (default 500000)
+//	BADGER_LSMBENCH_WALL_LIMIT  optional wall-clock budget, e.g. "10m"
+//	                            (default: disabled — absolute wall time is
+//	                            hardware-dependent; the CI workflow gates on
+//	                            a baseline-vs-head ratio instead)
+//
+// The structural gates (base level, L0 stall) are always on: they are the
+// hardware-independent signature of the #2327 collapse.
+func TestBulkLoadNoBaseLevelCollapse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("long-running integration benchmark")
+	}
+
+	rows := 500_000
+	if v := os.Getenv("BADGER_LSMBENCH_ROWS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			t.Fatalf("bad BADGER_LSMBENCH_ROWS %q", v)
+		}
+		rows = n
+	}
+
+	cfg := config{
+		dir:           t.TempDir(),
+		rows:          rows,
+		minBase:       3,
+		maxStall:      30 * time.Second,
+		maxShallowOcc: 0,
+	}
+
+	res, err := run(cfg)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	t.Logf("wall=%s stall=%s min_base=%d final_base=%d collapsed_cp=%d shallow_occ_cp=%d lsm_mb=%d entries=%d",
+		res.wall.Round(time.Second), res.stall, res.minBase, res.finalBase,
+		res.collapsedCp, res.shallowOccCp, res.lsmBytes/(1<<20), res.entries)
+
+	if err := gate(cfg, res); err != nil {
+		t.Error(err)
+	}
+
+	if v := os.Getenv("BADGER_LSMBENCH_WALL_LIMIT"); v != "" {
+		limit, err := time.ParseDuration(v)
+		if err != nil {
+			t.Fatalf("bad BADGER_LSMBENCH_WALL_LIMIT %q", v)
+		}
+		if res.wall > limit {
+			t.Errorf("bulk load took %s, exceeds budget %s", res.wall.Round(time.Second), limit)
+		}
+	}
+}

--- a/levels.go
+++ b/levels.go
@@ -360,14 +360,22 @@ type targets struct {
 // are calculated based on the size of the lowest level, typically L6. So, if L6 size is 1GB, then
 // L5 target size is 100MB, L4 target size is 10MB and so on.
 //
-// L0 files don't automatically go to L1. Instead, they get compacted to Lbase, where Lbase is
-// chosen based on the first level which is non-empty from top (check L1 through L6). For an empty
-// DB, that would be L6.  So, L0 compactions go to L6, then L5, L4 and so on.
+// L0 files don't automatically go to L1. Instead, they get compacted to Lbase. Lbase is chosen
+// in two steps (mirroring RocksDB's CalculateBaseBytes):
 //
-// Lbase is advanced to the upper levels when its target size exceeds BaseLevelSize. For
-// example, when L6 reaches 1.1GB, then L4 target sizes becomes 11MB, thus exceeding the
-// BaseLevelSize of 10MB. L3 would then become the new Lbase, with a target size of 1MB <
-// BaseLevelSize.
+//  1. The desired base level is the deepest level whose target size is still within
+//     BaseLevelSize, extended further down through empty levels. For an empty DB that is the
+//     last level; as the last level grows, the desired base level moves up (L6 at 1.1GB gives
+//     L4 a target of 11MB > BaseLevelSize, so the desired base becomes L3).
+//
+//  2. Lbase is then clamped to the first non-empty level (scanning L1 through L6) if that is
+//     shallower than the desired base level. Compacting L0 below a non-empty level would place
+//     newer versions of keys below older ones, resurrecting deleted data; compacting L0 *into*
+//     the first non-empty level instead merges the versions correctly. Crucially, L0 is never
+//     compacted into an *empty* level above a non-empty one: doing so makes that level non-empty
+//     and drags Lbase one level up on every compaction until it collapses to L1, forcing all
+//     data to cascade through every intermediate level (massive write-amplification, see
+//     issue #2327).
 func (s *levelsController) levelTargets() targets {
 	adjust := func(sz int64) int64 {
 		if sz < s.kv.opt.BaseLevelSize {
@@ -385,12 +393,22 @@ func (s *levelsController) levelTargets() targets {
 	for i := len(s.levels) - 1; i > 0; i-- {
 		ltarget := adjust(dbSize)
 		t.targetSz[i] = ltarget
+		// The desired base level is the deepest level whose target size is
+		// within BaseLevelSize.
+		if t.baseLevel == 0 && ltarget <= s.kv.opt.BaseLevelSize {
+			t.baseLevel = i
+		}
 		dbSize /= int64(s.kv.opt.LevelSizeMultiplier)
 	}
+	// For a very large LSM tree the loop above can fail to assign a base level:
+	// once the last level exceeds BaseLevelSize*multiplier^(MaxLevels-2), even
+	// L1's target is above BaseLevelSize. Clamp to L1 (see #2296).
+	if t.baseLevel == 0 {
+		t.baseLevel = 1
+	}
 
-	// Bring the base level down to the last empty level.
-	t.baseLevel = 1
-	for i := 1; i < len(s.levels)-1; i++ {
+	// Bring the base level further down through empty levels.
+	for i := t.baseLevel; i < len(s.levels)-1; i++ {
 		if s.levels[i].getTotalSize() > 0 {
 			break
 		}
@@ -405,6 +423,19 @@ func (s *levelsController) levelTargets() targets {
 	baseLevelIsNotLastLevel := b < len(lvl)-1
 	if baseLevelIsNotLastLevel && baseLevelIsEmpty && lvl[b+1].getTotalSize() < t.targetSz[b+1] && lvl[b+1].getTotalSize() < s.kv.opt.BaseLevelSize {
 		t.baseLevel++
+	}
+
+	// Safety clamp: the base level must never be below (deeper than) a non-empty
+	// level. Compacting L0 below existing data would place newer versions of keys
+	// under older ones, causing previously deleted data to reappear (#2278). If a
+	// shallower level holds data, compact L0 directly into that level instead:
+	// merging into it preserves version ordering, and the level then drains down
+	// via regular compactions until the base level recovers its desired depth.
+	for i := 1; i < t.baseLevel; i++ {
+		if s.levels[i].getTotalSize() > 0 {
+			t.baseLevel = i
+			break
+		}
 	}
 
 	tsz := s.kv.opt.BaseTableSize
@@ -423,9 +454,9 @@ func (s *levelsController) levelTargets() targets {
 		}
 	}
 
-	// The base level must never be L0. The base-level scan above starts at L1, so
-	// baseLevel is already >= 1; this is a defensive guard (added in #2296) against
-	// ever compacting L0 into itself, which would panic in fillTablesL0ToLbase.
+	// The base level must never be L0. The selection above already guarantees
+	// baseLevel >= 1; this is a defensive guard (added in #2296) against ever
+	// compacting L0 into itself, which would panic in fillTablesL0ToLbase.
 	if t.baseLevel == 0 {
 		t.baseLevel = 1
 	}

--- a/levels_test.go
+++ b/levels_test.go
@@ -1495,12 +1495,78 @@ func TestLevelTargets(t *testing.T) {
 			createAndOpen(db, data, opt.MaxLevels-2)
 			createAndOpen(db, data, opt.MaxLevels-1)
 
-			// Level 5 size exactly equals BaseLevelSize; should NOT bump past it.
+			// Level 5 size exactly equals BaseLevelSize. The size-ratio target
+			// for L5 is BaseLevelSize (L6 / LevelSizeMultiplier, clamped up), so
+			// L5 is the desired base level, and since every level above L5 is
+			// empty it is safe to compact L0 directly into it. Choosing the
+			// empty L4 above it instead would make L4 non-empty and ratchet the
+			// base level toward L1 (#2327).
 			db.lc.levels[opt.MaxLevels-2].totalSize = opt.BaseLevelSize
 			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize * 2
 
 			target := db.lc.levelTargets()
-			require.Equal(t, opt.MaxLevels-3, target.baseLevel)
+			require.Equal(t, opt.MaxLevels-2, target.baseLevel)
+		})
+	})
+}
+
+// TestLevelTargetsStrayLevels covers base-level selection when data is
+// stranded in a level above the size-ratio base level (issue #2327). The base
+// level must be clamped up to the stray level (never compact L0 below existing
+// data, #2278), but it must never be placed on an empty level above a
+// non-empty one — that ratchets the base level to L1 on every compaction and
+// forces data to cascade through every intermediate level.
+func TestLevelTargetsStrayLevels(t *testing.T) {
+	opt := DefaultOptions("").WithNumCompactors(0).WithNumVersionsToKeep(1)
+	opt.managedTxns = true
+
+	t.Run("stray level above the size-ratio base clamps base to the stray", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+			createAndOpen(db, data, 2)
+			createAndOpen(db, data, opt.MaxLevels-1)
+
+			// A small stray at L2, everything else at a large L6. The size
+			// ratio puts the base level deep, but L0 must compact into the
+			// stray level itself, not below it and not into empty L1.
+			db.lc.levels[2].totalSize = opt.BaseLevelSize / 4
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize * 100
+
+			target := db.lc.levelTargets()
+			require.Equal(t, 2, target.baseLevel)
+		})
+	})
+
+	t.Run("collapsed tree keeps base at the shallowest non-empty level", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+			// A collapsed tree, as left behind by the base level falling to L1:
+			// small remnants at L1-L3, bulk of the data at L6.
+			for _, lvl := range []int{1, 2, 3, opt.MaxLevels - 1} {
+				createAndOpen(db, data, lvl)
+				db.lc.levels[lvl].totalSize = opt.BaseLevelSize / 4
+			}
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize * 100
+
+			// L1 holds data, so it is the only safe target for L0 compactions.
+			target := db.lc.levelTargets()
+			require.Equal(t, 1, target.baseLevel)
+		})
+	})
+
+	t.Run("base level recovers once shallow levels are empty", func(t *testing.T) {
+		runBadgerTest(t, &opt, func(t *testing.T, db *DB) {
+			data := []keyValVersion{{"foo", "bar", 3, 0}, {"fooz", "baz", 1, 0}}
+			createAndOpen(db, data, 0)
+			createAndOpen(db, data, opt.MaxLevels-1)
+			db.lc.levels[opt.MaxLevels-1].totalSize = opt.BaseLevelSize * 100
+
+			// Same tree as above once the strays have been compacted away: the
+			// base level must return to its natural depth, not stay at L1.
+			target := db.lc.levelTargets()
+			require.Equal(t, opt.MaxLevels-2, target.baseLevel)
 		})
 	})
 }


### PR DESCRIPTION
Fixes #2327

## Problem

v4.9.4 introduced a severe ingestion regression: on large `db.Update`-based imports
(300M+ entries, default options), the base level collapses to L1 partway through the
load and never recovers. Every byte must then cascade through every intermediate level
(`1→2→3→4→5→6`) instead of being compacted directly toward the bottom (`0→L4/L5`,
`5→6`). The reporter measured **2.97x slower** wall time in production (2h36m → 7h45m),
with cascade compactions going from 9 to 681 and sustained L0 write stalls.

## Background: how the two previous versions chose Lbase

`levelTargets()` decides which level L0 gets compacted into (Lbase). The two released
behaviors each got one thing right and one thing wrong:

**v4.9.2 — fast, but unsafe.** Lbase came from a pure size-ratio computation
(dynamic level sizing, as in RocksDB): the deepest level whose target size is within
`BaseLevelSize`, extended further down through empty levels. For a bottom-heavy tree
this keeps Lbase deep (L3–L5) and write amplification low. However, the selection never
looked at the levels **above** the chosen base. If a stray table held data at a
shallower level (possible after the tree shrinks, or historical states), L0's newest
entries — including delete tombstones — were compacted **below** older versions of the
same keys. Reads stop at the shallowest version, so previously deleted data reappeared
and fresh updates read stale. That corruption is what #2278 fixed.

**v4.9.4 (#2278) — safe, but collapses.** The size-ratio selection was replaced with an
emptiness scan: start at L1 and walk down through *empty* levels, stopping at the first
non-empty one; Lbase is the empty level just above it. This makes the corruption
structurally impossible (nothing can sit above Lbase), but the rule is self-destructive
under write load: dumping L0 onto that empty level makes it non-empty, so the next
selection stops one level higher. Each dump burns a level — L4 → L3 → L2 → L1 — and
once Lbase reaches L1, `0→1` compactions keep L1 permanently non-empty, pinning the
base there forever. The result is the full per-level cascade, ~3x write amplification,
and L0 stalls.

## The fix

Combine the two, mirroring RocksDB's `CalculateBaseBytes()`:

1. **Restore the v4.9.2 size-ratio selection** (deepest level with target ≤
   `BaseLevelSize`, plus the existing walk down through empty levels and the
   step-onto-a-tiny-next-level tweak). This is the *performance floor*: occupying the
   base level does not move the next round's choice, so there is no ratchet.
2. **Add a safety clamp**: if any level *above* the chosen base holds data, Lbase
   becomes the **shallowest non-empty level itself** — never a level below existing
   data, and never an empty level above existing data. Compacting L0 *into* the
   occupied level merges versions in the correct order, so #2278's invariant is fully
   preserved (its runtime guard in `runCompactDef` is untouched and still enforces
   this at compaction time).

The clamp also makes bad states self-healing: an L0 dump merging into a stray level
pushes it past its size target, normal compaction drains it, and Lbase returns to its
natural depth — typically within one compaction cycle. Trees already collapsed by
v4.9.4 recover the same way under write load (their L1–L3 remnants sit far above the
10MB targets, so they drain at high priority).

## Why this does not reintroduce the #2278 corruption

The corruption required Lbase to be *deeper* than a level holding data. After the
clamp, `baseLevel ≤ first non-empty level` holds on every path, so every level above
Lbase is empty by construction. All regression tests added by #2278 pass, including
the end-to-end `TestDeletedKeyReappears` and the non-empty-level-above-base runtime
guard test. One #2278 unit expectation is deliberately updated:
`TestLevelTargets/level size exactly at BaseLevelSize boundary` now expects Lbase = L5
(the first non-empty level, whose size-ratio target is exactly `BaseLevelSize`) instead
of the empty L4 above it — compacting into L5 is safe (nothing above it) and choosing
empty L4 is precisely the ratchet mechanism this PR removes. The test comment explains
the reasoning.

## Results

Reporter's standalone reproducer from #2327 (302M entries via `db.Update`, batches of
5000, default options), same machine, three-way comparison:

|                              | v4.9.2      | v4.9.4              | this PR       |
| ---------------------------- | ----------- | ------------------- | ------------- |
| Wall time                    | 4m08s       | 4m26s               | **3m56–4m00s** (4 runs) |
| Lifetime L0 stall            | 0s          | **57.7s** (11 events) | **0s**      |
| Base level over the run      | L4          | collapses to **L1** at ~170M entries, never recovers | **L3/L4 throughout** |
| L1–L2 at end                 | empty       | 98MB + 61MB stuck   | empty         |
| Compaction pattern           | 9× `5→6`    | `5→6` + `0→1` + cascades | 2–5× `5→6` only |

(The wall-clock gap at this scale is small; at the reporter's production scale the
collapse compounds to ~3x. The structural signals — stalls, base level, cascade
compactions — are the meaningful metrics, and they match v4.9.2 exactly.)

Full test suite passes. New `TestLevelTargetsStrayLevels` covers the three selection
scenarios this PR is about: clamping to a stray level, a fully collapsed tree, and
recovery once shallow levels drain.

## Note for users downgrading as a workaround

Pinning back to v4.9.2 on a data directory that v4.9.4 left in the collapsed shape
(data stranded in L1–L3) re-exposes the #2278 corruption: v4.9.2 will compact L0 below
those levels. The safe options are staying on v4.9.4 or upgrading to a release with
this fix.

## Checklist

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
