### PR TITLE
fix(value): traverse all candidates in pickLog instead of aborting on first ineligible

### DIFF
--- a/value.go
+++ b/value.go
@@ -1028,42 +1028,56 @@ func (vlog *valueLog) pickLog(discardRatio float64) *logFile {
 	vlog.filesLock.RLock()
 	defer vlog.filesLock.RUnlock()
 
-LOOP:
-	// Pick a candidate that contains the largest amount of discardable data
-	fid, discard := vlog.discardStats.MaxDiscard()
-
-	// MaxDiscard will return fid=0 if it doesn't have any discard data. The
-	// vlog files start from 1.
-	if fid == 0 {
+	// Collect candidates from discard stats, sorted by discard descending.
+	type candidate struct {
+		fid     uint32
+		discard int64
+	}
+	var candidates []candidate
+	{
+		vlog.discardStats.Lock()
+		vlog.discardStats.Iterate(func(fid, stats uint64) {
+			if fid > 0 {
+				candidates = append(candidates, candidate{uint32(fid), int64(stats)})
+			}
+		})
+		vlog.discardStats.Unlock()
+	}
+	if len(candidates) == 0 {
 		vlog.opt.Debugf("No file with discard stats")
 		return nil
 	}
-	lf, ok := vlog.filesMap[fid]
-	// This file was deleted but it's discard stats increased because of compactions. The file
-	// doesn't exist so we don't need to do anything. Skip it and retry.
-	if !ok {
-		vlog.discardStats.Update(fid, -1)
-		goto LOOP
-	}
-	// We have a valid file.
-	fi, err := lf.Fd.Stat()
-	if err != nil {
-		vlog.opt.Errorf("Unable to get stats for value log fid: %d err: %+v", fi, err)
-		return nil
-	}
-	if thr := discardRatio * float64(fi.Size()); float64(discard) < thr {
-		vlog.opt.Debugf("Discard: %d less than threshold: %.0f for file: %s",
-			discard, thr, fi.Name())
-		return nil
-	}
-	if fid < vlog.maxFid {
-		vlog.opt.Infof("Found value log max discard fid: %d discard: %d\n", fid, discard)
-		lf, ok := vlog.filesMap[fid]
-		y.AssertTrue(ok)
-		return lf
-	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].discard > candidates[j].discard
+	})
 
-	// Don't randomly pick any value log file.
+	// Walk candidates in descending discard order, skipping ineligible files
+	// (deleted, active, or below ratio) instead of aborting on the first.
+	for _, c := range candidates {
+		fid, discard := c.fid, c.discard
+		lf, ok := vlog.filesMap[fid]
+		if !ok {
+			// This file was deleted but its discard stats increased because of compactions.
+			vlog.discardStats.Update(fid, -1)
+			continue
+		}
+		fi, err := lf.Fd.Stat()
+		if err != nil {
+			vlog.opt.Errorf("Unable to get stats for value log fid: %d err: %+v", fid, err)
+			return nil
+		}
+		if thr := discardRatio * float64(fi.Size()); float64(discard) < thr {
+			vlog.opt.Debugf("Discard: %d less than threshold: %.0f for file: %s",
+				discard, thr, fi.Name())
+			continue
+		}
+		if fid < vlog.maxFid {
+			vlog.opt.Infof("Found value log max discard fid: %d discard: %d\n", fid, discard)
+			return lf
+		}
+		// Active file — skip to the next candidate.
+		vlog.opt.Debugf("Skipping active value log file fid: %d discard: %d", fid, discard)
+	}
 	return nil
 }
 

--- a/value_test.go
+++ b/value_test.go
@@ -1660,7 +1660,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	// The old file's discard must exceed the threshold to be eligible.
 	const fileSize = 1 << 20 // 1 MB
 	vlog.discardStats.Update(maxFid, 1<<30)      // active: large discard, but ineligible
-	vlog.discardStats.Update(fids[0], int64(0.3*float64(fileSize))) // old file: 30% > 10% threshold
+	vlog.discardStats.Update(fids[0], 3*fileSize/10) // old file: 30% > 10% threshold
 
 	// Now pickLog should skip the active file and return the older one.
 	lf := vlog.pickLog(0.1)

--- a/value_test.go
+++ b/value_test.go
@@ -1616,7 +1616,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
-	opt.ValueLogFileSize = 1 << 20
+	opt.ValueLogFileSize = 128 << 10 // 128 KB: several small vlog files
 	opt.ValueThreshold = 1 << 10
 	opt.NumCompactors = 0
 
@@ -1627,18 +1627,9 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	vlog := kv.vlog
 	sz := 32 << 10
 
-	// Write data to create the first vlog file (fid=1).
+	// Write data to create the first vlog files (fid 1, 2, 3...).
 	txn := kv.NewTransaction(true)
-	for i := 0; i < 5; i++ {
-		v := make([]byte, sz)
-		rand.Read(v)
-		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))
-	}
-	require.NoError(t, txn.Commit())
-
-	// Write more data to create a second vlog file (fid=2, active).
-	txn = kv.NewTransaction(true)
-	for i := 5; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		v := make([]byte, sz)
 		rand.Read(v)
 		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))

--- a/value_test.go
+++ b/value_test.go
@@ -1619,7 +1619,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	opt.ValueLogFileSize = 1 << 20
 	opt.ValueThreshold = 1 << 10
 	opt.NumCompactors = 0
-	opt.ValueLogMaxEntries = 16 // force a new file every 16 entries
+	opt.ValueLogMaxEntries = 16
 
 	kv, err := Open(opt)
 	require.NoError(t, err)
@@ -1629,28 +1629,32 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	sz := 32 << 10
 
 	// Write data to create several vlog files.
-	txn := kv.NewTransaction(true)
-	for i := 0; i < 80; i++ {
-		v := make([]byte, sz)
-		rand.Read(v)
-		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))
-	}
-	require.NoError(t, txn.Commit())
+	func() {
+		txn := kv.NewTransaction(true)
+		for i := 0; i < 80; i++ {
+			v := make([]byte, sz)
+			rand.Read(v)
+			require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%03d", i)), v)))
+		}
+		require.NoError(t, txn.Commit())
+	}()
 
-	// Store fid and maxFid before any deletions.
+	// Close and reopen to get a consistent view of on-disk files.
+	require.NoError(t, kv.Close())
+	kv, err = Open(opt)
+	require.NoError(t, err)
+	defer kv.Close()
+	vlog = kv.vlog
+
 	vlog.filesLock.RLock()
 	fids := vlog.sortedFids()
 	maxFid := vlog.maxFid
-	var fidList []uint32
-	for _, f := range fids {
-		fidList = append(fidList, f)
-	}
 	vlog.filesLock.RUnlock()
+	t.Logf("fids=%v maxFid=%d", fids, maxFid)
 
-	if len(fidList) < 2 {
-		t.Fatalf("need at least two vlog files, got %d (fids=%v)", len(fidList), fidList)
+	if len(fids) < 2 {
+		t.Fatalf("need at least two vlog files, got %d", len(fids))
 	}
-	t.Logf("fids=%v maxFid=%d", fidList, maxFid)
 
 	// Delete entries in the first file to create discard.
 	for i := 0; i < 10; i++ {
@@ -1659,8 +1663,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 
 	// Manually give the active file a larger discard so it becomes the top
 	// candidate, which the old code would abort on.
-	activeDiscard := int64(1 << 30)
-	vlog.discardStats.Update(maxFid, activeDiscard)
+	vlog.discardStats.Update(maxFid, 1<<30)
 
 	// Now pickLog should skip the active file and return an older one.
 	lf := vlog.pickLog(0.5)
@@ -1670,7 +1673,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 			t.Logf("  discardStats[%d]=%d", fid, stats)
 		})
 		vlog.discardStats.Unlock()
-		t.Fatalf("pickLog returned nil; expected an old file (fid < %d) with fids=%v", maxFid, fidList)
+		t.Fatalf("pickLog returned nil; expected an old file (fid < %d) with fids=%v", maxFid, fids)
 	}
 	require.Less(t, lf.fid, maxFid, "pickLog must return an older file, not the active one")
 	t.Logf("pickLog returned fid=%d (maxFid=%d)", lf.fid, maxFid)

--- a/value_test.go
+++ b/value_test.go
@@ -1616,7 +1616,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
-	opt.ValueLogFileSize = 128 << 10 // 128 KB: several small vlog files
+	opt.ValueLogFileSize = 1 << 20 // 1 MB minimum, write enough data to force multiple files
 	opt.ValueThreshold = 1 << 10
 	opt.NumCompactors = 0
 
@@ -1629,7 +1629,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 
 	// Write data to create the first vlog files (fid 1, 2, 3...).
 	txn := kv.NewTransaction(true)
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 45; i++ {
 		v := make([]byte, sz)
 		rand.Read(v)
 		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))

--- a/value_test.go
+++ b/value_test.go
@@ -1660,7 +1660,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	// The old file's discard must exceed the threshold to be eligible.
 	const fileSize = 1 << 20 // 1 MB
 	vlog.discardStats.Update(maxFid, 1<<30)      // active: large discard, but ineligible
-	vlog.discardStats.Update(fids[0], int64(0.3*fileSize)) // old file: 30% > 10% threshold
+	vlog.discardStats.Update(fids[0], int64(0.3*float64(fileSize))) // old file: 30% > 10% threshold
 
 	// Now pickLog should skip the active file and return the older one.
 	lf := vlog.pickLog(0.1)

--- a/value_test.go
+++ b/value_test.go
@@ -1656,17 +1656,14 @@ func TestPickLogWalksCandidates(t *testing.T) {
 		t.Fatalf("need at least two vlog files, got %d", len(fids))
 	}
 
-	// Delete entries in the first file to create discard.
-	for i := 0; i < 10; i++ {
-		txnDelete(t, kv, []byte(fmt.Sprintf("key%03d", i)))
-	}
+	// Manually set discard stats for the active file (highest) and an old file.
+	// The old file's discard must exceed the threshold to be eligible.
+	const fileSize = 1 << 20 // 1 MB
+	vlog.discardStats.Update(maxFid, 1<<30)      // active: large discard, but ineligible
+	vlog.discardStats.Update(fids[0], int64(0.3*fileSize)) // old file: 30% > 10% threshold
 
-	// Manually give the active file a larger discard so it becomes the top
-	// candidate, which the old code would abort on.
-	vlog.discardStats.Update(maxFid, 1<<30)
-
-	// Now pickLog should skip the active file and return an older one.
-	lf := vlog.pickLog(0.1) // 10% threshold — delete 10 keys × 32KB ≈ 320KB > 0.1 × 1MB
+	// Now pickLog should skip the active file and return the older one.
+	lf := vlog.pickLog(0.1)
 	if lf == nil {
 		vlog.discardStats.Lock()
 		vlog.discardStats.Iterate(func(fid, stats uint64) {

--- a/value_test.go
+++ b/value_test.go
@@ -1619,6 +1619,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	opt.ValueLogFileSize = 1 << 20
 	opt.ValueThreshold = 1 << 10
 	opt.NumCompactors = 0
+	opt.ValueLogMaxEntries = 16 // force a new file every 16 entries
 
 	kv, err := Open(opt)
 	require.NoError(t, err)
@@ -1640,20 +1641,25 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	vlog.filesLock.RLock()
 	fids := vlog.sortedFids()
 	maxFid := vlog.maxFid
+	var fidList []uint32
+	for _, f := range fids {
+		fidList = append(fidList, f)
+	}
 	vlog.filesLock.RUnlock()
 
-	if len(fids) < 2 {
-		t.Skip("need at least two vlog files")
+	if len(fidList) < 2 {
+		t.Fatalf("need at least two vlog files, got %d (fids=%v)", len(fidList), fidList)
 	}
+	t.Logf("fids=%v maxFid=%d", fidList, maxFid)
 
-	// Delete entries likely to be in the first file.
-	for i := 0; i < 20; i++ {
-		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
+	// Delete entries in the first file to create discard.
+	for i := 0; i < 10; i++ {
+		txnDelete(t, kv, []byte(fmt.Sprintf("key%03d", i)))
 	}
 
 	// Manually give the active file a larger discard so it becomes the top
 	// candidate, which the old code would abort on.
-	activeDiscard := int64(1 << 30) // well above any real discard
+	activeDiscard := int64(1 << 30)
 	vlog.discardStats.Update(maxFid, activeDiscard)
 
 	// Now pickLog should skip the active file and return an older one.
@@ -1664,7 +1670,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 			t.Logf("  discardStats[%d]=%d", fid, stats)
 		})
 		vlog.discardStats.Unlock()
-		t.Fatalf("pickLog returned nil; expected an old file (fid < %d)", maxFid)
+		t.Fatalf("pickLog returned nil; expected an old file (fid < %d) with fids=%v", maxFid, fidList)
 	}
 	require.Less(t, lf.fid, maxFid, "pickLog must return an older file, not the active one")
 	t.Logf("pickLog returned fid=%d (maxFid=%d)", lf.fid, maxFid)

--- a/value_test.go
+++ b/value_test.go
@@ -1616,7 +1616,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	defer removeDir(dir)
 
 	opt := getTestOptions(dir)
-	opt.ValueLogFileSize = 1 << 20 // 1 MB minimum, write enough data to force multiple files
+	opt.ValueLogFileSize = 1 << 20
 	opt.ValueThreshold = 1 << 10
 	opt.NumCompactors = 0
 
@@ -1627,51 +1627,45 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	vlog := kv.vlog
 	sz := 32 << 10
 
-	// Write data to create the first vlog files (fid 1, 2, 3...).
+	// Write data to create several vlog files.
 	txn := kv.NewTransaction(true)
-	for i := 0; i < 45; i++ {
+	for i := 0; i < 80; i++ {
 		v := make([]byte, sz)
 		rand.Read(v)
 		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))
 	}
 	require.NoError(t, txn.Commit())
 
-	// Delete entries in the first file to create discard.
-	for i := 0; i < 3; i++ {
-		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
-	}
-
-	// Both files now have discard stats.  The active file (maxFid) may have
-	// accumulated discard too.  If it does, the old code would abort when
-	// MaxDiscard returned the active file; the new code should skip it and
-	// return the older file.
+	// Store fid and maxFid before any deletions.
 	vlog.filesLock.RLock()
-	maxFid := vlog.maxFid
 	fids := vlog.sortedFids()
+	maxFid := vlog.maxFid
 	vlog.filesLock.RUnlock()
 
 	if len(fids) < 2 {
-		t.Skip("need at least two vlog files for this test")
+		t.Skip("need at least two vlog files")
 	}
 
-	// Run pickLog — it should not return nil when at least one eligible file exists.
+	// Delete entries likely to be in the first file.
+	for i := 0; i < 20; i++ {
+		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
+	}
+
+	// Manually give the active file a larger discard so it becomes the top
+	// candidate, which the old code would abort on.
+	activeDiscard := int64(1 << 30) // well above any real discard
+	vlog.discardStats.Update(maxFid, activeDiscard)
+
+	// Now pickLog should skip the active file and return an older one.
 	lf := vlog.pickLog(0.5)
 	if lf == nil {
-		// If the active file is the only file with any discard, the test
-		// is inconclusive — there is no other candidate.  Skip.
 		vlog.discardStats.Lock()
-		defer vlog.discardStats.Unlock()
-		var hasOldDiscard bool
 		vlog.discardStats.Iterate(func(fid, stats uint64) {
-			if fid < uint64(maxFid) && stats > 0 {
-				hasOldDiscard = true
-			}
+			t.Logf("  discardStats[%d]=%d", fid, stats)
 		})
-		if !hasOldDiscard {
-			t.Skip("no non-active file has discard — test is inconclusive")
-		}
-		t.Errorf("pickLog returned nil even though an older file has discard; "+
-			"maxFid=%d fids=%v", maxFid, fids)
+		vlog.discardStats.Unlock()
+		t.Fatalf("pickLog returned nil; expected an old file (fid < %d)", maxFid)
 	}
 	require.Less(t, lf.fid, maxFid, "pickLog must return an older file, not the active one")
+	t.Logf("pickLog returned fid=%d (maxFid=%d)", lf.fid, maxFid)
 }

--- a/value_test.go
+++ b/value_test.go
@@ -1666,7 +1666,7 @@ func TestPickLogWalksCandidates(t *testing.T) {
 	vlog.discardStats.Update(maxFid, 1<<30)
 
 	// Now pickLog should skip the active file and return an older one.
-	lf := vlog.pickLog(0.5)
+	lf := vlog.pickLog(0.1) // 10% threshold — delete 10 keys × 32KB ≈ 320KB > 0.1 × 1MB
 	if lf == nil {
 		vlog.discardStats.Lock()
 		vlog.discardStats.Iterate(func(fid, stats uint64) {

--- a/value_test.go
+++ b/value_test.go
@@ -1605,3 +1605,82 @@ func TestVlogGCRaceDeletedKeyReappearsMultiCycle(t *testing.T) {
 
 	require.Len(t, deleted, cycles, "each cycle must have deleted a distinct key")
 }
+
+
+// TestPickLogWalksCandidates verifies that pickLog does not give up when the
+// single highest-discard file is the active (write) value log file. Instead it
+// should skip the active file and return the next-best eligible candidate.
+func TestPickLogWalksCandidates(t *testing.T) {
+	dir, err := os.MkdirTemp("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	opt := getTestOptions(dir)
+	opt.ValueLogFileSize = 1 << 20
+	opt.ValueThreshold = 1 << 10
+	opt.NumCompactors = 0
+
+	kv, err := Open(opt)
+	require.NoError(t, err)
+	defer kv.Close()
+
+	vlog := kv.vlog
+	sz := 32 << 10
+
+	// Write data to create the first vlog file (fid=1).
+	txn := kv.NewTransaction(true)
+	for i := 0; i < 5; i++ {
+		v := make([]byte, sz)
+		rand.Read(v)
+		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))
+	}
+	require.NoError(t, txn.Commit())
+
+	// Write more data to create a second vlog file (fid=2, active).
+	txn = kv.NewTransaction(true)
+	for i := 5; i < 10; i++ {
+		v := make([]byte, sz)
+		rand.Read(v)
+		require.NoError(t, txn.SetEntry(NewEntry([]byte(fmt.Sprintf("key%d", i)), v)))
+	}
+	require.NoError(t, txn.Commit())
+
+	// Delete entries in the first file to create discard.
+	for i := 0; i < 3; i++ {
+		txnDelete(t, kv, []byte(fmt.Sprintf("key%d", i)))
+	}
+
+	// Both files now have discard stats.  The active file (maxFid) may have
+	// accumulated discard too.  If it does, the old code would abort when
+	// MaxDiscard returned the active file; the new code should skip it and
+	// return the older file.
+	vlog.filesLock.RLock()
+	maxFid := vlog.maxFid
+	fids := vlog.sortedFids()
+	vlog.filesLock.RUnlock()
+
+	if len(fids) < 2 {
+		t.Skip("need at least two vlog files for this test")
+	}
+
+	// Run pickLog — it should not return nil when at least one eligible file exists.
+	lf := vlog.pickLog(0.5)
+	if lf == nil {
+		// If the active file is the only file with any discard, the test
+		// is inconclusive — there is no other candidate.  Skip.
+		vlog.discardStats.Lock()
+		defer vlog.discardStats.Unlock()
+		var hasOldDiscard bool
+		vlog.discardStats.Iterate(func(fid, stats uint64) {
+			if fid < uint64(maxFid) && stats > 0 {
+				hasOldDiscard = true
+			}
+		})
+		if !hasOldDiscard {
+			t.Skip("no non-active file has discard — test is inconclusive")
+		}
+		t.Errorf("pickLog returned nil even though an older file has discard; "+
+			"maxFid=%d fids=%v", maxFid, fids)
+	}
+	require.Less(t, lf.fid, maxFid, "pickLog must return an older file, not the active one")
+}


### PR DESCRIPTION
This PR fixes #2334: `pickLog` aborts GC when the single highest-discard file is ineligible, leaving older reclaimable files untouched.

## Problem

`valueLog.pickLog` calls `discardStats.MaxDiscard()` which returns exactly one candidate — the file with the largest accumulated discard. If that file:

1. Is the active (write) value log file (`fid == maxFid`), or
2. Has discard below the `discardRatio` threshold

the function returns `nil` and `RunValueLogGC` returns `ErrNoRewrite`. No other files are examined, even though older files may hold plenty of reclaimable space. The stall lasts until the active file rolls over (up to 1 GB of writes).

## Fix

Instead of aborting on the first ineligible candidate, collect all candidates from discard stats, sort them by discard descending, and walk the list skipping:

- Deleted files (clean up their discard stats)
- Files below the discard ratio threshold
- Active (write) value log files (`fid == maxFid`)

Return the first eligible candidate, or `nil` if none exist.

## Testing

- New `TestPickLogWalksCandidates` regression test: creates three vlog files, sets the active file as the top-discard candidate plus an older file above the threshold, and asserts `pickLog` skips the active file and returns the older one.
- Existing GC tests (`TestValueGC`, `TestValueGC2`, `TestValueGC3`, `TestValueGC4`, `TestValueGCManaged`) all pass — the normal happy path is unchanged.
