### PR TITLE
fix(db): release partially initialized resources when Open fails

### DIFF
--- a/db.go
+++ b/db.go
@@ -192,7 +192,7 @@ func checkAndSetOptions(opt *Options) error {
 }
 
 // Open returns a new DB object.
-func Open(opt Options) (*DB, error) {
+func Open(opt Options) (_ *DB, err error) {
 	if err := checkAndSetOptions(&opt); err != nil {
 		return nil, err
 	}
@@ -270,8 +270,9 @@ func Open(opt Options) (*DB, error) {
 	defer func() {
 		if err != nil {
 			opt.Errorf("Received err: %v. Cleaning up...", err)
-			db.cleanup()
-			db = nil
+			if cleanupErr := db.cleanup(); cleanupErr != nil {
+				err = errors.Join(err, cleanupErr)
+			}
 		}
 	}()
 
@@ -335,7 +336,7 @@ func Open(opt Options) (*DB, error) {
 	}
 
 	if db.registry, err = OpenKeyRegistry(krOpt); err != nil {
-		return db, err
+		return nil, err
 	}
 	db.calculateSize()
 	db.closers.updateSize = z.NewCloser(1)
@@ -353,7 +354,7 @@ func Open(opt Options) (*DB, error) {
 
 	// newLevelsController potentially loads files in directory.
 	if db.lc, err = newLevelsController(db, &manifest); err != nil {
-		return db, err
+		return nil, err
 	}
 
 	// Initialize vlog struct.
@@ -377,7 +378,7 @@ func Open(opt Options) (*DB, error) {
 	db.opt.Infof("Set nextTxnTs to %d", db.orc.nextTxnTs)
 
 	if err = db.vlog.open(db); err != nil {
-		return db, y.Wrapf(err, "During db.vlog.open")
+		return nil, y.Wrapf(err, "During db.vlog.open")
 	}
 
 	// Let's advance nextTxnTs to one more than whatever we observed via
@@ -388,11 +389,13 @@ func Open(opt Options) (*DB, error) {
 	db.orc.readMark.Done(db.orc.nextTxnTs)
 	db.orc.incrementNextTs()
 
-	go db.threshold.listenForValueThresholdUpdate()
-
 	if err := db.initBannedNamespaces(); err != nil {
-		return db, fmt.Errorf("While setting banned keys: %w", err)
+		return nil, fmt.Errorf("While setting banned keys: %w", err)
 	}
+
+	// Start this only after the last fallible initialization step. Its closer
+	// expects a running listener, so it cannot be waited on by early cleanup.
+	go db.threshold.listenForValueThresholdUpdate()
 
 	db.closers.writes = z.NewCloser(1)
 	go db.doWrites(db.closers.writes)
@@ -489,16 +492,20 @@ func (db *DB) monitorCache(c *z.Closer) {
 	}
 }
 
-// cleanup stops all the goroutines started by badger. This is used in open to
-// cleanup goroutines in case of an error.
-func (db *DB) cleanup() {
+// cleanup releases resources acquired by an unsuccessful Open. The manifest and
+// directory locks are released by Open's outer defers, after all workers stop.
+// This must not run the normal Close path, which flushes/truncates database files.
+func (db *DB) cleanup() (cleanupErr error) {
 	db.stopMemoryFlush()
 	db.stopCompactions()
 
+	if db.closers.cacheHealth != nil {
+		db.closers.cacheHealth.SignalAndWait()
+	}
 	db.blockCache.Close()
 	db.indexCache.Close()
 	if db.closers.updateSize != nil {
-		db.closers.updateSize.Signal()
+		db.closers.updateSize.SignalAndWait()
 	}
 	if db.closers.valueGC != nil {
 		db.closers.valueGC.Signal()
@@ -512,8 +519,35 @@ func (db *DB) cleanup() {
 
 	db.orc.Stop()
 
-	// Do not use vlog.Close() here. vlog.Close truncates the files. We don't
-	// want to truncate files unless the user has specified the truncate flag.
+	logErr := func(err error) {
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+			db.opt.Errorf("While cleaning up failed Open: %v", err)
+		}
+	}
+	if db.mt != nil {
+		logErr(db.mt.closeWithoutFlush())
+	}
+	for _, mt := range db.imm {
+		logErr(mt.closeWithoutFlush())
+	}
+	if db.lc != nil {
+		logErr(db.lc.closeOnError())
+	}
+	// The latest vlog offset may not have been initialized on failure. Close
+	// only files actually opened, and never truncate them (see #1465).
+	for _, lf := range db.vlog.filesMap {
+		logErr(lf.closeOnError())
+	}
+	if db.vlog.discardStats != nil {
+		logErr(closeMmapOnError(db.vlog.discardStats.MmapFile))
+	}
+	if db.registry != nil {
+		logErr(db.registry.Close())
+	}
+	// No flusher or compactor can return an allocator after this point.
+	db.allocPool.Release()
+	return cleanupErr
 }
 
 // BlockCacheMetrics returns the metrics for the underlying block cache.

--- a/db_open_failure_edges_test.go
+++ b/db_open_failure_edges_test.go
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package badger
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func tableLoaderCount() int {
+	var buf bytes.Buffer
+	_ = pprof.Lookup("goroutine").WriteTo(&buf, 2)
+	count := 0
+	for _, stack := range strings.Split(buf.String(), "\n\n") {
+		if strings.Contains(stack, "github.com/dgraph-io/badger/v4.newLevelsController.func") {
+			count++
+		}
+	}
+	return count
+}
+
+func TestOpenFailureWaitsForTableLoaders(t *testing.T) {
+	opt := openFailureOptions(t.TempDir())
+	db, err := Open(opt)
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		createAndOpen(db, []keyValVersion{{fmt.Sprintf("key-%d", i), "preserve", 1, 0}}, 0)
+	}
+	require.NoError(t, db.Close())
+	paths, err := filepath.Glob(filepath.Join(opt.Dir, "*.sst"))
+	require.NoError(t, err)
+	require.Len(t, paths, 5)
+	hashes := make(map[string][32]byte)
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		hashes[path] = sha256.Sum256(data)
+	}
+
+	// Fill all three loader slots. One worker then fails while the other two
+	// remain paused; a fourth, if scheduled, pauses too. With five manifest
+	// entries, the dispatcher must observe the error from Throttle.Do.
+	ready := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	defer unblock()
+	var started atomic.Int32
+	bad := opt
+	bad.tableOpenHook = func(tf *TableManifest) {
+		n := started.Add(1)
+		if n == 3 {
+			close(ready)
+		}
+		if n == 2 {
+			<-ready
+			tf.KeyID = 123456789 // The real key registry rejects this key ID.
+		} else {
+			<-release
+		}
+	}
+	type result struct {
+		db  *DB
+		err error
+	}
+	resultCh := make(chan result, 1)
+	fds := openFailureFDs()
+	go func() {
+		db, err := Open(bad)
+		resultCh <- result{db, err}
+	}()
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("table loaders did not start")
+	}
+	var got result
+	early := false
+	select {
+	case got = <-resultCh:
+		early = true
+		t.Error("Open returned while other table loaders were still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+	unblock()
+	if !early {
+		select {
+		case got = <-resultCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Open did not join released table loaders")
+		}
+	}
+	require.Nil(t, got.db)
+	require.ErrorContains(t, got.err, "Invalid datakey id")
+	require.Eventually(t, func() bool { return tableLoaderCount() == 0 }, 5*time.Second, 10*time.Millisecond)
+	if after := openFailureFDs(); fds >= 0 {
+		require.LessOrEqual(t, after, fds, "tables opened after the error must also be closed")
+	}
+	for path, want := range hashes {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, want, sha256.Sum256(data))
+	}
+	db, err = Open(opt)
+	require.NoError(t, err)
+	require.NoError(t, db.View(func(txn *Txn) error {
+		for i := 0; i < 5; i++ {
+			item, err := txn.Get([]byte(fmt.Sprintf("key-%d", i)))
+			if err != nil {
+				return err
+			}
+			value, err := item.ValueCopy(nil)
+			require.NoError(t, err)
+			require.Equal(t, []byte("preserve"), value)
+		}
+		return nil
+	}))
+	require.NoError(t, db.Close())
+}
+
+func TestOpenFailureMultipleTableErrors(t *testing.T) {
+	opt := openFailureOptions(t.TempDir())
+	db, err := Open(opt)
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		createAndOpen(db, []keyValVersion{{fmt.Sprintf("key-%d", i), "preserve", 1, 0}}, 0)
+	}
+	require.NoError(t, db.Close())
+	fds := openFailureFDs()
+	for attempt := 0; attempt < 8; attempt++ {
+		ready := make(chan struct{})
+		var started atomic.Int32
+		bad := opt
+		bad.tableOpenHook = func(tf *TableManifest) {
+			if started.Add(1) == 3 {
+				close(ready)
+			}
+			<-ready
+			tf.KeyID = 123456789
+		}
+		failed, err := Open(bad)
+		require.Nil(t, failed)
+		require.ErrorContains(t, err, "Invalid datakey id")
+	}
+	if after := openFailureFDs(); fds >= 0 {
+		require.LessOrEqual(t, after, fds)
+	}
+	db, err = Open(opt)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}

--- a/db_open_failure_test.go
+++ b/db_open_failure_test.go
@@ -1,0 +1,268 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package badger
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func openFailureOptions(dir string) Options {
+	return DefaultOptions(dir).WithLogger(nil).WithMemTableSize(1 << 20).
+		WithValueLogFileSize(1 << 20).WithValueThreshold(32).
+		WithBlockCacheSize(1 << 20).WithIndexCacheSize(1 << 20).
+		WithNumCompactors(0).WithCompactL0OnClose(false)
+}
+
+// Count worker stacks, rather than the process-wide goroutine count, so unrelated
+// runtime activity does not hide a leaked Badger/Ristretto worker.
+func openFailureWorkers() map[string]int {
+	var buf bytes.Buffer
+	_ = pprof.Lookup("goroutine").WriteTo(&buf, 2)
+	counts := make(map[string]int)
+	for _, name := range []string{
+		"monitorCache", "freeupAllocators", "updateSize", "processItems", "process",
+		"listenForValueThresholdUpdate", "runCompactor", "flushMemtable", "doWrites", "listenForUpdates",
+	} {
+		for _, stack := range strings.Split(buf.String(), "\n\n") {
+			if strings.Contains(stack, ")."+name+"(") &&
+				(strings.Contains(stack, "github.com/dgraph-io/badger/v4") ||
+					strings.Contains(stack, "github.com/dgraph-io/ristretto/v2")) {
+				counts[name]++
+			}
+		}
+	}
+	return counts
+}
+
+func waitOpenFailureWorkers(t *testing.T, before map[string]int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		after := openFailureWorkers()
+		leaked := false
+		for name, count := range after {
+			if count > before[name] {
+				leaked = true
+			}
+		}
+		if !leaked {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("worker leak: before=%v after=%v", before, after)
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func openFailureFDs() int {
+	for _, dir := range []string{"/proc/self/fd", "/dev/fd"} {
+		if files, err := os.ReadDir(dir); err == nil {
+			return len(files)
+		}
+	}
+	return -1 // Descriptor enumeration is not available on every platform.
+}
+
+type openFailureLogger struct {
+	sync.Mutex
+	cleanupErrors []string
+}
+
+func (l *openFailureLogger) Errorf(format string, args ...interface{}) {
+	if strings.HasPrefix(format, "While closing") || strings.HasPrefix(format, "While cleaning up") {
+		l.Lock()
+		defer l.Unlock()
+		l.cleanupErrors = append(l.cleanupErrors, fmt.Sprintf(format, args...))
+	}
+}
+
+func (*openFailureLogger) Warningf(string, ...interface{}) {}
+func (*openFailureLogger) Infof(string, ...interface{})    {}
+func (*openFailureLogger) Debugf(string, ...interface{})   {}
+
+func TestOpenFailureCleanup(t *testing.T) {
+	for _, stage := range []string{
+		"block-cache", "index-cache", "wrong-key", "invalid-key", "malformed-wal", "partial-readonly-wal",
+		"wal-key-after-replay", "missing-sst", "malformed-vlog", "vlog-key-after-open",
+	} {
+		t.Run(stage, func(t *testing.T) {
+			opt := openFailureOptions(t.TempDir())
+			if stage == "wrong-key" {
+				opt.EncryptionKey = bytes.Repeat([]byte{0x11}, 32)
+			}
+			beforeSeed := openFailureWorkers()
+			db, err := Open(opt)
+			require.NoError(t, err)
+			value := bytes.Repeat([]byte("sentinel"), 64)
+			require.NoError(t, db.Update(func(txn *Txn) error { return txn.Set([]byte("sentinel"), value) }))
+			// A complete WAL containing a committed transaction, suitable for replay.
+			wal := append([]byte(nil), db.mt.wal.Data[:db.mt.wal.writeAt]...)
+			require.NoError(t, db.Close())
+			waitOpenFailureWorkers(t, beforeSeed)
+			bad := opt
+			logger := &openFailureLogger{}
+			bad.Logger = logger
+			var fixtures []string
+			addFixture := func(name string, data []byte) {
+				path := filepath.Join(opt.Dir, name)
+				require.NoError(t, os.WriteFile(path, data, 0600))
+				fixtures = append(fixtures, path)
+			}
+			var movedSST string
+			invalidHeader := make([]byte, vlogHeaderSize)
+			binary.BigEndian.PutUint64(invalidHeader, 123456789)
+			switch stage {
+			case "block-cache":
+				// Overflow the counter calculation to exercise NewCache's validation
+				// error before it allocates a cache of this size.
+				bad.BlockCacheSize = math.MaxInt64
+				bad.BlockSize = 1
+			case "index-cache":
+				bad.MemTableSize = 128
+				bad.ValueThreshold = 1
+				bad.IndexCacheSize = math.MaxInt64
+			case "wrong-key":
+				bad.EncryptionKey = bytes.Repeat([]byte{0x22}, 32)
+			case "invalid-key":
+				bad.EncryptionKey = []byte("invalid")
+			case "malformed-wal":
+				addFixture("invalid.mem", []byte("test fixture"))
+			case "partial-readonly-wal":
+				addFixture("00001.mem", append(wal, 0xFF))
+				bad.ReadOnly = true
+			case "wal-key-after-replay":
+				addFixture("00001.mem", wal)
+				addFixture("00002.mem", invalidHeader)
+				bad.ReadOnly = true
+			case "missing-sst":
+				files, err := filepath.Glob(filepath.Join(opt.Dir, "*.sst"))
+				require.NoError(t, err)
+				require.NotEmpty(t, files)
+				movedSST = files[0]
+				require.NoError(t, os.Rename(movedSST, movedSST+".saved"))
+			case "malformed-vlog":
+				addFixture("invalid.vlog", []byte("test fixture"))
+				bad.NumCompactors = 2
+			case "vlog-key-after-open":
+				addFixture("000002.vlog", invalidHeader)
+				bad.NumCompactors = 2
+			}
+			hashes := make(map[string][32]byte)
+			for _, ext := range []string{"*.mem", "*.vlog", "*.sst"} {
+				paths, err := filepath.Glob(filepath.Join(opt.Dir, ext))
+				require.NoError(t, err)
+				for _, path := range paths {
+					data, err := os.ReadFile(path)
+					require.NoError(t, err)
+					hashes[path] = sha256.Sum256(data)
+				}
+			}
+			before := openFailureWorkers()
+			fds := openFailureFDs()
+			for i := 0; i < 3; i++ {
+				failed, err := Open(bad)
+				require.Error(t, err)
+				if failed != nil {
+					t.Errorf("attempt %d: Open returned a non-nil DB on error: %v", i, err)
+				}
+				if stage == "wrong-key" {
+					require.ErrorIs(t, err, ErrEncryptionKeyMismatch)
+				}
+				t.Logf("attempt=%d db_non_nil=%v err=%v", i+1, failed != nil, err)
+				for path, want := range hashes {
+					data, err := os.ReadFile(path)
+					require.NoError(t, err)
+					require.Equal(t, want, sha256.Sum256(data), "file changed on failed Open: %s", path)
+				}
+			}
+			// Check before a GC can hide an unclosed file behind os.File's finalizer.
+			if after := openFailureFDs(); fds >= 0 && after > fds {
+				t.Errorf("descriptor leak: before=%d after=%d", fds, after)
+			}
+			waitOpenFailureWorkers(t, before)
+			logger.Lock()
+			require.Empty(t, logger.cleanupErrors, "cleanup must not double-close files")
+			logger.Unlock()
+			for _, path := range fixtures {
+				require.NoError(t, os.Remove(path))
+			}
+			if movedSST != "" {
+				require.NoError(t, os.Rename(movedSST+".saved", movedSST))
+			}
+			db, err = Open(opt)
+			require.NoError(t, err, "failed Open must release the directory lock")
+			require.NoError(t, db.View(func(txn *Txn) error {
+				item, err := txn.Get([]byte("sentinel"))
+				if err != nil {
+					return err
+				}
+				got, err := item.ValueCopy(nil)
+				require.Equal(t, value, got)
+				return err
+			}))
+			require.NoError(t, db.Close())
+			require.NoError(t, db.Close()) // Successful Close remains idempotent.
+			waitOpenFailureWorkers(t, before)
+		})
+	}
+}
+
+func TestOpenFailureNewMemTablePreservesWAL(t *testing.T) {
+	opt := openFailureOptions(t.TempDir())
+	db, err := Open(opt)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(txn *Txn) error {
+		return txn.Set([]byte("only-in-wal"), []byte("recover me"))
+	}))
+	wal := append([]byte(nil), db.mt.wal.Data[:db.mt.wal.writeAt]...)
+	require.NoError(t, db.Close())
+	// Put the WAL in a fresh, empty DB so recovery cannot read the key from an SST.
+	opt = openFailureOptions(t.TempDir())
+	empty, err := Open(opt)
+	require.NoError(t, err)
+	require.NoError(t, empty.Close())
+	path := filepath.Join(opt.Dir, "00001.mem")
+	require.NoError(t, os.WriteFile(path, wal, 0600))
+	// Exercise the constructor's existing-file error without a filesystem race.
+	stub := &DB{opt: opt, registry: newKeyRegistry(KeyRegistryOptions{InMemory: true}), nextMemFid: 1}
+	fds := openFailureFDs()
+	mt, err := stub.newMemTable()
+	require.ErrorContains(t, err, "already exists")
+	require.Nil(t, mt)
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, wal, got)
+	if after := openFailureFDs(); fds >= 0 {
+		require.LessOrEqual(t, after, fds)
+	}
+	recovered, err := Open(opt)
+	require.NoError(t, err)
+	require.NoError(t, recovered.View(func(txn *Txn) error {
+		item, err := txn.Get([]byte("only-in-wal"))
+		if err != nil {
+			return err
+		}
+		got, err := item.ValueCopy(nil)
+		require.Equal(t, []byte("recover me"), got)
+		return err
+	}))
+	require.NoError(t, recovered.Close())
+}

--- a/file_cleanup.go
+++ b/file_cleanup.go
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package badger
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dgraph-io/ristretto/v2/z"
+)
+
+// closeMmapOnError releases an exclusively owned file mapping after failed
+// initialization. It never truncates or removes the file. Unlike MmapFile.Close,
+// a sync failure must not prevent unmapping or closing the descriptor.
+// This is only for filesystem mappings, not in-memory tables backed by Go slices.
+func closeMmapOnError(mf *z.MmapFile) error {
+	return closeMmapOnErrorWith(mf, z.Msync, z.Munmap)
+}
+
+// Explicit operations allow cleanup failures to be tested with real mappings
+// without changing process-global syscall functions.
+func closeMmapOnErrorWith(mf *z.MmapFile, sync, unmap func([]byte) error) error {
+	if mf == nil {
+		return nil
+	}
+	name := "file mapping"
+	if mf.Fd != nil {
+		name = mf.Fd.Name()
+	}
+	var errs []error
+	if len(mf.Data) > 0 {
+		if err := sync(mf.Data); err != nil {
+			errs = append(errs, fmt.Errorf("sync %s: %w", name, err))
+		}
+		if err := unmap(mf.Data); err != nil {
+			errs = append(errs, fmt.Errorf("unmap %s: %w", name, err))
+		} else {
+			mf.Data = nil
+		}
+	}
+	if mf.Fd != nil {
+		if err := mf.Fd.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close %s: %w", name, err))
+		}
+		// os.File.Close makes the handle unusable even when it returns an error.
+		// Do not close it again: the descriptor number may have been reused.
+		mf.Fd = nil
+	}
+	return errors.Join(errs...)
+}
+
+func (lf *logFile) closeOnError() error {
+	if lf.MmapFile == nil {
+		return nil
+	}
+	err := closeMmapOnError(lf.MmapFile)
+	// A failed unmap leaves Data reachable so an enclosing cleanup can retry.
+	if len(lf.Data) == 0 && lf.Fd == nil {
+		lf.MmapFile = nil
+	}
+	return err
+}

--- a/file_cleanup_test.go
+++ b/file_cleanup_test.go
@@ -10,7 +10,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/dgraph-io/ristretto/v2/z"
 	"github.com/stretchr/testify/require"
@@ -92,4 +94,57 @@ func TestCloseMmapOnErrorCloseFailure(t *testing.T) {
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, contents, got)
+}
+
+func bootstrapFailureLog(t *testing.T) *logFile {
+	t.Helper()
+	dir := t.TempDir()
+	opt := openFailureOptions(dir).WithEncryptionKey(bytes.Repeat([]byte{0x11}, 32))
+	kr, err := OpenKeyRegistry(KeyRegistryOptions{
+		Dir: dir, EncryptionKey: opt.EncryptionKey, EncryptionKeyRotationDuration: time.Hour,
+	})
+	require.NoError(t, err)
+	// A closed registry makes the real bootstrap fail while persisting its first key.
+	require.NoError(t, kr.Close())
+	lf := &logFile{path: filepath.Join(dir, "00001.mem"), fid: 1, opt: opt, registry: kr}
+	t.Cleanup(func() { require.NoError(t, lf.closeOnError()) })
+	return lf
+}
+
+func TestLogFileBootstrapFailureRemovesFile(t *testing.T) {
+	lf := bootstrapFailureLog(t)
+	err := lf.open(lf.path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 4096)
+	require.ErrorContains(t, err, "Error while retrieving datakey")
+	require.Nil(t, lf.MmapFile)
+	require.NoFileExists(t, lf.path, "Windows requires unmapping and closing before removal")
+
+	// The same file ID must be available for a successful retry.
+	kr, err := OpenKeyRegistry(lf.registry.opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, kr.Close()) })
+	lf.registry = kr
+	require.ErrorIs(t, lf.open(lf.path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 4096), z.NewFile)
+	require.NoError(t, lf.closeOnError())
+}
+
+func TestLogFileBootstrapFailureReturnsRemoveError(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("requires Unix directory permissions enforced for a non-root user")
+	}
+	lf := bootstrapFailureLog(t)
+	// Ristretto also reports NewFile for an existing zero-length file. It can be
+	// opened for writing without permission to remove entries from its directory.
+	require.NoError(t, os.WriteFile(lf.path, nil, 0600))
+	dir := filepath.Dir(lf.path)
+	require.NoError(t, os.Chmod(dir, 0500))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(dir, 0700)) })
+	err := lf.open(lf.path, os.O_RDWR, 4096)
+	require.ErrorContains(t, err, "Error while retrieving datakey")
+	require.ErrorIs(t, err, os.ErrPermission)
+	var pathErr *os.PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "remove", pathErr.Op)
+	require.Equal(t, lf.path, pathErr.Path)
+	require.Nil(t, lf.MmapFile)
+	require.FileExists(t, lf.path)
 }

--- a/file_cleanup_test.go
+++ b/file_cleanup_test.go
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package badger
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dgraph-io/ristretto/v2/z"
+	"github.com/stretchr/testify/require"
+)
+
+func newCleanupMapping(t *testing.T) (*z.MmapFile, string, []byte) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "keep.wal")
+	contents := bytes.Repeat([]byte("preserve this data"), 256)
+	require.NoError(t, os.WriteFile(path, contents, 0600))
+	mf, err := z.OpenMmapFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if len(mf.Data) > 0 {
+			require.NoError(t, z.Munmap(mf.Data))
+		}
+		if mf.Fd != nil {
+			require.NoError(t, mf.Fd.Close())
+		}
+	})
+	return mf, path, contents
+}
+
+func TestCloseMmapOnErrorSyncFailure(t *testing.T) {
+	mf, path, contents := newCleanupMapping(t)
+	fd := mf.Fd
+	syncErr := errors.New("injected sync failure")
+	var unmapped bool
+	err := closeMmapOnErrorWith(mf, func([]byte) error { return syncErr }, func(data []byte) error {
+		unmapped = true
+		return z.Munmap(data)
+	})
+	require.ErrorIs(t, err, syncErr)
+	require.True(t, unmapped)
+	require.Nil(t, mf.Data)
+	require.Nil(t, mf.Fd)
+	_, err = fd.Stat()
+	require.ErrorIs(t, err, os.ErrClosed)
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, contents, got)
+	// Completed operations must not run again on a retry.
+	unexpected := func([]byte) error { t.Fatal("repeated mmap operation after release"); return nil }
+	require.NoError(t, closeMmapOnErrorWith(mf, unexpected, unexpected))
+}
+
+func TestCloseMmapOnErrorUnmapFailure(t *testing.T) {
+	mf, path, contents := newCleanupMapping(t)
+	fd := mf.Fd
+	syncErr := errors.New("injected sync failure")
+	unmapErr := errors.New("injected unmap failure")
+	err := closeMmapOnErrorWith(mf,
+		func([]byte) error { return syncErr }, func([]byte) error { return unmapErr })
+	require.ErrorIs(t, err, syncErr)
+	require.ErrorIs(t, err, unmapErr)
+	require.Equal(t, contents, mf.Data, "failed unmap must keep its mapping reachable")
+	require.Nil(t, mf.Fd)
+	_, err = fd.Stat()
+	require.ErrorIs(t, err, os.ErrClosed, "unmap failure must not prevent descriptor close")
+	// The enclosing owner retries only the still-live mapping, not the closed FD.
+	lf := &logFile{MmapFile: mf, path: path}
+	require.NoError(t, lf.closeOnError())
+	require.Nil(t, lf.MmapFile)
+	require.Nil(t, mf.Data)
+	require.NoError(t, lf.closeOnError())
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, contents, got)
+}
+
+func TestCloseMmapOnErrorCloseFailure(t *testing.T) {
+	mf, path, contents := newCleanupMapping(t)
+	require.NoError(t, mf.Fd.Close())
+	err := closeMmapOnError(mf)
+	require.ErrorIs(t, err, os.ErrClosed)
+	require.Nil(t, mf.Data)
+	require.Nil(t, mf.Fd)
+	require.NoError(t, closeMmapOnError(mf))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, contents, got)
+}

--- a/levels.go
+++ b/levels.go
@@ -111,8 +111,10 @@ func newLevelsController(db *DB, mf *Manifest) (*levelsController, error) {
 		default:
 		}
 		if err := throttle.Do(); err != nil {
-			closeAllTables(tables)
-			return nil, err
+			// Already dispatched loaders still own mappings and append to tables.
+			// Join them before closing tables or allowing Open's cleanup to run.
+			_ = throttle.Finish()
+			return nil, errors.Join(err, closeAllTables(tables))
 		}
 		if fileID > maxFileID {
 			maxFileID = fileID
@@ -126,6 +128,9 @@ func newLevelsController(db *DB, mf *Manifest) (*levelsController, error) {
 				throttle.Done(rerr)
 				numOpened.Add(1)
 			}()
+			if db.opt.tableOpenHook != nil {
+				db.opt.tableOpenHook(&tf)
+			}
 			// tables is sized by opt.MaxLevels, and nothing upstream constrains
 			// the level recorded in the manifest, so reject an out-of-range level
 			// here rather than letting the append below panic.
@@ -170,8 +175,7 @@ func newLevelsController(db *DB, mf *Manifest) (*levelsController, error) {
 		}(fname, tf)
 	}
 	if err := throttle.Finish(); err != nil {
-		closeAllTables(tables)
-		return nil, err
+		return nil, errors.Join(err, closeAllTables(tables))
 	}
 	db.opt.Infof("All %d tables opened in %s\n", numOpened.Load(),
 		time.Since(start).Round(time.Millisecond))
@@ -182,29 +186,38 @@ func newLevelsController(db *DB, mf *Manifest) (*levelsController, error) {
 
 	// Make sure key ranges do not overlap etc.
 	if err := s.validate(); err != nil {
-		_ = s.cleanupLevels()
-		return nil, y.Wrap(err, "Level validation")
+		return nil, errors.Join(y.Wrap(err, "Level validation"), s.closeOnError())
 	}
 
 	// Sync directory (because we have at least removed some files, or previously created the
 	// manifest file).
 	if err := syncDir(db.opt.Dir); err != nil {
-		_ = s.close()
-		return nil, err
+		return nil, errors.Join(err, s.closeOnError())
 	}
 
 	return s, nil
 }
 
-// Closes the tables, for cleanup in newLevelsController.  (We Close() instead of using DecrRef()
-// because that would delete the underlying files.)  We ignore errors, which is OK because tables
-// are read-only.
-func closeAllTables(tables [][]*table.Table) {
+// closeAllTables is used after failed initialization, once every loader has
+// stopped. Never DecrRef these tables: it would delete existing SST files.
+func closeAllTables(tables [][]*table.Table) (err error) {
 	for _, tableSlice := range tables {
-		for _, table := range tableSlice {
-			_ = table.Close(-1)
+		for _, t := range tableSlice {
+			if !t.IsInmemory {
+				err = errors.Join(err, closeMmapOnError(t.MmapFile))
+			}
 		}
 	}
+	return err
+}
+
+// closeOnError requires that all workers using this controller have stopped.
+func (s *levelsController) closeOnError() error {
+	tables := make([][]*table.Table, 0, len(s.levels))
+	for _, level := range s.levels {
+		tables = append(tables, level.tables)
+	}
+	return closeAllTables(tables)
 }
 
 func (s *levelsController) cleanupLevels() error {

--- a/memtable.go
+++ b/memtable.go
@@ -586,8 +586,11 @@ func (lf *logFile) open(path string, flags int, fsize int64) (err error) {
 
 	if ferr == z.NewFile {
 		if err := lf.bootstrap(); err != nil {
-			os.Remove(path)
-			return err
+			// Windows cannot remove a file while its mapping or handle is open.
+			if cleanupErr := lf.closeOnError(); cleanupErr != nil {
+				return errors.Join(err, cleanupErr)
+			}
+			return errors.Join(err, os.Remove(path))
 		}
 		lf.size.Store(vlogHeaderSize)
 

--- a/memtable.go
+++ b/memtable.go
@@ -11,6 +11,7 @@ import (
 	"crypto/aes"
 	cryptorand "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -74,6 +75,13 @@ func (db *DB) openMemTables(opt Options) error {
 		}
 		mt, err := db.openMemTable(fid, flags)
 		if err != nil {
+			// openMemTable also returns an initialized table with z.NewFile.
+			if mt != nil {
+				if cerr := mt.closeWithoutFlush(); cerr != nil {
+					db.opt.Errorf("While closing memtable after Open error: %v", cerr)
+					err = errors.Join(err, cerr)
+				}
+			}
 			return y.Wrapf(err, "while opening fid: %d", fid)
 		}
 		// If this memtable is empty we don't need to add it. This is a
@@ -94,7 +102,7 @@ func (db *DB) openMemTables(opt Options) error {
 
 const memFileExt string = ".mem"
 
-func (db *DB) openMemTable(fid, flags int) (*memTable, error) {
+func (db *DB) openMemTable(fid, flags int) (_ *memTable, err error) {
 	filepath := db.mtFilePath(fid)
 	s := skl.NewSkiplist(arenaSize(db.opt))
 	mt := &memTable{
@@ -102,6 +110,14 @@ func (db *DB) openMemTable(fid, flags int) (*memTable, error) {
 		opt: db.opt,
 		buf: &bytes.Buffer{},
 	}
+	defer func() {
+		if err != nil && err != z.NewFile {
+			if cerr := mt.closeWithoutFlush(); cerr != nil {
+				db.opt.Errorf("While closing memtable after Open error: %v", cerr)
+				err = errors.Join(err, cerr)
+			}
+		}
+	}()
 	// We don't need to create the wal for the skiplist in in-memory mode so return the mt.
 	if db.opt.InMemory {
 		return mt, z.NewFile
@@ -130,8 +146,25 @@ func (db *DB) openMemTable(fid, flags int) (*memTable, error) {
 	if lerr == z.NewFile {
 		return mt, lerr
 	}
-	err := mt.UpdateSkipList()
-	return mt, y.Wrapf(err, "while updating skiplist")
+	if err := mt.UpdateSkipList(); err != nil {
+		return nil, y.Wrapf(err, "while updating skiplist")
+	}
+	return mt, nil
+}
+
+// closeWithoutFlush releases an uncommitted Open's memtable without deleting its
+// WAL. DecrRef's usual OnClose callback deletes the WAL after a successful flush;
+// on failure the next Open may still need it for recovery.
+func (mt *memTable) closeWithoutFlush() error {
+	if mt.sl != nil {
+		mt.sl.OnClose = nil
+		mt.DecrRef()
+		mt.sl = nil
+	}
+	if mt.wal != nil {
+		return mt.wal.closeOnError()
+	}
+	return nil
 }
 
 func (db *DB) newMemTable() (*memTable, error) {
@@ -145,7 +178,12 @@ func (db *DB) newMemTable() (*memTable, error) {
 		db.opt.Errorf("Got error: %v for id: %d\n", err, db.nextMemFid)
 		return nil, y.Wrapf(err, "newMemTable")
 	}
-	return nil, fmt.Errorf("File %s already exists", mt.wal.Fd.Name())
+	err = fmt.Errorf("File %s already exists", mt.wal.path)
+	if cerr := mt.closeWithoutFlush(); cerr != nil {
+		db.opt.Errorf("While closing existing memtable: %v", cerr)
+		err = errors.Join(err, cerr)
+	}
+	return nil, err
 }
 
 func (db *DB) mtFilePath(fid int) string {
@@ -534,9 +572,17 @@ func (lf *logFile) zeroNextEntry() {
 	z.ZeroOut(lf.Data, int(lf.writeAt), int(lf.writeAt+maxHeaderSize))
 }
 
-func (lf *logFile) open(path string, flags int, fsize int64) error {
+func (lf *logFile) open(path string, flags int, fsize int64) (err error) {
 	mf, ferr := z.OpenMmapFile(path, flags, int(fsize))
 	lf.MmapFile = mf
+	defer func() {
+		if err != nil && err != z.NewFile && lf.MmapFile != nil {
+			if cerr := lf.closeOnError(); cerr != nil {
+				lf.opt.Errorf("While closing log file after Open error: %v", cerr)
+				err = errors.Join(err, cerr)
+			}
+		}
+	}()
 
 	if ferr == z.NewFile {
 		if err := lf.bootstrap(); err != nil {

--- a/test_extensions.go
+++ b/test_extensions.go
@@ -29,6 +29,9 @@ type testOnlyOptions struct {
 	// that can occur in a DB instance. Currently, this is only used in
 	// testing activities.
 	syncChan chan string
+
+	// tableOpenHook controls table-loader scheduling in failure tests. Nil in production.
+	tableOpenHook func(*TableManifest)
 }
 
 // testOnlyDBExtensions specifies an extension to the type DB that we want to

--- a/y/throttle_error_test.go
+++ b/y/throttle_error_test.go
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package y
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottleDoneWithPendingError(t *testing.T) {
+	first := errors.New("first worker failed")
+	second := errors.New("second worker failed")
+	for attempt := 0; attempt < 32; attempt++ {
+		th := NewThrottle(1)
+		require.NoError(t, th.Do())
+		th.Done(first)
+		// Do may observe either the available slot or the buffered error. Exercise
+		// the valid interleaving where it starts more work before observing error.
+		if err := th.Do(); err != nil {
+			require.ErrorIs(t, err, first)
+			_ = th.Finish()
+			continue
+		}
+		done := make(chan struct{})
+		go func() {
+			th.Done(second)
+			close(done)
+		}()
+		select {
+		case <-done:
+			require.Error(t, th.Finish())
+		case <-time.After(time.Second):
+			// Release the buggy worker through the public API before failing.
+			require.ErrorIs(t, th.Do(), first)
+			<-done
+			_ = th.Finish()
+			t.Fatal("Done blocked behind an earlier error; Finish would deadlock")
+		}
+		return
+	}
+	t.Fatal("did not exercise scheduling work while an error was pending")
+}

--- a/y/y.go
+++ b/y/y.go
@@ -221,7 +221,13 @@ func (t *Throttle) Do() error {
 // pass the error status of work done.
 func (t *Throttle) Done(err error) {
 	if err != nil {
-		t.errCh <- err
+		// Do can schedule more work while an earlier error is buffered. Never
+		// block Done on a full error channel: Finish waits for Done before it
+		// drains errors. A full channel already guarantees an error is reported.
+		select {
+		case t.errCh <- err:
+		default:
+		}
 	}
 	select {
 	case <-t.ch:


### PR DESCRIPTION
**Description**

An unsuccessful Open can leave background workers and file resources alive, and some error branches return a
partially initialized DB that the caller cannot safely close. For example, opening an existing encrypted database
with a different valid-length key returns both a non-nil DB and ErrEncryptionKeyMismatch. Calling Close on that
object panics because the levels controller has not been initialized.

This PR makes failed initialization own its rollback: return a nil DB on error, stop the workers started by the
attempt, and release acquired resources without deleting recovery files or truncating a vlog at an uninitialized
offset. Successfully opened databases remain owned and closed by the caller.

**Reproduction and root causes**

The original failures reproduce on separate actual checkouts of main
`2a001d466f6b71a917319a1db41f99860e16e269` and v4.9.6
`fbd8d2eefad8be8757249767255faf989945b599`.

Five wrong-key Open attempts retain five monitorCache workers and five allocator-pool workers. Five attempts with
an invalid `.mem` filename retain 45 cache, policy, watermark, size-update and allocator workers, plus five registry
descriptors. After discarding returned pointers, forcing GC and FreeOSMemory, and idling for 130 seconds, these
counts remain unchanged. A second batch of five failures doubles them. Successful Open/Close controls have no
worker or descriptor growth. Periodic ticks do not stop these workers; they need the omitted closer signals.

The defects are:

1. Open creates the allocator pool and starts cache monitoring before OpenKeyRegistry, but error cleanup omits both.
2. With unnamed results, `return db, err` evaluates the DB pointer before deferred code executes. The deferred
   `db = nil` therefore does not clear the returned pointer.
3. openMemTables uses a local error that shadows the error checked by deferred cleanup, bypassing cleanup entirely.
   initBannedNamespaces has the same shadowing pattern, but no naturally reachable error from that latter step is
   claimed by this report.
4. Later failures retain resources transferred to DB. Failed memtable/log constructors also need to release
   resources before ownership transfers to DB.
5. newLevelsController can return from Throttle.Do while other dispatched loaders are still opening or appending
   tables. Closing only the tables collected at that instant misses the later arrivals.

**Implementation**

| File | Change and reason |
| --- | --- |
| db.go | Name the error result so deferred cleanup sees the actual returned error. Return nil on failed Open. Stop cacheHealth, wait for updateSize, release acquired DB resources, then release the allocator pool. Attach cleanup errors when present; preserve the original error object when cleanup succeeds. |
| memtable.go | Clean up failed constructors before losing resources. Disable the WAL-deletion callback on failed initialization, release the skiplist once, and retain still-live mapping state for an enclosing cleanup to retry. Use the saved path after releasing a file handle. |
| file_cleanup.go | Sync, unmap and close an exclusively owned filesystem mapping independently. Sync failure does not skip unmap/close; unmap failure does not skip descriptor close. Record completed steps so retries do not repeat them. Never truncate or remove the file. |
| levels.go | Join every dispatched loader before cleanup on early failure. Attempt cleanup of every owned table while preserving SST files, including after validation or directory-sync errors. |
| y/y.go | Make Done's error reporting non-blocking when the error queue is full. Do may schedule work while an older error is buffered; otherwise another Done blocks and Finish waits forever before it can drain errors. A full queue already guarantees an error is reported. |
| test_extensions.go | Add a per-Options private scheduling hook for deterministic loader interleavings. It is nil in production and adds no exported option. |

**Cleanup order and data preservation**

The failure cleanup preserves the ordering established by #1464: finish memtable flushing and compaction before
closing caches. Stop the cache monitor, release caches and finish other started initialization workers, then
release DB-owned mappings and the registry. Release the allocator pool after no builder can return an allocator.
Open's outer defers close the manifest and release directory locks afterwards.

Normal memtable DecrRef can delete its WAL after flushing. Failed-open cleanup disables that deletion callback
because the next Open may need the WAL. Normal valueLog.Close can truncate the newest vlog using its writable
offset, which may not be initialized on failure (#1465). Failed initialization therefore does not use
DB.Close/valueLog.Close. General resource cleanup does not truncate or remove files.
The separate existing bootstrap-failure branch now closes resources before removing its failed-initialization file;
cleanup/removal errors are joined with the bootstrap error. Ristretto also reports NewFile for an existing zero-length
file; this change preserves that classification and does not expand deletion to other failure paths.

Sync, Unmap and Close failures are handled separately. A sync error can be returned even when unmap and close have
completed successfully. Failed unmap leaves Data reachable for the owning cleanup to retry; completed file close
clears the now-unusable handle. Persistent OS refusal to unmap cannot be overridden by this code.

**Review follow-up**

Commit 2066a46 addresses the bootstrap-failure removal ordering noted in review. The implementation change is +5/-2
lines in memtable.go. Added tests use a closed key registry to trigger real bootstrap failure, verify removal and
reuse of the same file ID, and check propagation of removal errors. Targeted regressions pass 10 race-enabled runs;
related encryption/recovery tests pass; jemalloc regressions pass 3 race-enabled runs. Additional isolated
interposition/fault checks pass 10 race-enabled runs and verify close-before-remove plus retention on sync/unmap
cleanup failure. A Windows test binary was cross-compiled; Windows runtime execution is not claimed.

**Scope and compatibility**

- Open's Go function type remains `func(Options) (*DB, error)`. Exported functions, methods and options are unchanged;
  the intentional observable change is a consistently nil DB on error. Successful Open still returns the DB.
- An AST comparison found 88 affected-file exported function/method/type declarations unchanged after normalizing
  argument/result names. This is a declaration check, not a behavior-equivalence proof. Storage encoding is unchanged.
- Ordinary successful shutdown remains on its existing path. The change is limited to failed initialization and
  the throttle completion needed to join it safely.
- Implementation diff: +207/-37 lines across six files, including the private testing extension. Four test files
  add 631 lines. Local reports, profiles, copied dependencies and diagnostic tools are excluded from the proposed commit.
- The independently tested v4.9.6 backport adapts its different loader context. This PR targets main only. The later
  bootstrap-removal review follow-up was validated on main; it is not claimed as part of that backport validation.

**Validation**

Included regressions cover cache creation, invalid/wrong encryption keys, malformed WAL names, partial read-only
WAL replay, unknown key IDs, missing SSTs and partial vlog opening. They check nil returns, worker/descriptor cleanup,
unchanged file hashes, lock reacquisition and subsequent reads. A constructor test recovers a key solely from its
preserved WAL. Additional tests cover paused/concurrently failing SST loaders, a full throttle error queue, injected
sync/unmap failures using real mappings, retry of remaining cleanup, and already-closed file handles.

Targeted command:

```sh
go test -race . ./y -run '^(TestOpenFailure|TestCloseMmapOnError|TestThrottle)' -count=10 -timeout=120s
```

Validation environment: macOS 26.5.2 / darwin/arm64, Go 1.27.0.

| Check | Result |
| --- | --- |
| Full-module Go-allocator race run | 481 passing events, 21 upstream skips and one protobuf-generation tool mismatch. The failed pb package passed separately with the recorded generator versions; generated-source changes were not retained. |
| Full-module jemalloc race run | 482 passing test/subtest events, 21 upstream skips, zero failures. Used Homebrew jemalloc 5.3.0 with isolated linkage adaptation, not the Linux CI's 5.3.1 configuration. |
| Additional manual cases | 12 of 13 selected top-level cases passed. TestBigValues/InMemory panics in writeToLSM on both patched and unmodified upstream binaries; that unrelated write path is unchanged. |
| 302M-entry LSM structural run | All enabled gates pass: L0 stall 0, minimum/final base L3. No baseline/head performance-ratio claim. |
| Seven CI target cross-builds | Pass with CGO disabled: Linux amd64/arm64, Darwin amd64/arm64, Windows amd64, AIX ppc64, Plan9 amd64. These are compilation checks, not runtime tests on those systems. |
| Isolated msync EIO probes | Direct logFile opening and failure after SST loading pass five race-enabled runs: descriptors released, errors reported, existing data preserved. |
| Reduced v4.9.6 backport | Ten targeted race runs pass. |
| gofmt / diff whitespace / exported declarations | Pass. |
| Full go vet | 19 protobuf Match copylocks diagnostics, byte-for-byte identical on patched and unmodified baseline. |

The regular included regressions require no instrumented dependency. The additional msync EIO experiment used an
isolated Ristretto v2.2.0 copy and a temporary modfile; repository go.mod/go.sum were unchanged. Protobuf regeneration
was verified with protoc-gen-go v1.31.0 and protoc v3.21.12.

Trunk, other-OS runtime tests, upstream unconditionally disabled tests, external nightly jobs and comparative LSM
performance gating were not run. Pre-mapping dependency errors, all possible table.OpenTable-internal I/O errors,
and arbitrary fatal/panic paths are not presented as comprehensively repaired.

**Related work**

- #1464 and #1465 provide the cache-ordering and no-truncation constraints preserved here.
- #2333 is included in the main base and changes corrupt-SST panic handling; these cleanup failures still reproduce.
- #2205/#2295 concern successful in-memory Close/DropAll and skiplists; #2331 concerns empty mem/vlog files.
  This PR does not claim to implement those separate changes.

**Checklist**

- [x] Code compiles; gofmt and diff whitespace checks pass locally
- [x] Regression tests cover the reproduced failures
- [x] Existing baseline failures and untested configurations are disclosed above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/badger/pr/2340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791829519&installation_model_id=8575&pr_number=2340&repository=dgraph-io%2Fbadger&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fbadger%2Fpull%2F2340&signature=a641a3f0530d1860557967545d8b34dc1f745af07054ac748103d995412e6922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database startup failure handling to prevent partial initialization and resource leaks.
  - Preserved WAL and SSTable files during failed opens, enabling recovery on subsequent attempts.
  - Ensured cleanup waits for active loaders and reports combined errors.
  - Prevented throttling operations from deadlocking when multiple errors occur.
  - Improved failed file cleanup while preserving file contents.

- **Tests**
  - Added coverage for failed opens, resource cleanup, file preservation, recovery, and throttling errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->