### PR TITLE
fix: handle empty .mem / .vlog files during Open() instead of failing with z.NewFile (#2207)

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -2740,8 +2740,9 @@ func TestCloseDBWhileReading(t *testing.T) {
 
 // TestOpenWithEmptyMemFile verifies that badger.Open handles empty .mem files
 // gracefully. An empty .mem file can be left behind after a crash that occurs
-// between file creation and the first write. Before the fix for #2207,
-// openMemTables would treat z.NewFile as a fatal error and refuse to open the DB.
+// between file creation and the first write. The fix for #2207 stats each .mem
+// file during discovery and skips 0-byte files, which works for both read-write
+// and read-only modes without mutating the file.
 func TestOpenWithEmptyMemFile(t *testing.T) {
 	dir := t.TempDir()
 	opt := getTestOptions(dir)
@@ -2787,6 +2788,13 @@ func TestOpenWithEmptyMemFile(t *testing.T) {
 	// Step 3: Re-open the DB. This must succeed despite the empty .mem file.
 	db2, err := Open(opt)
 	require.NoError(t, err, "Open should succeed with an empty .mem file")
+
+	// The empty file should still exist — the stat-and-skip approach is
+	// intentionally non-mutating so it works in read-only mode as well.
+	require.FileExists(t, emptyFile)
+	fi, err := os.Stat(emptyFile)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), fi.Size(), "empty .mem file should be left untouched")
 
 	// Step 4: Verify existing data is intact.
 	err = db2.View(func(txn *Txn) error {

--- a/db_test.go
+++ b/db_test.go
@@ -2823,4 +2823,155 @@ func TestOpenWithEmptyMemFile(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, db2.Close())
+
+	// Step 6: Read-only Open must also succeed with the empty .mem file
+	// present, since the stat-and-skip approach avoids truncation entirely.
+	roOpt := opt
+	roOpt.ReadOnly = true
+	db3, err := Open(roOpt)
+	require.NoError(t, err, "read-only Open should succeed with an empty .mem file")
+	require.NoError(t, db3.Close())
+}
+
+// TestOpenWithEmptyVlogFile verifies that badger.Open handles empty .vlog files
+// gracefully. Like an empty .mem file, a 0-byte .vlog file can be left behind
+// after a crash between file creation and the first write. The fix stats each
+// .vlog file during open and skips 0-byte files, which works for both read-write
+// and read-only modes without mutating the file.
+func TestOpenWithEmptyVlogFile(t *testing.T) {
+	dir := t.TempDir()
+	opt := getTestOptions(dir)
+
+	// Step 1: Create a DB with some data.
+	db, err := Open(opt)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		err := db.Update(func(txn *Txn) error {
+			return txn.Set([]byte(fmt.Sprintf("key:%05d", i)),
+				[]byte(fmt.Sprintf("value:%05d", i)))
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Close())
+
+	// Step 2: Find the highest file ID and plant an empty .vlog file with a
+	// higher ID. Value log files use %06d.vlog (6-digit zero padding).
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	maxFid := 0
+	for _, e := range entries {
+		name := e.Name()
+		for _, ext := range []string{".vlog", ".sst", memFileExt} {
+			if strings.HasSuffix(name, ext) {
+				fidStr := name[:len(name)-len(ext)]
+				if fid, err := strconv.ParseInt(fidStr, 10, 64); err == nil {
+					if int(fid) > maxFid {
+						maxFid = int(fid)
+					}
+				}
+			}
+		}
+	}
+	emptyFid := maxFid + 1
+	emptyFile := filepath.Join(dir, fmt.Sprintf("%06d.vlog", emptyFid))
+	f, err := os.Create(emptyFile)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Step 3: Re-open the DB. This must succeed despite the empty .vlog file.
+	db2, err := Open(opt)
+	require.NoError(t, err, "Open should succeed with an empty .vlog file")
+
+	// The empty file should still exist — stat-and-skip is non-mutating so it
+	// works in read-only mode as well.
+	require.FileExists(t, emptyFile)
+	fi, err := os.Stat(emptyFile)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), fi.Size(), "empty .vlog file should be left untouched")
+
+	// Step 4: Verify existing data is intact.
+	err = db2.View(func(txn *Txn) error {
+		for i := 0; i < 100; i++ {
+			item, err := txn.Get([]byte(fmt.Sprintf("key:%05d", i)))
+			if err != nil {
+				return err
+			}
+			err = item.Value(func(val []byte) error {
+				expected := fmt.Sprintf("value:%05d", i)
+				require.Equal(t, expected, string(val))
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Step 5: Write more data to ensure the DB is fully functional.
+	err = db2.Update(func(txn *Txn) error {
+		return txn.Set([]byte("new-key"), []byte("new-value"))
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db2.Close())
+
+	// Step 6: Read-only Open must also succeed with the empty .vlog file present.
+	roOpt := opt
+	roOpt.ReadOnly = true
+	db3, err := Open(roOpt)
+	require.NoError(t, err, "read-only Open should succeed with an empty .vlog file")
+	require.NoError(t, db3.Close())
+}
+
+// TestVlogCloseWithEmptyFile verifies that vlog.Close() does not panic when a
+// 0-byte .vlog file was skipped during Open. The skip must remove the unopened
+// logFile from filesMap, otherwise Close() iterates over it and dereferences its
+// nil MmapFile, causing a panic.
+func TestVlogCloseWithEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	opt := getTestOptions(dir)
+
+	// Create a DB with a value so a non-empty .vlog file exists.
+	db, err := Open(opt)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(txn *Txn) error {
+		return txn.Set([]byte("key"), []byte("value"))
+	}))
+	require.NoError(t, db.Close())
+
+	// Plant a 0-byte .vlog file with a higher fid than any existing .vlog file.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var maxFid uint32
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".vlog") {
+			continue
+		}
+		if fid, err := strconv.ParseUint(name[:len(name)-len(".vlog")], 10, 32); err == nil {
+			if uint32(fid) > maxFid {
+				maxFid = uint32(fid)
+			}
+		}
+	}
+	emptyFid := maxFid + 1
+	emptyFile := filepath.Join(dir, fmt.Sprintf("%06d.vlog", emptyFid))
+	f, err := os.Create(emptyFile)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	db2, err := Open(opt)
+	require.NoError(t, err)
+
+	// The skipped 0-byte file's fid must be removed from filesMap; a lingering
+	// entry would hold a nil MmapFile and panic on Close.
+	_, ok := db2.vlog.filesMap[emptyFid]
+	require.False(t, ok, "skipped 0-byte .vlog file must not remain in filesMap")
+
+	// Close must not panic.
+	require.NotPanics(t, func() {
+		require.NoError(t, db2.Close())
+	})
 }

--- a/db_test.go
+++ b/db_test.go
@@ -2889,6 +2889,11 @@ func TestOpenWithEmptyVlogFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), fi.Size(), "empty .vlog file should be left untouched")
 
+	// The skipped fid must have been removed from filesMap; a lingering entry
+	// would hold a nil MmapFile and panic on Close.
+	_, ok := db2.vlog.filesMap[uint32(emptyFid)]
+	require.False(t, ok, "skipped 0-byte .vlog file must not remain in filesMap")
+
 	// Step 4: Verify existing data is intact.
 	err = db2.View(func(txn *Txn) error {
 		for i := 0; i < 100; i++ {
@@ -2915,7 +2920,10 @@ func TestOpenWithEmptyVlogFile(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, db2.Close())
+	// Close must not panic.
+	require.NotPanics(t, func() {
+		require.NoError(t, db2.Close())
+	})
 
 	// Step 6: Read-only Open must also succeed with the empty .vlog file present.
 	roOpt := opt
@@ -2923,55 +2931,4 @@ func TestOpenWithEmptyVlogFile(t *testing.T) {
 	db3, err := Open(roOpt)
 	require.NoError(t, err, "read-only Open should succeed with an empty .vlog file")
 	require.NoError(t, db3.Close())
-}
-
-// TestVlogCloseWithEmptyFile verifies that vlog.Close() does not panic when a
-// 0-byte .vlog file was skipped during Open. The skip must remove the unopened
-// logFile from filesMap, otherwise Close() iterates over it and dereferences its
-// nil MmapFile, causing a panic.
-func TestVlogCloseWithEmptyFile(t *testing.T) {
-	dir := t.TempDir()
-	opt := getTestOptions(dir)
-
-	// Create a DB with a value so a non-empty .vlog file exists.
-	db, err := Open(opt)
-	require.NoError(t, err)
-	require.NoError(t, db.Update(func(txn *Txn) error {
-		return txn.Set([]byte("key"), []byte("value"))
-	}))
-	require.NoError(t, db.Close())
-
-	// Plant a 0-byte .vlog file with a higher fid than any existing .vlog file.
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	var maxFid uint32
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".vlog") {
-			continue
-		}
-		if fid, err := strconv.ParseUint(name[:len(name)-len(".vlog")], 10, 32); err == nil {
-			if uint32(fid) > maxFid {
-				maxFid = uint32(fid)
-			}
-		}
-	}
-	emptyFid := maxFid + 1
-	emptyFile := filepath.Join(dir, fmt.Sprintf("%06d.vlog", emptyFid))
-	f, err := os.Create(emptyFile)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
-	db2, err := Open(opt)
-	require.NoError(t, err)
-
-	// The skipped 0-byte file's fid must be removed from filesMap; a lingering
-	// entry would hold a nil MmapFile and panic on Close.
-	_, ok := db2.vlog.filesMap[emptyFid]
-	require.False(t, ok, "skipped 0-byte .vlog file must not remain in filesMap")
-
-	// Close must not panic.
-	require.NotPanics(t, func() {
-		require.NoError(t, db2.Close())
-	})
 }

--- a/db_test.go
+++ b/db_test.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2734,4 +2736,83 @@ func TestCloseDBWhileReading(t *testing.T) {
 	time.Sleep(time.Second)
 	require.NoError(t, db.Close())
 	wg.Wait()
+}
+
+// TestOpenWithEmptyMemFile verifies that badger.Open handles empty .mem files
+// gracefully. An empty .mem file can be left behind after a crash that occurs
+// between file creation and the first write. Before the fix for #2207,
+// openMemTables would treat z.NewFile as a fatal error and refuse to open the DB.
+func TestOpenWithEmptyMemFile(t *testing.T) {
+	dir := t.TempDir()
+	opt := getTestOptions(dir)
+
+	// Step 1: Create a DB with some data.
+	db, err := Open(opt)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		err := db.Update(func(txn *Txn) error {
+			return txn.Set([]byte(fmt.Sprintf("key:%05d", i)),
+				[]byte(fmt.Sprintf("value:%05d", i)))
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Close())
+
+	// Step 2: Find the highest file ID in the directory and create an empty
+	// .mem file with a higher ID. After a clean close, memtable WALs are
+	// flushed and deleted, so we may need to pick fid 1 from scratch.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	maxFid := 0
+	for _, e := range entries {
+		name := e.Name()
+		// Match both .mem and .sst files to find the highest ID.
+		for _, ext := range []string{memFileExt, ".sst", ".vlog"} {
+			if strings.HasSuffix(name, ext) {
+				fidStr := name[:len(name)-len(ext)]
+				if fid, err := strconv.ParseInt(fidStr, 10, 64); err == nil {
+					if int(fid) > maxFid {
+						maxFid = int(fid)
+					}
+				}
+			}
+		}
+	}
+	emptyFid := maxFid + 1
+	emptyFile := filepath.Join(dir, fmt.Sprintf("%05d%s", emptyFid, memFileExt))
+	f, err := os.Create(emptyFile)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Step 3: Re-open the DB. This must succeed despite the empty .mem file.
+	db2, err := Open(opt)
+	require.NoError(t, err, "Open should succeed with an empty .mem file")
+
+	// Step 4: Verify existing data is intact.
+	err = db2.View(func(txn *Txn) error {
+		for i := 0; i < 100; i++ {
+			item, err := txn.Get([]byte(fmt.Sprintf("key:%05d", i)))
+			if err != nil {
+				return err
+			}
+			err = item.Value(func(val []byte) error {
+				expected := fmt.Sprintf("value:%05d", i)
+				require.Equal(t, expected, string(val))
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Step 5: Write more data to ensure the DB is fully functional.
+	err = db2.Update(func(txn *Txn) error {
+		return txn.Set([]byte("new-key"), []byte("new-value"))
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db2.Close())
 }

--- a/memtable.go
+++ b/memtable.go
@@ -68,17 +68,23 @@ func (db *DB) openMemTables(opt Options) error {
 		return fids[i] < fids[j]
 	})
 	for _, fid := range fids {
+		// Skip empty .mem files that can be left behind by a crash
+		// between file creation and the first write. Stat-and-skip
+		// avoids opening them at all, which works for both read-write
+		// and read-only modes (no truncation required).
+		fi, err := os.Stat(db.mtFilePath(fid))
+		if err != nil {
+			return errFile(err, db.mtFilePath(fid), "Unable to stat mem file.")
+		}
+		if fi.Size() == 0 {
+			continue
+		}
+
 		flags := os.O_RDWR
 		if db.opt.ReadOnly {
 			flags = os.O_RDONLY
 		}
 		mt, err := db.openMemTable(fid, flags)
-		if err == z.NewFile {
-			// This memtable's WAL was empty (0 bytes), so it was
-			// bootstrapped. There's nothing to recover; discard it.
-			mt.DecrRef()
-			continue
-		}
 		if err != nil {
 			return y.Wrapf(err, "while opening fid: %d", fid)
 		}

--- a/memtable.go
+++ b/memtable.go
@@ -73,6 +73,12 @@ func (db *DB) openMemTables(opt Options) error {
 			flags = os.O_RDONLY
 		}
 		mt, err := db.openMemTable(fid, flags)
+		if err == z.NewFile {
+			// This memtable's WAL was empty (0 bytes), so it was
+			// bootstrapped. There's nothing to recover; discard it.
+			mt.DecrRef()
+			continue
+		}
 		if err != nil {
 			return y.Wrapf(err, "while opening fid: %d", fid)
 		}

--- a/value.go
+++ b/value.go
@@ -604,6 +604,23 @@ func (vlog *valueLog) open(db *DB) error {
 		y.AssertTrue(ok)
 
 		lf.opt = vlog.opt
+
+		// Skip 0-byte .vlog files left behind by a crash between file
+		// creation and the first write. Stat-and-skip avoids opening them at
+		// all, which works in both read-write and read-only modes (no
+		// truncation required). The file stays on disk but is harmless.
+		fi, err := os.Stat(lf.path)
+		if err != nil {
+			return y.Wrapf(err, "Unable to stat file: %q", lf.path)
+		}
+		if fi.Size() == 0 {
+			// Since the logfile, corresponding to this fid, does not
+			// have MmapFile initialized, susceptible to nil deref panic.
+			// Like that in vlog.Close()
+			delete(vlog.filesMap, fid)
+			continue
+		}
+
 		flags := os.O_RDWR
 		if vlog.opt.ReadOnly {
 			flags = os.O_RDONLY
@@ -627,18 +644,19 @@ func (vlog *valueLog) open(db *DB) error {
 	}
 	// Now we can read the latest value log file, and see if it needs truncation. We could
 	// technically do this over all the value log files, but that would mean slowing down the value
-	// log open.
-	last, ok := vlog.filesMap[vlog.maxFid]
-	y.AssertTrue(ok)
-	lastOff, err := last.iterate(vlog.opt.ReadOnly, vlogHeaderSize,
-		func(_ Entry, vp valuePointer) error {
-			return nil
-		})
-	if err != nil {
-		return y.Wrapf(err, "while iterating over: %s", last.path)
-	}
-	if err := last.Truncate(int64(lastOff)); err != nil {
-		return y.Wrapf(err, "while truncating last value log file: %s", last.path)
+	// log open. If the maxFid file was a 0-byte crash artifact skipped above, it's no longer in
+	// filesMap and there's nothing to recover, so skip straight to creating a fresh file.
+	if last, ok := vlog.filesMap[vlog.maxFid]; ok {
+		lastOff, err := last.iterate(vlog.opt.ReadOnly, vlogHeaderSize,
+			func(_ Entry, vp valuePointer) error {
+				return nil
+			})
+		if err != nil {
+			return y.Wrapf(err, "while iterating over: %s", last.path)
+		}
+		if err := last.Truncate(int64(lastOff)); err != nil {
+			return y.Wrapf(err, "while truncating last value log file: %s", last.path)
+		}
 	}
 
 	// Don't write to the old log file. Always create a new one.


### PR DESCRIPTION
**Description**

Fixes [#2207](https://github.com/dgraph-io/badger/issues/2207)

When badger.Open() encounters an empty (0-byte) .mem or .vlog file in the data directory, it fails instead of opening the database. Both can be left behind by a crash between file creation and the first write.

Old Buggy Behaviour

- .mem, read-write: z.OpenMmapFileUsing truncates the 0-byte file to MemTableSize and returns the z.NewFile sentinel, which openMemTables treats as a fatal error → Open() aborts.
- .mem, read-only: the same truncate runs against an O_RDONLY fd and fails with "invalid argument" before the sentinel is returned → Open() aborts.
- .vlog, read-write: same as .mem — the file is truncated to 2 * ValueLogFileSize and the z.NewFile sentinel is treated as fatal → Open() aborts.
- .vlog, read-only: truncate on an O_RDONLY fd fails with "invalid argument" → Open() aborts.

Fix (mem): stat each .mem file before opening and skip any 0-byte file. Stat-and-skip never opens the file, so no truncation is attempted — it works in both read-write and read-only modes and leaves the empty file untouched.

Fix (vlog): same stat-and-skip for .vlog files, removing the skipped fid from vlog.filesMap so Close() doesn't dereference its nil MmapFile, and guarding the max-fid truncation so a skipped max-fid artifact isn't touched.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/badger/pr/2331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788779308&installation_model_id=8575&pr_number=2331&repository=dgraph-io%2Fbadger&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fbadger%2Fpull%2F2331&signature=5610b4b18b10b4ced9bba90751e23800b7ac701cd9abb8eaaaed67ebf6a2d382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->