### PR TITLE
docs: fix quickstart.md prettier formatting

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -342,9 +342,9 @@ res, _ := m.Get() // res should have value 6 encoded
 ## Setting time to live and user metadata on keys
 
 Badger allows setting an optional Time to Live (TTL) value on keys. Once the TTL has elapsed, the
-key is no longer retrievable, but the disk space it occupies is not reclaimed at that point. See
-the Garbage collection section below for what actually frees it. A TTL can be set as a
-`time.Duration` value using the `Entry.WithTTL()` and `Txn.SetEntry()` API methods.
+key is no longer retrievable, but the disk space it occupies is not reclaimed at that point. See the
+Garbage collection section below for what actually frees it. A TTL can be set as a `time.Duration`
+value using the `Entry.WithTTL()` and `Txn.SetEntry()` API methods.
 
 ```go
 err := db.Update(func(txn *badger.Txn) error {
@@ -633,13 +633,12 @@ the following method, which can be invoked at an appropriate time:
   automatically discards older/invalid versions of keys.
 
 <Note>
-  The `RunValueLogGC` method would not garbage collect the latest value log.
-
-  It also reclaims space only for values that live in the value log, and only once a compaction has
-  accounted for them. Values smaller than `ValueThreshold` (1 MB by default) are stored inline in
-  the LSM tree and are never collected by this method. Expiring keys with a TTL, or deleting them,
-  does not reclaim space on its own either: compactions are driven by incoming writes, so a
-  database that has stopped taking writes will not shrink.
+  The `RunValueLogGC` method would not garbage collect the latest value log. It also reclaims space
+  only for values that live in the value log, and only once a compaction has accounted for them.
+  Values smaller than `ValueThreshold` (1 MB by default) are stored inline in the LSM tree and are
+  never collected by this method. Expiring keys with a TTL, or deleting them, does not reclaim space
+  on its own either: compactions are driven by incoming writes, so a database that has stopped
+  taking writes will not shrink.
 </Note>
 
 ## Database backup


### PR DESCRIPTION
**Description**

`docs/quickstart.md` has been failing the prettier check since #2328 merged. It surfaces as a trunk
failure for anyone who touches the file or runs `trunk fmt` locally, which is how @adityeah8969 ran
into it on #2333.

The cause is the blank line added inside the `RunValueLogGC` `<Note>`. Per CommonMark an HTML block
ends at a blank line, so everything after it parsed as ordinary markdown and prettier reflowed the
closing `</Note>` onto the end of a text sentence. Collapsing the note back to a single paragraph
matches the three other `<Note>`/`<Tip>` blocks in `docs/` and keeps the tag on its own line.

Also reflows the TTL paragraph to prettier's width. No wording changes; content is identical to what
#2328 landed.

`npx prettier --check docs/quickstart.md` passes, and `trunk fmt` is a no-op on the result.

**Checklist**

- [x] Code compiles correctly and linting passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/badger/pr/2336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790364591&installation_model_id=8575&pr_number=2336&repository=dgraph-io%2Fbadger&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fbadger%2Fpull%2F2336&signature=f756ceddd2177f32f88d316b762c28876c4932a4b52b70b3b913ff018f47fafe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->