### PR TITLE
[PR READY, Not in Draft] fix(stream): single read txn for all backup orchestrate workers

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -7,18 +7,26 @@ package badger
 
 import (
 	"bytes"
+	"context"
+	"encoding/binary"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/dgraph-io/badger/v4/pb"
+	"github.com/dgraph-io/ristretto/v2/z"
 )
 
 func TestBackupRestore1(t *testing.T) {
@@ -551,4 +559,183 @@ func TestBackupBitClear(t *testing.T) {
 		require.Equal(t, val, v)
 		return nil
 	}))
+}
+
+// TestOrchestrateWorkersShareReadTs verifies that Stream.Orchestrate pins a
+// single read timestamp that every worker shares, rather than letting each
+// worker open its own transaction at a (potentially) different time. The latter
+// is what caused inconsistent/torn backups (#2049).
+func TestOrchestrateWorkersShareReadTs(t *testing.T) {
+	dir, err := os.MkdirTemp("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	db, err := Open(getTestOptions(dir))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	// Pre-populate enough keys so Stream.Ranges splits the keyspace into
+	// multiple ranges that get handled by different workers.
+	const nKeys = 20000
+	wb := db.NewWriteBatch()
+	for i := 0; i < nKeys; i++ {
+		require.NoError(t, wb.Set([]byte(fmt.Sprintf("key-%05d", i)), []byte(strconv.Itoa(i))))
+	}
+	require.NoError(t, wb.Flush())
+
+	// Churn writer: keeps committing while the stream runs. If workers each
+	// opened their own transaction at different times, this would cause them to
+	// observe different read timestamps.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		j := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = db.Update(func(txn *Txn) error {
+				return txn.Set([]byte("churn"), []byte(strconv.Itoa(j)))
+			})
+			j++
+		}
+	}()
+
+	// Record the read timestamp observed by each worker via the iterator.
+	var mu sync.Mutex
+	readTs := make(map[uint64]struct{})
+	stream := db.NewStream()
+	stream.KeyToList = func(key []byte, itr *Iterator) (*pb.KVList, error) {
+		mu.Lock()
+		readTs[itr.readTs] = struct{}{}
+		mu.Unlock()
+		return stream.ToList(key, itr)
+	}
+	// Discard the streamed output; we only care about the readTs observed above.
+	stream.Send = func(buf *z.Buffer) error { return nil }
+
+	require.NoError(t, stream.Orchestrate(context.Background()))
+
+	close(stop)
+	wg.Wait()
+
+	// With a single shared read transaction, every worker must observe the same
+	// timestamp. If workers read different timestamps, a backup built from them
+	// could observe a torn transaction.
+	require.Len(t, readTs, 1, "workers did not share a single read timestamp: %v", readTs)
+}
+
+// TestBackupConsistentSnapshot ensures that DB.Backup produces a point-in-time
+// snapshot even while writes are happening concurrently. Each writer commits a
+// pair of keys (one at each end of the keyspace, so they land in different
+// stream ranges and are handled by different workers) in a single transaction.
+// A backup must observe either both keys of a pair or neither — never a torn
+// half (one key visible without the other).
+func TestBackupConsistentSnapshot(t *testing.T) {
+	dir, err := os.MkdirTemp("", "badger-test")
+	require.NoError(t, err)
+	defer removeDir(dir)
+
+	db, err := Open(getTestOptions(dir))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	const prePopulate = 20000
+	wb := db.NewWriteBatch()
+	for i := 0; i < prePopulate; i++ {
+		require.NoError(t, wb.Set([]byte(fmt.Sprintf("key-%05d", i)), []byte(strconv.Itoa(i))))
+	}
+	require.NoError(t, wb.Flush())
+
+	const numWriters = 16
+	const pairsPerWriter = 500
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, numWriters)
+
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for j := 0; j < pairsPerWriter; j++ {
+				err := db.Update(func(txn *Txn) error {
+					val := []byte(strconv.Itoa(j))
+					// Two keys at opposite ends of the keyspace, committed
+					// atomically in a single transaction.
+					if err := txn.Set([]byte(fmt.Sprintf("a-%d-%d", w, j)), val); err != nil {
+						return err
+					}
+					return txn.Set([]byte(fmt.Sprintf("z-%d-%d", w, j)), val)
+				})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				// Yield so the backup goroutine below keeps getting scheduled
+				// while writers are still active.
+				runtime.Gosched()
+			}
+		}(w)
+	}
+
+	// Run several backups while writers are churning and assert none of them
+	// observe a torn transaction.
+	for b := 0; b < 30; b++ {
+		var buf bytes.Buffer
+		_, err := db.Backup(&buf, 0)
+		require.NoError(t, err)
+		checkBackupConsistency(t, &buf)
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("writer failed: %v", err)
+	}
+}
+
+// checkBackupConsistency parses a backup stream and fails the test if it
+// contains one half of a paired write without the other.
+func checkBackupConsistency(t *testing.T, buf *bytes.Buffer) {
+	t.Helper()
+
+	r := bytes.NewReader(buf.Bytes())
+	keys := make(map[string][]byte)
+	for {
+		var sz uint64
+		if err := binary.Read(r, binary.LittleEndian, &sz); err != nil {
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+		}
+		chunk := make([]byte, sz)
+		if _, err := io.ReadFull(r, chunk); err != nil {
+			require.NoError(t, err)
+		}
+		var list pb.KVList
+		require.NoError(t, proto.Unmarshal(chunk, &list))
+		for _, kv := range list.Kv {
+			keys[string(kv.Key)] = kv.Value
+		}
+	}
+
+	for k, v := range keys {
+		var partner string
+		switch {
+		case strings.HasPrefix(k, "a-"):
+			partner = "z-" + strings.TrimPrefix(k, "a-")
+		case strings.HasPrefix(k, "z-"):
+			partner = "a-" + strings.TrimPrefix(k, "z-")
+		default:
+			continue
+		}
+		pv, ok := keys[partner]
+		require.True(t, ok, "backup contains %q but not its partner %q: torn transaction", k, partner)
+		require.Equal(t, v, pv, "values of %q and %q differ", k, partner)
+	}
 }

--- a/stream.go
+++ b/stream.go
@@ -170,17 +170,9 @@ func (st *Stream) produceRanges(ctx context.Context) {
 }
 
 // produceKVs picks up ranges from rangeCh, generates KV lists and sends them to kvChan.
-func (st *Stream) produceKVs(ctx context.Context, threadId int) error {
+func (st *Stream) produceKVs(ctx context.Context, threadId int, txn *Txn) error {
 	st.numProducers.Add(1)
 	defer st.numProducers.Add(-1)
-
-	var txn *Txn
-	if st.readTs > 0 {
-		txn = st.db.NewTransactionAt(st.readTs, false)
-	} else {
-		txn = st.db.NewTransaction(false)
-	}
-	defer txn.Discard()
 
 	// produceKVs is running iterate serially. So, we can define the outList here.
 	outList := z.NewBuffer(2*batchSize, "Stream.ProduceKVs")
@@ -426,6 +418,21 @@ func (st *Stream) Orchestrate(ctx context.Context) error {
 		st.KeyToList = st.ToList
 	}
 
+	// Create a single read transaction up front so that all workers iterate over
+	// the same point-in-time snapshot of the DB. Without this, each worker would
+	// open its own transaction at a different timestamp, so a write committed
+	// mid-stream could be visible to some workers and not others, producing an
+	// inconsistent (torn) backup.
+	var txn *Txn
+	if st.readTs > 0 {
+		txn = st.db.NewTransactionAt(st.readTs, false)
+	} else {
+		txn = st.db.NewTransaction(false)
+	}
+	// Discard runs after wg.Wait() below, by which point all iterators created
+	// from this txn have been closed.
+	defer txn.Discard()
+
 	// Picks up ranges from Badger, and sends them to rangeCh.
 	go st.produceRanges(ctx)
 
@@ -437,7 +444,7 @@ func (st *Stream) Orchestrate(ctx context.Context) error {
 		go func(threadId int) {
 			defer wg.Done()
 			// Picks up ranges from rangeCh, generates KV lists, and sends them to kvChan.
-			if err := st.produceKVs(ctx, threadId); err != nil {
+			if err := st.produceKVs(ctx, threadId, txn); err != nil {
 				select {
 				case errCh <- err:
 				default:


### PR DESCRIPTION
**Description**

Fixes [#2049](https://github.com/dgraph-io/badger/issues/2049)

Stream.Orchestrate previously let each produceKVs worker open its own transaction at a different point in time. A write committed mid-stream could therefore be visible to some workers and not others, so a backup built from their output could capture a torn (half-applied) transaction

Create one shared read transaction up front in Orchestrate and pass it to every worker, so all of them iterate over the same point-in-time snapshot.

Add two regression tests:

- TestOrchestrateWorkersShareReadTs asserts every worker observes the same read timestamp while a churn writer commits concurrently (fails before the fix).
- TestBackupConsistentSnapshot writes key pairs atomically across the keyspace during concurrent backups and asserts no backup captures a torn half  or partial tx writes.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/badger/pr/2339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790720684&installation_model_id=8575&pr_number=2339&repository=dgraph-io%2Fbadger&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fbadger%2Fpull%2F2339&signature=a1aa2d7db4b05cbd275c9813af4d858edc1020804828249d4422072db4c0cda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->