### PR TITLE
[PR READY, not draft] fix(db): ignore compaction deleted files during db size calculation

### DIFF
--- a/db.go
+++ b/db.go
@@ -1197,6 +1197,32 @@ func exists(path string) (bool, error) {
 	return true, err
 }
 
+// calculateDirSize walks dir and returns the total size of the .sst files
+// (lsmSize) and .vlog files (vlogSize) it contains. Files may be created and
+// deleted concurrently by compactions, so a file that disappears mid-walk is
+// ignored rather than treated as an error.
+func calculateDirSize(dir string) (lsmSize, vlogSize int64, err error) {
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// A file deleted or renamed by a concurrent compaction makes Walk
+			// report "no such file or directory"; that's expected, so skip it
+			// and keep walking instead of aborting the whole walk.
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		switch filepath.Ext(path) {
+		case ".sst":
+			lsmSize += info.Size()
+		case ".vlog":
+			vlogSize += info.Size()
+		}
+		return nil
+	})
+	return lsmSize, vlogSize, err
+}
+
 // This function does a filewalk, calculates the size of vlog and sst files and stores it in
 // y.LSMSize and y.VlogSize.
 func (db *DB) calculateSize() {
@@ -1209,32 +1235,17 @@ func (db *DB) calculateSize() {
 		return v
 	}
 
-	totalSize := func(dir string) (int64, int64) {
-		var lsmSize, vlogSize int64
-		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			ext := filepath.Ext(path)
-			switch ext {
-			case ".sst":
-				lsmSize += info.Size()
-			case ".vlog":
-				vlogSize += info.Size()
-			}
-			return nil
-		})
-		if err != nil {
-			db.opt.Debugf("Got error while calculating total size of directory: %s", dir)
-		}
-		return lsmSize, vlogSize
+	lsmSize, vlogSize, err := calculateDirSize(db.opt.Dir)
+	if err != nil {
+		db.opt.Debugf("Got error while calculating total size of directory %s: %v", db.opt.Dir, err)
 	}
-
-	lsmSize, vlogSize := totalSize(db.opt.Dir)
 	y.LSMSizeSet(db.opt.MetricsEnabled, db.opt.Dir, newInt(lsmSize))
 	// If valueDir is different from dir, we'd have to do another walk.
 	if db.opt.ValueDir != db.opt.Dir {
-		_, vlogSize = totalSize(db.opt.ValueDir)
+		_, vlogSize, err = calculateDirSize(db.opt.ValueDir)
+		if err != nil {
+			db.opt.Debugf("Got error while calculating total size of directory %s: %v", db.opt.ValueDir, err)
+		}
 	}
 	y.VlogSizeSet(db.opt.MetricsEnabled, db.opt.ValueDir, newInt(vlogSize))
 }

--- a/db_test.go
+++ b/db_test.go
@@ -18,7 +18,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2734,4 +2736,84 @@ func TestCloseDBWhileReading(t *testing.T) {
 	time.Sleep(time.Second)
 	require.NoError(t, db.Close())
 	wg.Wait()
+}
+
+// countingLogger records how many times badger logs the issue #2116 message:
+// "Got error while calculating total size of directory".
+type countingLogger struct {
+	hits *int64
+}
+
+func (l *countingLogger) Errorf(string, ...interface{})   {}
+func (l *countingLogger) Warningf(string, ...interface{}) {}
+func (l *countingLogger) Infof(string, ...interface{})    {}
+func (l *countingLogger) Debugf(format string, args ...interface{}) {
+	if strings.Contains(fmt.Sprintf(format, args...), "Got error while calculating total size of directory") {
+		atomic.AddInt64(l.hits, 1)
+	}
+}
+
+// TestCalculateSizeIgnoresConcurrentDeletes reproduces the issue #2116 scenario:
+// compactions delete .sst/.mem files while calculateSize() walks the directory.
+// The fixed calculateSize() must ignore files deleted because of compaction.
+func TestCalculateSizeIgnoresConcurrentDeletes(t *testing.T) {
+	dir := t.TempDir()
+	var hits int64
+
+	opts := DefaultOptions(dir).
+		WithLogger(&countingLogger{hits: &hits}).
+		WithSyncWrites(false).
+		// Aggressive flush/compaction so .sst/.mem files churn constantly.
+		WithNumMemtables(1).
+		WithMemTableSize(1 << 20).
+		WithBaseTableSize(1 << 20).
+		WithBaseLevelSize(4 << 20).
+		WithNumLevelZeroTables(1).
+		WithNumLevelZeroTablesStall(2).
+		WithNumCompactors(2).
+		WithValueThreshold(1 << 16)
+
+	db, err := Open(opts)
+	require.NoError(t, err)
+	defer db.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	var seq int64
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				n := atomic.AddInt64(&seq, 1)
+				_ = db.Update(func(txn *Txn) error {
+					return txn.Set(
+						[]byte(fmt.Sprintf("key:%d:%d", id, n)),
+						[]byte(fmt.Sprintf("val:%d:%d:abcdefghijklmnopqrstuvwxyz", id, n)))
+				})
+			}
+		}(w)
+	}
+
+	// Call calculateSize() in a tight loop for 3 seconds while the writers keep
+	// flushing/compacting, so it walks over .sst files that are being deleted.
+	// Tiiggering "db.calculateSize()" continuously leads to calling
+	// "calculateDirSize" and ~40 hits to "os.IsNotExist(err)" i.e
+	// we observe multiple occurences of us ignoring the deleted files.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		db.calculateSize()
+	}
+
+	close(stop)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&hits); got != 0 {
+		t.Fatalf("calculateSize() logged error %d times; it should tolerate files deleted during compaction", got)
+	}
 }


### PR DESCRIPTION
**Description**

Fixes [#2116](https://github.com/dgraph-io/badger/issues/2116)

Badger's `calculateSize()` walks the LSM/value directories with `filepath.Walk` once a minute to publish LSM/vlog size metrics. During compaction, `.sst`/`.mem` files are created and deleted concurrently. When a file is removed between the walk's directory read and its `lstat`, `filepath.Walk` reports `lstat <file>: no such file or directory`, and Badger logged:

`Got error while calculating total size of directory: <dir>`

Because deletions by compaction are expected, this is noise, not an error.

This change extracts the walk into `calculateDirSize` and treats `os.IsNotExist` as benign — skipping the missing file and continuing the walk — instead of aborting and logging. All other errors (permission, I/O, etc.) still propagate and are logged as before.

Added `TestCalculateSizeIgnoresConcurrentDeletes`: opens a DB with aggressive flush/compaction settings and concurrent writers, calls `calculateSize()` in a tight loop, and asserts the error is never logged.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/badger/pr/2338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790628377&installation_model_id=8575&pr_number=2338&repository=dgraph-io%2Fbadger&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fbadger%2Fpull%2F2338&signature=26a6813c4ef8d9444e019a8060b5db0a9dd6c0cb345260e01e818e7d369a04e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->